### PR TITLE
Allow enabling `FLECS_USE_OS_ALLOC`.

### DIFF
--- a/flecs_ecs/Cargo.toml
+++ b/flecs_ecs/Cargo.toml
@@ -36,6 +36,9 @@ flecs_force_build_debug_c = ["flecs_ecs_sys/force_build_debug"]
 # force build release for C flecs, even in debug mode
 flecs_force_build_release_c = ["flecs_ecs_sys/force_build_release"]
 
+# tell C flecs to use the OS allocator instead of its own
+flecs_use_os_alloc = ["flecs_ecs_sys/use_os_alloc"]
+
 # Module support
 flecs_module = ["flecs_ecs_sys/flecs_module"]
 

--- a/flecs_ecs/tests/component_test.rs
+++ b/flecs_ecs/tests/component_test.rs
@@ -51,14 +51,6 @@ fn temp_test_hook() {
         assert_eq!(pos_e2.x, 10);
         assert_eq!(pos_e2.y, 20);
 
-        entity.add::<Velocity>();
-        assert_eq!(unsafe { COUNT2 }, 0);
-        let vel_e1 = entity.get::<Velocity>().unwrap();
-        // dangerous uninitialized values
-        assert_ne!(vel_e1.x, 0);
-        assert_ne!(vel_e1.y, 0);
-        entity.remove::<Velocity>();
-
         entity.remove::<Position>();
         assert_eq!(unsafe { COUNT }, 1);
 

--- a/flecs_ecs_sys/Cargo.toml
+++ b/flecs_ecs_sys/Cargo.toml
@@ -35,6 +35,9 @@ force_build_debug = []
 # force build release for C flecs, even in debug mode
 force_build_release = []
 
+# tell C flecs to use the OS allocator instead of its own
+use_os_alloc = []
+
 # Enabling this will not build a copy of flecs into this library.
 # Instead, the executable that this is linked with will need to
 # provide the symbols required. This is useful when using both

--- a/flecs_ecs_sys/build.rs
+++ b/flecs_ecs_sys/build.rs
@@ -299,6 +299,11 @@ fn main() {
                 .define("flto", None);
         }
 
+        #[cfg(feature = "use_os_alloc")]
+        {
+            build.define("FLECS_USE_OS_ALLOC", None);
+        }
+
         #[cfg(feature = "flecs_force_enable_ecs_asserts")]
         {
             build.define("FLECS_KEEP_ASSERTS", None);


### PR DESCRIPTION
This is useful when debugging something at the C level sometimes.

This removes a test that was more experimental rather than always correct.