### PR TITLE
Correct crate/local dependencies.

### DIFF
--- a/flecs_ecs/Cargo.toml
+++ b/flecs_ecs/Cargo.toml
@@ -18,10 +18,8 @@ rustdoc-args = [ "-Zunstable-options", "--generate-link-to-definition"]
 cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]
 
 [dependencies]
-# flecs_ecs_derive = { path = "../flecs_ecs_derive", version = "*"}
-# flecs_ecs_sys = { path = "../flecs_ecs_sys", version = "*"}
-flecs_ecs_derive = "0.1.0"
-flecs_ecs_sys = "0.1.0"
+flecs_ecs_derive = { version = "0.1.0", path = "../flecs_ecs_derive" }
+flecs_ecs_sys = { version = "0.1.0", path = "../flecs_ecs_sys" }
 compact_str = "0.8.0"
 fxhash = "0.2.1"
 


### PR DESCRIPTION
This lets published versions use that and local development within the repo continue correctly.