### PR TITLE
Ignore Drop if panicking

### DIFF
--- a/flecs_ecs/src/core/components/component_binding.rs
+++ b/flecs_ecs/src/core/components/component_binding.rs
@@ -14,6 +14,10 @@ pub(crate) struct ComponentBindingCtx {
 
 impl Drop for ComponentBindingCtx {
     fn drop(&mut self) {
+        if std::thread::panicking() {
+            return;
+        }
+
         if let Some(on_add) = self.on_add {
             if let Some(free_on_add) = self.free_on_add {
                 unsafe { free_on_add(on_add) };

--- a/flecs_ecs/src/core/query.rs
+++ b/flecs_ecs/src/core/query.rs
@@ -72,7 +72,7 @@ where
             // If the world didn't end through normal reasons (user dropping it manually or resetting it)
             // and it's holding remaining references to queries in Rust, the world will panic, in that case, don't invoke
             // the query destruction since the memory will already be invalidated.
-            if self.world_ctx.as_ref().is_panicking {
+            if self.world_ctx.as_ref().is_panicking() {
                 return;
             }
 

--- a/flecs_ecs/src/core/table/mod.rs
+++ b/flecs_ecs/src/core/table/mod.rs
@@ -728,6 +728,10 @@ impl<'a> TableLock<'a> {
 
 impl<'a> Drop for TableLock<'a> {
     fn drop(&mut self) {
+        if std::thread::panicking() {
+            return;
+        }
+
         unsafe {
             sys::ecs_table_unlock(self.world.world_ptr_mut(), self.table.as_ptr());
         }

--- a/flecs_ecs/src/core/utility/types.rs
+++ b/flecs_ecs/src/core/utility/types.rs
@@ -61,6 +61,10 @@ pub(crate) struct ObserverEntityBindingCtx {
 
 impl Drop for ObserverEntityBindingCtx {
     fn drop(&mut self) {
+        if std::thread::panicking() {
+            return;
+        }
+
         if let Some(empty) = self.empty {
             if let Some(free_empty) = self.free_empty {
                 free_empty(empty);

--- a/flecs_ecs/src/core/world.rs
+++ b/flecs_ecs/src/core/world.rs
@@ -89,7 +89,7 @@ impl Drop for World {
                 let ctx = self.world_ctx_mut();
                 unsafe { sys::ecs_fini(self.raw_world.as_ptr()) };
                 let is_ref_count_not_zero = !ctx.is_ref_count_zero();
-                if is_ref_count_not_zero && !ctx.is_panicking {
+                if is_ref_count_not_zero && !ctx.is_panicking() {
                     ctx.set_is_panicking_true();
                     panic!("The code base still has lingering references to `Query` objects. This is a bug in the user code.
                         Please ensure that all `Query` objects are out of scope before the world is destroyed.");

--- a/flecs_ecs/src/core/world.rs
+++ b/flecs_ecs/src/core/world.rs
@@ -81,6 +81,10 @@ impl Default for World {
 
 impl Drop for World {
     fn drop(&mut self) {
+        if std::thread::panicking() {
+            return;
+        }
+
         let world_ptr = self.raw_world.as_ptr();
         if unsafe { sys::flecs_poly_release_(world_ptr as *mut c_void) } == 0 {
             if unsafe { sys::ecs_stage_get_id(world_ptr) } == -1 {

--- a/flecs_ecs/src/core/world_ctx.rs
+++ b/flecs_ecs/src/core/world_ctx.rs
@@ -5,7 +5,7 @@ pub(crate) struct WorldCtx {
     query_ref_count: i32,
     pub(crate) components: FlecsIdMap,
     pub(crate) components_array: FlecsArray,
-    pub(crate) is_panicking: bool,
+    is_panicking: bool,
 }
 
 impl WorldCtx {
@@ -52,6 +52,10 @@ impl WorldCtx {
 
     pub(crate) fn set_is_panicking_true(&mut self) {
         self.is_panicking = true;
+    }
+
+    pub(crate) fn is_panicking(&self) -> bool {
+        self.is_panicking
     }
 }
 

--- a/flecs_ecs/src/core/world_ctx.rs
+++ b/flecs_ecs/src/core/world_ctx.rs
@@ -55,7 +55,7 @@ impl WorldCtx {
     }
 
     pub(crate) fn is_panicking(&self) -> bool {
-        self.is_panicking
+        self.is_panicking || std::thread::panicking()
     }
 }
 

--- a/flecs_ecs/tests/flecs/observer_test.rs
+++ b/flecs_ecs/tests/flecs/observer_test.rs
@@ -950,3 +950,14 @@ fn observer_name_from_root() {
     let ns = world.entity_named("::ns");
     assert!(ns == o.parent().unwrap());
 }
+
+#[test]
+#[should_panic]
+fn observer_panic_inside() {
+    #[derive(Component)]
+    struct Tag;
+
+    let world = World::new();
+    world.observer::<flecs::OnAdd, &Tag>().each(|_| panic!());
+    world.add::<Tag>();
+}

--- a/flecs_ecs/tests/flecs/query_test.rs
+++ b/flecs_ecs/tests/flecs/query_test.rs
@@ -56,3 +56,16 @@ fn query_iter_stage() {
 
     world.progress();
 }
+
+#[test]
+#[should_panic]
+fn query_panic_inside() {
+    #[derive(Component)]
+    struct Tag;
+
+    let world = World::new();
+    let query = world.query::<&Tag>().build();
+    query.run(|_| {
+        panic!();
+    });
+}


### PR DESCRIPTION
If a Rust panic occurs while Flecs-Rust is on the stack (e.g. query callback) or worse, while Flecs itself is on the stack (e.g. observer, system callbacks), the unwinding process causes `Drop` implementations to be called.

Flecs-Rust's `Drop` implementations call into Flecs, which is not (and probably cannot be) panic-safe and often does not react well to the re-entrancy involved, causing an `abort()` and thus breaking things like test harnesses.

Note that this does **not** make it safe to continue using any part of Flecs after a panic occurs; I suspect that the entire library state should be considered "poisoned".

Future work:
- register a flecs abort hook, so that flecs' own errors become Rust panics
- optional enforcement of "poisoning"? may be too expensive for production use