### PR TITLE
Component definition macros for Meta V2

### DIFF
--- a/flecs_ecs/src/addons/meta/macros.rs
+++ b/flecs_ecs/src/addons/meta/macros.rs
@@ -1,0 +1,290 @@
+pub mod type_equality {
+    #![doc(hidden)]
+    pub trait EqType {
+        type Itself;
+    }
+
+    impl<T> EqType for T {
+        type Itself = T;
+    }
+
+    pub fn ty_must_eq<T, U>(_: T)
+    where
+        T: EqType<Itself = U>,
+    {
+    }
+
+    /// Assert that a struct field has a given type.
+    ///
+    /// Source: <https://stackoverflow.com/a/70978292> (with minor modifications)
+    ///
+    /// Usage: `assert_is_type!(Struct, field: FieldType)`
+    ///
+    /// # Examples
+    /// ```
+    /// # use flecs_ecs::assert_is_type;
+    /// struct Test {
+    ///     field: u32,
+    /// }
+    ///
+    /// struct Test2(u32);
+    ///
+    /// assert_is_type!(Test, field: u32);
+    /// assert_is_type!(Test2, 0: u32);
+    /// ```
+    ///
+    /// ```compile_fail
+    /// # use flecs_ecs::assert_is_type;
+    /// struct Test {
+    ///     field: u32,
+    /// }
+    ///
+    /// assert_is_type!(Test, field: &u32);
+    /// ```
+    #[macro_export]
+    macro_rules! assert_is_type {
+        ($t:ty, $i:tt: $ti:ty) => {
+            const _: () = {
+                #[allow(unused)]
+                fn dummy(v: $t) {
+                    $crate::addons::meta::macros::type_equality::ty_must_eq::<_, $ti>(v.$i);
+                }
+            };
+        };
+    }
+}
+
+/// Like [`stringify!`](::core::stringify!) but omits whitespace around generics.
+#[macro_export]
+macro_rules! component_type_stringify {
+    ($t:tt <$($generic:ty),*>) => {
+        ::core::concat!(::core::stringify!($t), "<", $($crate::component_type_stringify!($generic)),*, ">")
+    };
+    ($t:ty) => {
+        ::core::stringify!($t)
+    };
+}
+
+/// Function-like macro for registering a component's field metadata.
+///
+/// Intended to be used by [`component!`](crate::component) but can be used standalone.
+///
+/// Currently aliased to [`member_ext!`](crate::member_ext!).
+#[macro_export]
+macro_rules! member {
+    ($($tt:tt)*) => {
+        $crate::member_ext!($($tt)*);
+    };
+}
+
+/// Function-like macro for registering an external component's field metadata.
+///
+/// Intended to be used by [`component_ext!`](crate::component_ext) but can be used standalone.
+///
+/// Field types are verified using [`assert_is_type!`](crate::assert_is_type!).
+///
+/// **Known issue:** due to bugs in Flecs, fields must be specified such that the field with offset = 0 comes first.
+///
+/// # Examples
+/// ```
+/// # use flecs_ecs::prelude::*;
+/// # let world = World::new();
+/// struct Struct {
+///     foo: u32,
+///     bar: u32,
+///     array: [u32; 3],
+/// };
+/// let component = component_ext!(&world, Struct);
+///
+/// // If the component has already been fetched, you can provide it
+/// member_ext!(&world, component: Struct, foo: u32);
+///
+/// // Otherwise, the macro will fetch it for you
+/// member_ext!(&world, Struct, bar: u32);
+///
+/// member_ext!(&world, Struct, array: [u32; 3]);
+/// ```
+#[macro_export]
+macro_rules! member_ext {
+    ($world:expr, $compvar:ident: $component:ty, $name:tt : [$type:ty; $n:literal]) => {
+        $crate::assert_is_type!($component, $name: [$type; $n]);
+        $compvar.member_id(::flecs_ecs::prelude::id!($world, $type), ::core::stringify!($name), $n, ::core::mem::offset_of!($component, $name).try_into().unwrap())
+    };
+    ($world:expr, $compvar:ident: $component:ty, $name:tt : $type:ty) => {
+        $crate::assert_is_type!($component, $name: $type);
+        $compvar.member_id(::flecs_ecs::prelude::id!($world, $type), ::core::stringify!($name), 1, ::core::mem::offset_of!($component, $name).try_into().unwrap())
+    };
+    ($world:expr, $component:ty, $name:tt : $($tail:tt)*) => {{
+        let world = $world;
+        let component = $crate::component!(world, $component);
+        $crate::member_ext!(world, component: $component, $name : $($tail)*);
+    }};
+}
+
+#[allow(dead_code, clippy::print_stdout)]
+/// Run this to regenerate the tuple rules for [`component_ext!`]
+fn codegen_tuple_struct_macro() {
+    for i in 1..=12 {
+        let items = (1..=i).map(|j| (j - 1, (b'a' + j - 1) as char));
+        print!("($world:expr, $(#[name=$regname:literal])? $component:ident$(<$($generic:ty),*>)?");
+        print!(
+            "({} $(,)?)",
+            items
+                .clone()
+                .map(|(_, var)| { format!("${var}:tt$(<$(${var}g:ty),*>)?") })
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+        print!(
+            ") => {{$crate::component_ext!($world, $(#[name=$regname])? $component$(<$($generic),*>)?"
+        );
+        print!(
+            "{{ {} }}",
+            items
+                .map(|(idx, var)| { format!("{idx}: ${var}$(<$(${var}g),*>)?") })
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+        println!(")}};");
+    }
+}
+
+/// Function-like macro for registering a component, optionally including field metadata.
+///
+/// Supports structs, fieldless enums and tuple structs (up to 12 items).
+/// Arrays are translated to flecs arrays (`count`).
+///
+/// Field types are verified using [`assert_is_type!`](crate::assert_is_type!).
+///
+/// Returns the component.
+///
+/// Currently aliased to [`component_ext!`](crate::component_ext!).
+#[macro_export]
+macro_rules! component {
+    ($($tt:tt)*) => {
+        $crate::component_ext!($($tt)*)
+    };
+}
+
+/// Function-like macro for registering an external component, optionally including field metadata.
+///
+/// Supports structs, fieldless enums and tuple structs (up to 12 items).
+/// - Arrays are translated to flecs arrays (`count`).
+/// - Generics are supported, but only type parameters can be passed. Use [`member_ext!`](crate::member_ext) directly if you need more complex types.
+/// - Field types are verified using [`assert_is_type!`](crate::assert_is_type!).
+///
+/// Returns the component.
+///
+/// **Known issue:** due to bugs in Flecs, fields must be specified such that the field with offset = 0 comes first.
+///
+/// # Examples
+/// ## Tuple structs
+/// ```
+/// # use flecs_ecs::prelude::*;
+/// # let world = World::new();
+/// struct TupleStruct(u32, u64);
+///
+/// component_ext!(&world, TupleStruct(u32, u64));
+/// component_ext!(
+///     &world,
+///     #[name = "CustomName"]
+///     TupleStruct(u32, u64)
+/// );
+/// ```
+///
+/// ## Structs
+/// ```
+/// # use flecs_ecs::prelude::*;
+/// # let world = World::new();
+/// struct Struct {
+///     foo: u32,
+///     bar: u64,
+/// }
+///
+/// component_ext!(&world, Struct { foo: u32, bar: u64 });
+/// component_ext!(
+///     &world,
+///     #[name = "CustomName"]
+///     Struct { foo: u32, bar: u64 }
+/// );
+/// ```
+///
+/// ## Fieldless enums
+/// ```
+/// # use flecs_ecs::prelude::*;
+/// # let world = World::new();
+/// #[repr(u32)]
+/// enum Enum {
+///     Foo,
+///     Bar,
+///     Baz,
+/// }
+///
+/// component_ext!(&world, Enum { Foo, Bar, Baz });
+/// component_ext!(
+///     &world,
+///     #[name = "CustomName"]
+///     Enum { Foo, Bar, Baz }
+/// );
+/// ```
+///
+/// ## Arrays
+/// ```
+/// # use flecs_ecs::prelude::*;
+/// # let world = World::new();
+/// struct TupleStruct([u32; 3]);
+/// struct Struct {
+///     field: [u32; 3],
+/// }
+///
+/// component_ext!(&world, TupleStruct([u32; 3]));
+/// component_ext!(&world, Struct { field: [u32; 3] });
+/// ```
+#[macro_export]
+macro_rules! component_ext {
+    // tuple struct
+    ($world:expr, $(#[name=$regname:literal])? $component:ident$(<$($generic:ty),*>)?($a:tt$(<$($ag:ty),*>)? $(,)?)) => {$crate::component_ext!($world, $(#[name=$regname])? $component$(<$($generic),*>)?{ 0: $a$(<$($ag),*>)? })};
+    ($world:expr, $(#[name=$regname:literal])? $component:ident$(<$($generic:ty),*>)?($a:tt$(<$($ag:ty),*>)?, $b:tt$(<$($bg:ty),*>)? $(,)?)) => {$crate::component_ext!($world, $(#[name=$regname])? $component$(<$($generic),*>)?{ 0: $a$(<$($ag),*>)?, 1: $b$(<$($bg),*>)? })};
+    ($world:expr, $(#[name=$regname:literal])? $component:ident$(<$($generic:ty),*>)?($a:tt$(<$($ag:ty),*>)?, $b:tt$(<$($bg:ty),*>)?, $c:tt$(<$($cg:ty),*>)? $(,)?)) => {$crate::component_ext!($world, $(#[name=$regname])? $component$(<$($generic),*>)?{ 0: $a$(<$($ag),*>)?, 1: $b$(<$($bg),*>)?, 2: $c$(<$($cg),*>)? })};
+    ($world:expr, $(#[name=$regname:literal])? $component:ident$(<$($generic:ty),*>)?($a:tt$(<$($ag:ty),*>)?, $b:tt$(<$($bg:ty),*>)?, $c:tt$(<$($cg:ty),*>)?, $d:tt$(<$($dg:ty),*>)? $(,)?)) => {$crate::component_ext!($world, $(#[name=$regname])? $component$(<$($generic),*>)?{ 0: $a$(<$($ag),*>)?, 1: $b$(<$($bg),*>)?, 2: $c$(<$($cg),*>)?, 3: $d$(<$($dg),*>)? })};
+    ($world:expr, $(#[name=$regname:literal])? $component:ident$(<$($generic:ty),*>)?($a:tt$(<$($ag:ty),*>)?, $b:tt$(<$($bg:ty),*>)?, $c:tt$(<$($cg:ty),*>)?, $d:tt$(<$($dg:ty),*>)?, $e:tt$(<$($eg:ty),*>)? $(,)?)) => {$crate::component_ext!($world, $(#[name=$regname])? $component$(<$($generic),*>)?{ 0:    $a$(<$($ag),*>)?, 1: $b$(<$($bg),*>)?, 2: $c$(<$($cg),*>)?, 3: $d$(<$($dg),*>)?, 4: $e$(<$($eg),*>)? })};
+    ($world:expr, $(#[name=$regname:literal])? $component:ident$(<$($generic:ty),*>)?($a:tt$(<$($ag:ty),*>)?, $b:tt$(<$($bg:ty),*>)?, $c:tt$(<$($cg:ty),*>)?, $d:tt$(<$($dg:ty),*>)?, $e:tt$(<$($eg:ty),*>)?, $f:tt$(<$($fg:ty),*>)? $(,)?)) => {$crate::component_ext!($world, $(#[name=$regname])? $component$(<$($generic),*>)?{ 0: $a$(<$($ag),*>)?, 1: $b$(<$($bg),*>)?, 2: $c$(<$($cg),*>)?, 3: $d$(<$($dg),*>)?, 4: $e$(<$($eg),*>)?, 5: $f$(<$($fg),*>)? })};
+    ($world:expr, $(#[name=$regname:literal])? $component:ident$(<$($generic:ty),*>)?($a:tt$(<$($ag:ty),*>)?, $b:tt$(<$($bg:ty),*>)?, $c:tt$(<$($cg:ty),*>)?, $d:tt$(<$($dg:ty),*>)?, $e:tt$(<$($eg:ty),*>)?, $f:tt$(<$($fg:ty),*>)?, $g:tt$(<$($gg:ty),*>)? $(,)?)) => {$crate::component_ext!($world, $(#[name=$regname])? $component$(<$($generic),*>)?{ 0: $a$(<$($ag),*>)?, 1: $b$(<$($bg),*>)?, 2: $c$(<$($cg),*>)?, 3: $d$(<$($dg),*>)?, 4: $e$(<$($eg),*>)?, 5: $f$(<$($fg),*>)?, 6: $g$(<$($gg),*>)? })};
+    ($world:expr, $(#[name=$regname:literal])? $component:ident$(<$($generic:ty),*>)?($a:tt$(<$($ag:ty),*>)?, $b:tt$(<$($bg:ty),*>)?, $c:tt$(<$($cg:ty),*>)?, $d:tt$(<$($dg:ty),*>)?, $e:tt$(<$($eg:ty),*>)?, $f:tt$(<$($fg:ty),*>)?, $g:tt$(<$($gg:ty),*>)?, $h:tt$(<$($hg:ty),*>)? $(,)?)) => {$crate::component_ext!($world, $(#[name=$regname])? $component$(<$($generic),*>)?{ 0: $a$(<$($ag),*>)?, 1: $b$(<$($bg),*>)?, 2: $c$(<$($cg),*>)?, 3: $d$(<$($dg),*>)?, 4: $e$(<$($eg),*>)?, 5: $f$(<$($fg),*>)?, 6: $g$(<$($gg),*>)?, 7: $h$(<$($hg),*>)? })};
+    ($world:expr, $(#[name=$regname:literal])? $component:ident$(<$($generic:ty),*>)?($a:tt$(<$($ag:ty),*>)?, $b:tt$(<$($bg:ty),*>)?, $c:tt$(<$($cg:ty),*>)?, $d:tt$(<$($dg:ty),*>)?, $e:tt$(<$($eg:ty),*>)?, $f:tt$(<$($fg:ty),*>)?, $g:tt$(<$($gg:ty),*>)?, $h:tt$(<$($hg:ty),*>)?, $i:tt$(<$($ig:ty),*>)? $(,)?)) => {$crate::component_ext!($world, $(#[name=$regname])? $component$(<$($generic),*>)?{ 0: $a$(<$($ag),*>)?, 1: $b$(<$($bg),*>)?, 2: $c$(<$($cg),*>)?, 3: $d$(<$($dg),*>)?, 4: $e$(<$($eg),*>)?, 5: $f$(<$($fg),*>)?, 6: $g$(<$($gg),*>)?, 7: $h$(<$($hg),*>)?, 8: $i$(<$($ig),*>)? })};
+    ($world:expr, $(#[name=$regname:literal])? $component:ident$(<$($generic:ty),*>)?($a:tt$(<$($ag:ty),*>)?, $b:tt$(<$($bg:ty),*>)?, $c:tt$(<$($cg:ty),*>)?, $d:tt$(<$($dg:ty),*>)?, $e:tt$(<$($eg:ty),*>)?, $f:tt$(<$($fg:ty),*>)?, $g:tt$(<$($gg:ty),*>)?, $h:tt$(<$($hg:ty),*>)?, $i:tt$(<$($ig:ty),*>)?, $j:tt$(<$($jg:ty),*>)? $(,)?)) => {$crate::component_ext!($world, $(#[name=$regname])? $component$(<$($generic),*>)?{ 0: $a$(<$($ag),*>)?, 1: $b$(<$($bg),*>)?, 2: $c$(<$($cg),*>)?, 3: $d$(<$($dg),*>)?, 4: $e$(<$($eg),*>)?, 5: $f$(<$($fg),*>)?, 6: $g$(<$($gg),*>)?, 7: $h$(<$($hg),*>)?, 8: $i$(<$($ig),*>)?, 9: $j$(<$($jg),*>)? })};
+    ($world:expr, $(#[name=$regname:literal])? $component:ident$(<$($generic:ty),*>)?($a:tt$(<$($ag:ty),*>)?, $b:tt$(<$($bg:ty),*>)?, $c:tt$(<$($cg:ty),*>)?, $d:tt$(<$($dg:ty),*>)?, $e:tt$(<$($eg:ty),*>)?, $f:tt$(<$($fg:ty),*>)?, $g:tt$(<$($gg:ty),*>)?, $h:tt$(<$($hg:ty),*>)?, $i:tt$(<$($ig:ty),*>)?, $j:tt$(<$($jg:ty),*>)?, $k:tt$(<$($kg:ty),*>)? $(,)?)) => {$crate::component_ext!($world, $(#[name=$regname])? $component$(<$($generic),*>)?{ 0: $a$(<$($ag),*>)?, 1: $b$(<$($bg),*>)?, 2: $c$(<$($cg),*>)?, 3: $d$(<$($dg),*>)?, 4: $e$(<$($eg),*>)?, 5: $f$(<$($fg),*>)?, 6: $g$(<$($gg),*>)?, 7: $h$(<$($hg),*>)?, 8: $i$(<$($ig),*>)?, 9: $j$(<$($jg),*>)?, 10: $k$(<$($kg),*>)? })};
+    ($world:expr, $(#[name=$regname:literal])? $component:ident$(<$($generic:ty),*>)?($a:tt$(<$($ag:ty),*>)?, $b:tt$(<$($bg:ty),*>)?, $c:tt$(<$($cg:ty),*>)?, $d:tt$(<$($dg:ty),*>)?, $e:tt$(<$($eg:ty),*>)?, $f:tt$(<$($fg:ty),*>)?, $g:tt$(<$($gg:ty),*>)?, $h:tt$(<$($hg:ty),*>)?, $i:tt$(<$($ig:ty),*>)?, $j:tt$(<$($jg:ty),*>)?, $k:tt$(<$($kg:ty),*>)?, $l:tt$(<$($lg:ty),*>)? $(,)?)) => {$crate::component_ext!($world, $(#[name=$regname])? $component$(<$($generic),*>)?{ 0: $a$(<$($ag),*>)?, 1: $b$(<$($bg),*>)?, 2: $c$(<$($cg),*>)?, 3: $d$(<$($dg),*>)?, 4: $e$(<$($eg),*>)?, 5: $f$(<$($fg),*>)?, 6: $g$(<$($gg),*>)?, 7: $h$(<$($hg),*>)?, 8: $i$(<$($ig),*>)?, 9: $j$(<$($jg),*>)?, 10: $k$(<$($kg),*>)?, 11: $l$(<$($lg),*>)? })};
+
+    // struct
+    ($world:expr, #[name=$regname:literal] $component:ty $({$($name:tt : $type:tt$(<$($generic:ty),*>)?),* $(,)?})?) => {{
+        let world = $world;
+        let component = world.component_named_ext(::flecs_ecs::prelude::id!(world, $component), $regname);
+        $($($crate::member_ext!(world, component: $component, $name: $type$(<$($generic),*>)?);)*)?
+        component
+    }};
+
+    ($world:expr, $component:ty $({$($name:tt : $type:tt$(<$($generic:ty),*>)?),* $(,)?})?) => {{
+        let world = $world;
+        let component = world.component_named_ext(::flecs_ecs::prelude::id!(world, $component), $crate::component_type_stringify!($component));
+        $($($crate::member_ext!(world, component: $component, $name: $type$(<$($generic),*>)?);)*)?
+        component
+    }};
+
+    // fieldless enum
+    ($world:expr, #[name=$regname:literal] $component:ty {$($name:tt),* $(,)?}) => {{
+        let world = $world;
+        let component = world.component_named_ext(::flecs_ecs::prelude::id!(world, $component), $regname);
+        const _: () = assert!(::core::mem::size_of::<$component>() == 4, "Flecs demands that enums are 4 bytes");
+        $(component.constant(::core::stringify!($name), <$component>::$name as i32);)*
+        component
+    }};
+
+    ($world:expr, $component:ty {$($name:tt),* $(,)?}) => {{
+        let world = $world;
+        let component = world.component_named_ext(::flecs_ecs::prelude::id!(world, $component), $crate::component_type_stringify!($component));
+        const _: () = assert!(::core::mem::size_of::<$component>() == 4, "Flecs demands that enums are 4 bytes");
+        $(component.constant(::core::stringify!($name), <$component>::$name as i32);)*
+        component
+    }};
+}

--- a/flecs_ecs/src/addons/meta/mod.rs
+++ b/flecs_ecs/src/addons/meta/mod.rs
@@ -5,6 +5,7 @@ mod cursor;
 mod declarations;
 mod impl_bindings;
 mod impl_primitives;
+pub mod macros;
 mod meta_functions;
 pub mod meta_trait;
 mod opaque;

--- a/flecs_ecs/src/prelude.rs
+++ b/flecs_ecs/src/prelude.rs
@@ -7,3 +7,5 @@ pub use flecs_ecs_sys::EcsComponent;
 
 #[cfg(feature = "flecs_meta")]
 pub use crate::addons::meta::*;
+#[cfg(feature = "flecs_meta")]
+pub use crate::{component,component_ext,member,member_ext};

--- a/flecs_ecs/tests/flecs/main.rs
+++ b/flecs_ecs/tests/flecs/main.rs
@@ -13,6 +13,7 @@ mod eq_test;
 mod flecs_docs_test;
 mod is_ref_test;
 mod meta_test;
+mod meta_macro_test;
 mod meta_trait_test;
 mod observer_test;
 mod query_builder_test;

--- a/flecs_ecs/tests/flecs/meta_macro_test.rs
+++ b/flecs_ecs/tests/flecs/meta_macro_test.rs
@@ -1,0 +1,588 @@
+#![allow(clippy::float_cmp)]
+use std::ffi::CStr;
+
+use flecs_ecs::prelude::meta::*;
+use flecs_ecs::{component, prelude::*};
+use flecs_ecs_sys::ecs_world_t;
+
+fn std_string_support(world: WorldRef) -> Opaque<String> {
+    let mut ts = Opaque::<String>::new(world);
+
+    // Let reflection framework know what kind of type this is
+    ts.as_type(flecs::meta::String);
+
+    // Forward std::string value to (JSON/...) serializer
+    ts.serialize(|s: &Serializer, data: &String| {
+        s.value_id(
+            flecs::meta::String,
+            &data.as_ptr() as *const *const u8 as *const std::ffi::c_void,
+        )
+    });
+
+    // Serialize string into std::string
+    ts.assign_string(|data: &mut String, value: *const i8| {
+        *data = unsafe { CStr::from_ptr(value).to_string_lossy().into_owned() }
+    });
+
+    ts
+}
+
+fn std_vector_support<T: Default>(world: WorldRef) -> Opaque<Vec<T>, T> {
+    let id = id!(&world, Vec<T>);
+    let mut ts = Opaque::<Vec<T>, T>::new_id(world, id);
+
+    // Let reflection framework know what kind of type this is
+    ts.as_type(world.vector(id));
+
+    // Forward std::vector value to (JSON/...) serializer
+    ts.serialize(|s: &Serializer, data: &Vec<T>| {
+        let world = unsafe { WorldRef::from_ptr(s.world as *mut ecs_world_t) };
+        let id = id!(world, T);
+        for el in data.iter() {
+            s.value_id(id, el as *const T as *const std::ffi::c_void);
+        }
+        0
+    });
+
+    // Return vector size
+    ts.count(|data: &mut Vec<T>| data.len());
+
+    fn ensure_generic_element<T: Default>(data: &mut Vec<T>, elem: usize) -> &mut T {
+        if data.len() <= elem {
+            data.resize_with(elem + 1, || T::default());
+        }
+        &mut data[elem]
+    }
+
+    fn resize_generic_vec<T: Default>(data: &mut Vec<T>, elem: usize) {
+        data.resize_with(elem + 1, || T::default());
+    }
+
+    // Ensure element exists, return
+    ts.ensure_element(ensure_generic_element::<T>);
+
+    // Resize contents of vector
+    ts.resize(resize_generic_vec::<T>);
+
+    ts
+}
+
+#[test]
+fn meta_struct() {
+    let world = World::new();
+
+    #[derive(Component)]
+    struct Test {
+        a: i32,
+        b: f32,
+    }
+
+    let c = component!(&world, Test { a: i32, b: f32 });
+
+    assert!(c.id() != 0);
+
+    let a = c.lookup("a");
+    assert!(a.id() != 0);
+    assert!(a.has::<flecs::meta::Member>());
+
+    a.get::<&flecs::meta::Member>(|mem| {
+        assert_eq!(mem.type_, flecs::meta::I32);
+    });
+
+    let b = c.lookup("b");
+    assert!(b.id() != 0);
+    assert!(b.has::<flecs::meta::Member>());
+
+    b.get::<&flecs::meta::Member>(|mem| {
+        assert_eq!(mem.type_, flecs::meta::F32);
+    });
+}
+
+#[test]
+fn meta_nested_struct() {
+    let world = World::new();
+
+    #[derive(Component)]
+    struct Test {
+        x: i32,
+    }
+
+    #[derive(Component)]
+    struct Nested {
+        a: Test,
+    }
+
+    let t = component!(&world, Test { x: i32 });
+
+    let n = component!(&world, Nested { a: Test });
+
+    assert!(n.id() != 0);
+
+    let a = n.lookup("a");
+    assert!(a.id() != 0);
+    assert!(a.has::<flecs::meta::Member>());
+
+    a.get::<&flecs::meta::Member>(|mem| {
+        assert_eq!(mem.type_, t.id());
+    });
+}
+
+#[test]
+fn meta_struct_w_portable_type() {
+    let world = World::new();
+
+    #[derive(Component)]
+    struct Test {
+        a: usize,
+        b: usize,
+        c: Entity,
+        d: Entity,
+    }
+
+    let t = component!(
+        &world,
+        Test {
+            a: usize,
+            b: usize,
+            c: Entity,
+            d: Entity
+        }
+    );
+
+    assert!(t.id() != 0);
+
+    let a = t.lookup("a");
+    assert!(a.id() != 0);
+    assert!(a.has::<flecs::meta::Member>());
+
+    a.get::<&flecs::meta::Member>(|mem| {
+        assert_eq!(mem.type_, flecs::meta::UPtr);
+    });
+
+    let b = t.lookup("b");
+    assert!(b.id() != 0);
+    assert!(b.has::<flecs::meta::Member>());
+
+    // b.get::<&flecs::meta::Member>(|mem| {
+    //     assert_eq!(mem.type_, flecs::meta::UPtr);
+    // });
+
+    // let c = t.lookup("c");
+    // assert!(c.id() != 0);
+    // assert!(c.has::<flecs::meta::Member>());
+
+    // c.get::<&flecs::meta::Member>(|mem| {
+    //     assert_eq!(mem.type_, flecs::meta::Entity);
+    // });
+
+    // let d = t.lookup("d");
+    // assert!(d.id() != 0);
+    // assert!(d.has::<flecs::meta::Member>());
+
+    // d.get::<&flecs::meta::Member>(|mem| {
+    //     assert_eq!(mem.type_, flecs::meta::Entity);
+    // });
+}
+
+//TODO meta_units -- units addon is not yet implemented in Rust
+//TODO Meta_unit_w_quantity -- units addon is not yet implemented in Rust
+//TODO Meta_unit_w_prefix -- units addon is not yet implemented in Rust
+//TODO Meta_unit_w_over -- units addon is not yet implemented in Rust
+
+#[test]
+fn meta_partial_struct() {
+    let world = World::new();
+
+    #[derive(Component)]
+    #[repr(C)]
+    struct Position {
+        x: f32,
+    }
+
+    let c = component!(&world, Position { x: f32 });
+
+    assert!(c.id() != 0);
+
+    c.get::<&flecs::Component>(|ptr| {
+        assert_eq!(ptr.size, 4);
+        assert_eq!(ptr.alignment, 4);
+    });
+
+    let xe = c.lookup("x");
+    assert!(xe.id() != 0);
+    assert!(xe.has::<flecs::meta::Member>());
+    xe.get::<&flecs::meta::Member>(|x| {
+        assert_eq!(x.type_, flecs::meta::F32);
+        assert_eq!(x.offset, 0);
+    });
+}
+
+#[test]
+fn meta_partial_struct_custom_offset() {
+    let world = World::new();
+
+    #[derive(Component)]
+    #[repr(C)]
+    struct Position {
+        x: f32,
+        y: f32,
+    }
+
+    let c = component!(&world, Position { y: f32 });
+
+    assert!(c.id() != 0);
+
+    c.get::<&flecs::Component>(|ptr| {
+        assert_eq!(ptr.size, 8);
+        assert_eq!(ptr.alignment, 4);
+    });
+
+    let xe = c.lookup("y");
+    assert!(xe.id() != 0);
+    assert!(xe.has::<flecs::meta::Member>());
+    xe.get::<&flecs::meta::Member>(|x| {
+        assert_eq!(x.type_, flecs::meta::F32);
+        assert_eq!(x.offset, 4);
+    });
+}
+
+#[test]
+fn meta_bitmask() {
+    let world = World::new();
+
+    #[derive(Component)]
+    struct Toppings {
+        value: u32,
+    }
+
+    impl Toppings {
+        const BACON: u32 = 0x1;
+        const LETTUCE: u32 = 0x2;
+        const TOMATO: u32 = 0x4;
+
+        fn new() -> Self {
+            Toppings { value: 0 }
+        }
+
+        fn add(&mut self, topping: u32) {
+            self.value |= topping;
+        }
+
+        fn remove(&mut self, topping: u32) {
+            self.value &= !topping;
+        }
+
+        fn has(&self, topping: u32) -> bool {
+            self.value & topping != 0
+        }
+    }
+
+    #[derive(Component)]
+    struct Sandwich {
+        toppings: Toppings,
+    }
+
+    impl Sandwich {
+        fn new() -> Self {
+            Sandwich {
+                toppings: Toppings::new(),
+            }
+        }
+
+        fn add_topping(&mut self, topping: u32) {
+            self.toppings.add(topping);
+        }
+
+        fn remove_topping(&mut self, topping: u32) {
+            self.toppings.remove(topping);
+        }
+
+        fn has_topping(&self, topping: u32) -> bool {
+            self.toppings.has(topping)
+        }
+    }
+
+    world
+        .component::<Toppings>()
+        .bit("bacon", Toppings::BACON)
+        .bit("lettuce", Toppings::LETTUCE)
+        .bit("tomato", Toppings::TOMATO);
+
+    component!(&world, Sandwich { toppings: Toppings });
+
+    // Create entity with Sandwich as usual
+    let e = world.entity().set(Sandwich {
+        toppings: Toppings {
+            value: Toppings::BACON | Toppings::LETTUCE,
+        },
+    });
+
+    // Convert Sandwidth component to flecs expression string
+    e.get::<&Sandwich>(|val| {
+        assert_eq!(world.to_expr(val), "{toppings: lettuce|bacon}");
+    });
+}
+
+#[test]
+fn meta_world_ser_deser_flecs_entity() {
+    #[derive(Component)]
+    struct RustEntity {
+        entity: Entity,
+    }
+
+    let world = World::new();
+
+    component!(&world, RustEntity { entity: Entity });
+
+    let e1 = world.entity_named("ent1");
+    let e2 = world
+        .entity_named("ent2")
+        .set(RustEntity { entity: e1.id() });
+
+    e2.get::<Option<&RustEntity>>(|ptr| {
+        assert!(ptr.is_some());
+        let ptr = ptr.unwrap();
+        assert_eq!(world.to_json::<RustEntity>(ptr), "{\"entity\":\"ent1\"}");
+    });
+
+    let json = world.to_json_world();
+
+    let world = World::new();
+
+    component!(&world, RustEntity { entity: Entity });
+
+    world.from_json_world(json.as_str(), None);
+
+    assert!(e1.is_alive());
+    assert!(e2.is_alive());
+
+    e2.get::<Option<&RustEntity>>(|ptr| {
+        assert!(ptr.is_some());
+        let ptr = ptr.unwrap();
+        assert_eq!(world.to_json::<RustEntity>(ptr), "{\"entity\":\"ent1\"}");
+    });
+}
+
+#[test]
+fn meta_new_world_ser_deser_flecs_entity() {
+    #[derive(Component)]
+    struct RustEntity {
+        entity: Entity,
+    }
+
+    let world = World::new();
+
+    component!(&world, RustEntity { entity: Entity });
+
+    let e1 = world.entity_named("ent1");
+    let e2 = world
+        .entity_named("ent2")
+        .set(RustEntity { entity: e1.id() });
+
+    e2.get::<Option<&RustEntity>>(|ptr| {
+        assert!(ptr.is_some());
+        let ptr = ptr.unwrap();
+        assert_eq!(world.to_json::<RustEntity>(ptr), "{\"entity\":\"ent1\"}");
+    });
+
+    let json = world.to_json_world();
+
+    let world = World::new();
+
+    component!(&world, RustEntity { entity: Entity });
+
+    world.from_json_world(json.as_str(), None);
+
+    let e1 = world.lookup("ent1");
+    let e2 = world.lookup("ent2");
+
+    assert!(e1.id() != 0);
+    assert!(e2.id() != 0);
+
+    assert!(e1.is_alive());
+    assert!(e2.is_alive());
+
+    e2.get::<Option<&RustEntity>>(|ptr| {
+        assert!(ptr.is_some());
+        let ptr = ptr.unwrap();
+        assert_eq!(world.to_json::<RustEntity>(ptr), "{\"entity\":\"ent1\"}");
+    });
+}
+
+#[test]
+fn meta_new_world_ser_deser_empty_flecs_entity() {
+    #[derive(Component)]
+    struct RustEntity {
+        entity: Entity,
+    }
+
+    let world = World::new();
+
+    component!(&world, RustEntity { entity: Entity });
+
+    let e1 = Entity::null();
+    let e2 = world.entity_named("ent2").set(RustEntity { entity: e1 });
+
+    e2.get::<Option<&RustEntity>>(|ptr| {
+        assert!(ptr.is_some());
+        let ptr = ptr.unwrap();
+        assert_eq!(world.to_json::<RustEntity>(ptr), "{\"entity\":\"#0\"}");
+    });
+
+    let json = world.to_json_world();
+
+    let world = World::new();
+
+    component!(&world, RustEntity { entity: Entity });
+
+    world.from_json_world(json.as_str(), None);
+
+    let e2 = world.lookup("ent2");
+
+    assert!(e2.id() != 0);
+
+    assert!(e2.is_alive());
+
+    e2.get::<Option<&RustEntity>>(|ptr| {
+        assert!(ptr.is_some());
+        let ptr = ptr.unwrap();
+        assert_eq!(world.to_json::<RustEntity>(ptr), "{\"entity\":\"#0\"}");
+    });
+}
+
+#[repr(C)]
+#[derive(Component)]
+#[allow(clippy::enum_clike_unportable_variant)]
+enum EnumWithBits {
+    BitA = 0,
+    BitB = 1 << 0,
+    BitAll = 0xffffffff,
+}
+
+#[derive(Component)]
+struct EnumWithBitsStruct {
+    bits: EnumWithBits,
+}
+
+impl Default for EnumWithBitsStruct {
+    fn default() -> Self {
+        EnumWithBitsStruct {
+            bits: EnumWithBits::BitAll,
+        }
+    }
+}
+
+#[test]
+fn meta_struct_member_ptr() {
+    let world = World::new();
+
+    #[repr(C)]
+    #[derive(Component)]
+    struct Test {
+        x: i32,
+    }
+
+    #[repr(C)]
+    #[derive(Component)]
+    struct Test2 {
+        y: f64,
+    }
+
+    #[repr(C)]
+    #[derive(Component)]
+    struct Nested {
+        a: Test, //what offset should this be? Rust returns 16, but CPP gives 0 lol
+        pad: i32,
+        b: [Test2; 2],
+    }
+
+    let t = component!(&world, Test { x: i32 });
+
+    let t2 = component!(&world, Test2 { y: f64 });
+
+    let n = component!(
+        &world,
+        Nested {
+            a: Test,
+            b: [Test2; 2]
+        }
+    );
+
+    //validate Test #1
+    assert!(t.id() != 0);
+
+    let x = t.lookup("x");
+    assert!(x.id() != 0);
+    assert!(x.has::<flecs::meta::Member>());
+    x.get::<&flecs::meta::Member>(|xm| {
+        assert_eq!(xm.type_, flecs::meta::I32);
+        assert_eq!(xm.offset, offset_of!(Test, x));
+    });
+
+    //validate Test2 #2
+    assert!(t2.id() != 0);
+
+    let y = t2.lookup("y");
+    assert!(y.id() != 0);
+    assert!(y.has::<flecs::meta::Member>());
+    y.get::<&flecs::meta::Member>(|ym| {
+        assert_eq!(ym.type_, flecs::meta::F64);
+        assert_eq!(ym.offset, offset_of!(Test2, y));
+    });
+
+    // Validate Nested
+    assert!(n.id() != 0);
+
+    let a = n.lookup("a");
+    assert!(a.id() != 0);
+    assert!(a.has::<flecs::meta::Member>());
+    a.get::<&flecs::meta::Member>(|am| {
+        assert_eq!(am.type_, t.id());
+        let offset = offset_of!(Nested, a);
+        assert_eq!(am.offset, offset);
+    });
+
+    let b = n.lookup("b");
+    assert!(b.id() != 0);
+    assert!(b.has::<flecs::meta::Member>());
+    b.get::<&flecs::meta::Member>(|bm| {
+        assert_eq!(bm.type_, t2.id());
+        assert_eq!(bm.offset, offset_of!(Nested, b));
+        assert_eq!(bm.count, 2);
+    });
+}
+
+#[test]
+#[should_panic]
+/// Known issue: fields must be provided with offset=0 field first
+fn meta_struct_field_order() {
+    let world = World::new();
+
+    #[repr(C)]
+    #[derive(Component)]
+    struct Test {
+        a: u32,
+        b: i32,
+    }
+
+    let t = component!(&world, Test { b: i32, a: u32 });
+
+    assert_ne!(t.id(), 0);
+    let a = t.lookup("a");
+    assert_ne!(a.id(), 0);
+    assert!(a.has::<flecs::meta::Member>());
+    a.get::<&flecs::meta::Member>(|am| {
+        assert_eq!(am.type_, flecs::meta::U32);
+        assert_eq!(am.offset, offset_of!(Test, a));
+    });
+
+    assert_ne!(t.id(), 0);
+    let b = t.lookup("b");
+    assert_ne!(b.id(), 0);
+    assert!(b.has::<flecs::meta::Member>());
+    b.get::<&flecs::meta::Member>(|bm| {
+        assert_eq!(bm.type_, flecs::meta::I32);
+        assert_eq!(bm.offset, offset_of!(Test, b));
+    });
+}
+

--- a/flecs_ecs/tests/flecs/meta_macro_test.rs
+++ b/flecs_ecs/tests/flecs/meta_macro_test.rs
@@ -586,3 +586,31 @@ fn meta_struct_field_order() {
     });
 }
 
+#[test]
+fn meta_ser_deser_option() {
+    let world = World::new();
+
+    #[derive(Component, Default, Debug, PartialEq)]
+    struct OptComponent(Option<u32>);
+
+    component!(&world, #[auto] Option<u32>);
+    component!(&world, OptComponent(Option<u32>));
+
+    {
+        let mut v = OptComponent::default();
+        let json = "{\"0\":{\"None\":false}}".to_string();
+        world.from_json::<OptComponent>(&mut v, &json, None);
+        assert_eq!(v, OptComponent(None));
+        let json = world.to_json::<OptComponent>(&v);
+        assert_eq!(json, "{\"0\":{\"None\":false}}");
+    }
+
+    {
+        let mut v = OptComponent::default();
+        let json = "{\"0\":{\"Some\":42}}".to_string();
+        world.from_json::<OptComponent>(&mut v, &json, None);
+        assert_eq!(v, OptComponent(Some(42)));
+        let json = world.to_json::<OptComponent>(&v);
+        assert_eq!(json, "{\"0\":{\"Some\":42}}");
+    }
+}


### PR DESCRIPTION
Known issue: Rust can cause fields to be reordered; if the offset=0 field is not the first one defined, it breaks.