### PR TITLE
fix build error on Windows

### DIFF
--- a/flecs_ecs/src/addons/meta/mod.rs
+++ b/flecs_ecs/src/addons/meta/mod.rs
@@ -95,7 +95,7 @@ impl World {
     /// * C++ API: `world::primitive`
     pub fn primitive(&self, kind: EcsPrimitiveKind) -> EntityView {
         let desc = sys::ecs_primitive_desc_t {
-            kind: kind as u32,
+            kind: kind as sys::ecs_primitive_kind_t,
             entity: 0u64,
         };
 


### PR DESCRIPTION
```
error[E0308]: mismatched types
  --> flecs_ecs\src\addons\meta\mod.rs:98:19
   |
98 |             kind: kind as u32,
   |                   ^^^^^^^^^^^ expected `i32`, found `u32`
```