### PR TITLE
Replace uses of i8 with c_char

### DIFF
--- a/flecs_ecs/src/addons/alerts/alert_builder.rs
+++ b/flecs_ecs/src/addons/alerts/alert_builder.rs
@@ -127,11 +127,11 @@ where
     pub fn message(&mut self, message: &str) -> &mut Self {
         let message = format!("{}\0", message);
         self.str_ptrs_to_free.push(StringToFree {
-            ptr: message.as_ptr() as *mut i8,
+            ptr: message.as_ptr() as *mut _,
             len: message.len(),
             capacity: message.capacity(),
         });
-        self.desc.message = message.as_ptr() as *const i8;
+        self.desc.message = message.as_ptr() as *const _;
         core::mem::forget(message);
         self
     }
@@ -149,11 +149,11 @@ where
     pub fn brief(&mut self, brief: &str) -> &mut Self {
         let brief = format!("{}\0", brief);
         self.str_ptrs_to_free.push(StringToFree {
-            ptr: brief.as_ptr() as *mut i8,
+            ptr: brief.as_ptr() as *mut _,
             len: brief.len(),
             capacity: brief.capacity(),
         });
-        self.desc.brief = brief.as_ptr() as *const i8;
+        self.desc.brief = brief.as_ptr() as *const _;
         core::mem::forget(brief);
         self
     }
@@ -171,11 +171,11 @@ where
     pub fn doc_name(&mut self, doc_name: &str) -> &mut Self {
         let doc_name = format!("{}\0", doc_name);
         self.str_ptrs_to_free.push(StringToFree {
-            ptr: doc_name.as_ptr() as *mut i8,
+            ptr: doc_name.as_ptr() as *mut _,
             len: doc_name.len(),
             capacity: doc_name.capacity(),
         });
-        self.desc.doc_name = doc_name.as_ptr() as *const i8;
+        self.desc.doc_name = doc_name.as_ptr() as *const _;
         core::mem::forget(doc_name);
         self
     }
@@ -256,9 +256,9 @@ where
         filter.with = *with.into();
         if let Some(var) = var {
             let var = format!("{}\0", var);
-            filter.var = var.as_ptr() as *const i8;
+            filter.var = var.as_ptr() as *const _;
             self.str_ptrs_to_free.push(StringToFree {
-                ptr: var.as_ptr() as *mut i8,
+                ptr: var.as_ptr() as *mut _,
                 len: var.as_bytes().len(),
                 capacity: var.as_bytes().len(),
             });
@@ -423,11 +423,11 @@ where
         if let Some(var) = var {
             let var = format!("{}\0", var);
             self.str_ptrs_to_free.push(StringToFree {
-                ptr: var.as_ptr() as *mut i8,
+                ptr: var.as_ptr() as *mut _,
                 len: var.len(),
                 capacity: var.capacity(),
             });
-            self.desc.var = var.as_ptr() as *const i8;
+            self.desc.var = var.as_ptr() as *const _;
             core::mem::forget(var);
         }
 
@@ -447,11 +447,11 @@ where
     pub fn var(&mut self, var: &str) -> &mut Self {
         let var = format!("{}\0", var);
         self.str_ptrs_to_free.push(StringToFree {
-            ptr: var.as_ptr() as *mut i8,
+            ptr: var.as_ptr() as *mut _,
             len: var.len(),
             capacity: var.capacity(),
         });
-        self.desc.var = var.as_ptr() as *const i8;
+        self.desc.var = var.as_ptr() as *const _;
         core::mem::forget(var);
         self
     }

--- a/flecs_ecs/src/addons/json/mod.rs
+++ b/flecs_ecs/src/addons/json/mod.rs
@@ -29,7 +29,7 @@ impl<'a> EntityView<'a> {
         unsafe {
             let type_ = sys::ecs_get_typeid(world, comp);
             if type_ == 0 {
-                //sys::ecs_err(b"id is not a type\0".as_ptr() as *const i8);
+                //sys::ecs_err(b"id is not a type\0".as_ptr() as *const _);
                 //TODO implement ecs_err
                 return self;
             }
@@ -42,13 +42,13 @@ impl<'a> EntityView<'a> {
             );
             let json = compact_str::format_compact!("{}\0", json);
             if let Some(desc) = desc {
-                sys::ecs_ptr_from_json(world, type_, ptr, json.as_ptr() as *const i8, desc);
+                sys::ecs_ptr_from_json(world, type_, ptr, json.as_ptr() as *const _, desc);
             } else {
                 sys::ecs_ptr_from_json(
                     world,
                     type_,
                     ptr,
-                    json.as_ptr() as *const i8,
+                    json.as_ptr() as *const _,
                     std::ptr::null(),
                 );
             }
@@ -128,7 +128,7 @@ impl<'a> EntityView<'a> {
         //TODO we should have an Json Type so we don't need to make these conversions multiple times.
         let json = compact_str::format_compact!("{}\0", json);
         unsafe {
-            sys::ecs_entity_from_json(world, id, json.as_ptr() as *const i8, std::ptr::null());
+            sys::ecs_entity_from_json(world, id, json.as_ptr() as *const _, std::ptr::null());
         }
         self
     }
@@ -224,7 +224,7 @@ impl World {
         let json = compact_str::format_compact!("{}\0", json);
 
         unsafe {
-            sys::ecs_ptr_from_json(world, tid, value, json.as_ptr() as *const i8, desc_ptr);
+            sys::ecs_ptr_from_json(world, tid, value, json.as_ptr() as *const _, desc_ptr);
         }
     }
 
@@ -263,7 +263,7 @@ impl World {
             .unwrap_or(std::ptr::null());
 
         unsafe {
-            sys::ecs_world_from_json(world, json.as_ptr() as *const i8, desc_ptr);
+            sys::ecs_world_from_json(world, json.as_ptr() as *const _, desc_ptr);
         }
 
         self
@@ -288,7 +288,7 @@ impl World {
             .unwrap_or(std::ptr::null());
 
         unsafe {
-            sys::ecs_world_from_json_file(world, json_file.as_ptr() as *const i8, desc_ptr);
+            sys::ecs_world_from_json_file(world, json_file.as_ptr() as *const _, desc_ptr);
         }
 
         self

--- a/flecs_ecs/src/addons/meta/builtin.rs
+++ b/flecs_ecs/src/addons/meta/builtin.rs
@@ -81,7 +81,7 @@ fn std_string_support(world: WorldRef) -> Opaque<String> {
     });
 
     // Serialize string into std::string
-    ts.assign_string(|data: &mut String, value: *const i8| {
+    ts.assign_string(|data: &mut String, value: *const std::ffi::c_char| {
         *data = unsafe { CStr::from_ptr(value).to_string_lossy().into_owned() }
     });
 

--- a/flecs_ecs/src/addons/meta/component_id_fetcher.rs
+++ b/flecs_ecs/src/addons/meta/component_id_fetcher.rs
@@ -64,7 +64,7 @@ impl<T: 'static> ExternalComponent<T> for &ComponentIdFetcher<T> {
         let id = *(map.entry(std::any::TypeId::of::<T>()).or_insert_with(|| {
             let type_name = get_only_type_name::<T>();
             let name = compact_str::format_compact!("external_components::{}\0", type_name);
-            external_register_component::<true, T>(world, name.as_ptr() as *const i8)
+            external_register_component::<true, T>(world, name.as_ptr() as *const _)
         }));
         FetchedId::new(id)
     }

--- a/flecs_ecs/src/addons/meta/cursor.rs
+++ b/flecs_ecs/src/addons/meta/cursor.rs
@@ -43,7 +43,7 @@ impl<'a> Cursor<'a> {
     /// Move to member by name
     pub fn member(&mut self, name: &str) -> i32 {
         let name = compact_str::format_compact!("{}\0", name);
-        unsafe { sys::ecs_meta_member(&mut self.cursor, name.as_ptr() as *const i8) }
+        unsafe { sys::ecs_meta_member(&mut self.cursor, name.as_ptr() as *const _) }
     }
 
     /// Move to element by index
@@ -97,7 +97,7 @@ impl<'a> Cursor<'a> {
 
     /// Set char value
     pub fn set_char(&mut self, value: char) -> i32 {
-        unsafe { sys::ecs_meta_set_char(&mut self.cursor, value as i8) }
+        unsafe { sys::ecs_meta_set_char(&mut self.cursor, value as std::ffi::c_char) }
     }
 
     /// Set signed int value
@@ -118,13 +118,13 @@ impl<'a> Cursor<'a> {
     /// Set string value
     pub fn set_string(&mut self, value: &str) -> i32 {
         let value = compact_str::format_compact!("{}\0", value);
-        unsafe { sys::ecs_meta_set_string(&mut self.cursor, value.as_ptr() as *const i8) }
+        unsafe { sys::ecs_meta_set_string(&mut self.cursor, value.as_ptr() as *const _) }
     }
 
     /// Set string literal value
     pub fn set_string_literal(&mut self, value: &str) -> i32 {
         let value = compact_str::format_compact!("{}\0", value);
-        unsafe { sys::ecs_meta_set_string_literal(&mut self.cursor, value.as_ptr() as *const i8) }
+        unsafe { sys::ecs_meta_set_string_literal(&mut self.cursor, value.as_ptr() as *const _) }
     }
 
     /// Set entity value
@@ -168,7 +168,7 @@ impl<'a> Cursor<'a> {
     }
 
     /// Get string value
-    pub fn get_string(&self) -> *const i8 {
+    pub fn get_string(&self) -> *const std::ffi::c_char {
         // TODO: Rustify this to return &str
         unsafe { sys::ecs_meta_get_string(&self.cursor) }
     }

--- a/flecs_ecs/src/addons/meta/macros/macro_component.rs
+++ b/flecs_ecs/src/addons/meta/macros/macro_component.rs
@@ -364,7 +364,10 @@ pub fn opaque_option_struct<T: Default>(world: WorldRef) -> Opaque<Option<T>, T>
     });
 
     // TODO: try to relax the Default requirement.
-    fn ensure_member<T: Default>(data: &mut Option<T>, member: *const i8) -> *mut std::ffi::c_void {
+    fn ensure_member<T: Default>(
+        data: &mut Option<T>,
+        member: *const std::ffi::c_char,
+    ) -> *mut std::ffi::c_void {
         let member = unsafe { std::ffi::CStr::from_ptr(member) };
         if member == c"None" {
             *data = None;

--- a/flecs_ecs/src/addons/meta/meta_functions.rs
+++ b/flecs_ecs/src/addons/meta/meta_functions.rs
@@ -1,4 +1,4 @@
-use std::ffi::c_void;
+use std::ffi::{c_char, c_void};
 
 use crate::core::{Entity, WorldRef};
 
@@ -55,22 +55,22 @@ where
 }
 
 pub trait AssignCharFn<T> {
-    fn to_extern_fn(self) -> extern "C-unwind" fn(&mut T, i8);
+    fn to_extern_fn(self) -> extern "C-unwind" fn(&mut T, c_char);
 }
 
 impl<F, T> AssignCharFn<T> for F
 where
-    F: Fn(&mut T, i8),
+    F: Fn(&mut T, c_char),
 {
-    fn to_extern_fn(self) -> extern "C-unwind" fn(&mut T, i8) {
+    fn to_extern_fn(self) -> extern "C-unwind" fn(&mut T, c_char) {
         const {
             assert!(std::mem::size_of::<Self>() == 0);
         }
         std::mem::forget(self);
 
-        extern "C-unwind" fn output<F, T>(value: &mut T, data: i8)
+        extern "C-unwind" fn output<F, T>(value: &mut T, data: c_char)
         where
-            F: Fn(&mut T, i8),
+            F: Fn(&mut T, c_char),
         {
             (unsafe { std::mem::transmute_copy::<_, F>(&()) })(value, data);
         }
@@ -155,22 +155,22 @@ where
 }
 
 pub trait AssignStringFn<T> {
-    fn to_extern_fn(self) -> extern "C-unwind" fn(&mut T, *const i8);
+    fn to_extern_fn(self) -> extern "C-unwind" fn(&mut T, *const c_char);
 }
 
 impl<F, T> AssignStringFn<T> for F
 where
-    F: Fn(&mut T, *const i8),
+    F: Fn(&mut T, *const c_char),
 {
-    fn to_extern_fn(self) -> extern "C-unwind" fn(&mut T, *const i8) {
+    fn to_extern_fn(self) -> extern "C-unwind" fn(&mut T, *const c_char) {
         const {
             assert!(std::mem::size_of::<Self>() == 0);
         }
         std::mem::forget(self);
 
-        extern "C-unwind" fn output<F, T>(value: &mut T, data: *const i8)
+        extern "C-unwind" fn output<F, T>(value: &mut T, data: *const c_char)
         where
-            F: Fn(&mut T, *const i8),
+            F: Fn(&mut T, *const c_char),
         {
             (unsafe { std::mem::transmute_copy::<_, F>(&()) })(value, data);
         }
@@ -280,22 +280,22 @@ where
 }
 
 pub trait EnsureMemberFn<T> {
-    fn to_extern_fn(self) -> extern "C-unwind" fn(&mut T, *const i8) -> *mut c_void;
+    fn to_extern_fn(self) -> extern "C-unwind" fn(&mut T, *const c_char) -> *mut c_void;
 }
 
 impl<F, T> EnsureMemberFn<T> for F
 where
-    F: Fn(&mut T, *const i8) -> *mut c_void,
+    F: Fn(&mut T, *const c_char) -> *mut c_void,
 {
-    fn to_extern_fn(self) -> extern "C-unwind" fn(&mut T, *const i8) -> *mut c_void {
+    fn to_extern_fn(self) -> extern "C-unwind" fn(&mut T, *const c_char) -> *mut c_void {
         const {
             assert!(std::mem::size_of::<Self>() == 0);
         }
         std::mem::forget(self);
 
-        extern "C-unwind" fn output<F, T>(value: &mut T, data: *const i8) -> *mut c_void
+        extern "C-unwind" fn output<F, T>(value: &mut T, data: *const c_char) -> *mut c_void
         where
-            F: Fn(&mut T, *const i8) -> *mut c_void,
+            F: Fn(&mut T, *const c_char) -> *mut c_void,
         {
             (unsafe { std::mem::transmute_copy::<_, F>(&()) })(value, data)
         }

--- a/flecs_ecs/src/addons/meta/mod.rs
+++ b/flecs_ecs/src/addons/meta/mod.rs
@@ -217,7 +217,7 @@ impl EcsSerializer for sys::ecs_serializer_t {
     fn member(&self, name: &str) -> i32 {
         let name = compact_str::format_compact!("{}\0", name);
         if let Some(member_func) = self.member {
-            unsafe { member_func(self, name.as_ptr() as *const i8) }
+            unsafe { member_func(self, name.as_ptr() as *const _) }
         } else {
             0
         }
@@ -372,7 +372,7 @@ impl<'a> UntypedComponent<'a> {
         unsafe { sys::ecs_add_id(world, id, flecs::meta::EcsEnum::ID) };
 
         let desc = sys::ecs_entity_desc_t {
-            name: name.as_ptr() as *const i8,
+            name: name.as_ptr() as *const _,
             parent: id,
             ..Default::default()
         };
@@ -418,7 +418,7 @@ impl<'a> UntypedComponent<'a> {
         let unit = *unit.into();
 
         let desc = sys::ecs_entity_desc_t {
-            name: name.as_ptr() as *const i8,
+            name: name.as_ptr() as *const _,
             parent: id,
             ..Default::default()
         };
@@ -544,7 +544,7 @@ impl<'a> UntypedComponent<'a> {
         unsafe { sys::ecs_add_id(world, id, flecs::meta::Bitmask::ID) };
 
         let desc = sys::ecs_entity_desc_t {
-            name: name.as_ptr() as *const i8,
+            name: name.as_ptr() as *const _,
             parent: id,
             ..Default::default()
         };
@@ -698,7 +698,7 @@ impl<'a> EntityView<'a> {
             let symbol = compact_str::format_compact!("{}\0", symbol);
             let desc = sys::ecs_unit_desc_t {
                 entity: *self.id,
-                symbol: symbol.as_ptr() as *const i8,
+                symbol: symbol.as_ptr() as *const _,
                 base: *base.into(),
                 over: *over.into(),
                 prefix: *prefix.into(),
@@ -734,7 +734,7 @@ impl<'a> EntityView<'a> {
         let symbol = compact_str::format_compact!("{}\0", symbol);
         let desc = sys::ecs_unit_prefix_desc_t {
             entity: *self.id,
-            symbol: symbol.as_ptr() as *const i8,
+            symbol: symbol.as_ptr() as *const _,
             translation: sys::ecs_unit_translation_t { factor, power },
         };
 

--- a/flecs_ecs/src/addons/meta/opaque.rs
+++ b/flecs_ecs/src/addons/meta/opaque.rs
@@ -86,8 +86,8 @@ impl<'a, T, ElemType> Opaque<'a, T, ElemType> {
     pub fn assign_char(&mut self, func: impl AssignCharFn<T>) -> &mut Self {
         self.desc.type_.assign_char = Some(unsafe {
             std::mem::transmute::<
-                extern "C-unwind" fn(&mut T, i8),
-                unsafe extern "C-unwind" fn(*mut std::ffi::c_void, i8),
+                extern "C-unwind" fn(&mut T, std::ffi::c_char),
+                unsafe extern "C-unwind" fn(*mut std::ffi::c_void, std::ffi::c_char),
             >(func.to_extern_fn())
         });
         self
@@ -130,8 +130,8 @@ impl<'a, T, ElemType> Opaque<'a, T, ElemType> {
     pub fn assign_string(&mut self, func: impl AssignStringFn<T>) -> &mut Self {
         self.desc.type_.assign_string = Some(unsafe {
             std::mem::transmute::<
-                extern "C-unwind" fn(&mut T, *const i8),
-                unsafe extern "C-unwind" fn(*mut std::ffi::c_void, *const i8),
+                extern "C-unwind" fn(&mut T, *const std::ffi::c_char),
+                unsafe extern "C-unwind" fn(*mut std::ffi::c_void, *const std::ffi::c_char),
             >(func.to_extern_fn())
         });
         self
@@ -189,10 +189,10 @@ impl<'a, T, ElemType> Opaque<'a, T, ElemType> {
     pub fn ensure_member(&mut self, func: impl EnsureMemberFn<T>) -> &mut Self {
         self.desc.type_.ensure_member = Some(unsafe {
             std::mem::transmute::<
-                extern "C-unwind" fn(&mut T, *const i8) -> *mut std::ffi::c_void,
+                extern "C-unwind" fn(&mut T, *const std::ffi::c_char) -> *mut std::ffi::c_void,
                 unsafe extern "C-unwind" fn(
                     *mut std::ffi::c_void,
-                    *const i8,
+                    *const std::ffi::c_char,
                 ) -> *mut std::ffi::c_void,
             >(func.to_extern_fn())
         });

--- a/flecs_ecs/src/addons/pipeline/pipeline_builder.rs
+++ b/flecs_ecs/src/addons/pipeline/pipeline_builder.rs
@@ -103,7 +103,7 @@ where
         };
 
         let entity_desc: sys::ecs_entity_desc_t = sys::ecs_entity_desc_t {
-            name: name.as_ptr() as *const i8,
+            name: name.as_ptr() as *const _,
             sep: SEPARATOR.as_ptr(),
             ..Default::default()
         };

--- a/flecs_ecs/src/addons/script/script_builder.rs
+++ b/flecs_ecs/src/addons/script/script_builder.rs
@@ -32,7 +32,7 @@ impl<'a> ScriptBuilder<'a> {
     pub fn new_named(world: impl WorldProvider<'a>, name: &str) -> Self {
         let name = compact_str::format_compact!("{}\0", name);
         let entity_desc = sys::ecs_entity_desc_t {
-            name: name.as_ptr() as *const i8,
+            name: name.as_ptr() as *const _,
             sep: SEPARATOR.as_ptr(),
             root_sep: SEPARATOR.as_ptr(),
             ..Default::default()
@@ -85,7 +85,7 @@ impl<'a> ScriptBuilder<'a> {
         let filename = compact_str::format_compact!("{}\0", filename);
         let world = self.world.world_ptr_mut();
 
-        self.script.filename = filename.as_ptr() as *const i8;
+        self.script.filename = filename.as_ptr() as *const _;
 
         let result = unsafe { sys::ecs_script_init(world, &self.script) };
 
@@ -114,7 +114,7 @@ impl<'a> ScriptBuilder<'a> {
         let code = compact_str::format_compact!("{}\0", code);
         let world = self.world.world_ptr_mut();
 
-        self.script.code = code.as_ptr() as *const i8;
+        self.script.code = code.as_ptr() as *const _;
 
         let result = unsafe { sys::ecs_script_init(world, &self.script) };
 

--- a/flecs_ecs/src/addons/script/script_entity_view.rs
+++ b/flecs_ecs/src/addons/script/script_entity_view.rs
@@ -68,7 +68,7 @@ impl<'a> ScriptEntityView<'a> {
                 world.world_ptr_mut(),
                 *self.id,
                 instance.map(|e| *e.into()).unwrap_or(0),
-                code.as_ptr() as *const i8,
+                code.as_ptr() as *const _,
             ) == 0
         }
     }

--- a/flecs_ecs/src/addons/script/unmanaged_script.rs
+++ b/flecs_ecs/src/addons/script/unmanaged_script.rs
@@ -13,7 +13,7 @@ use flecs_ecs::sys;
 #[repr(C)]
 pub struct Script<'a> {
     script: *mut sys::ecs_script_t,
-    ast: *mut i8,
+    ast: *mut std::ffi::c_char,
     _phantom: std::marker::PhantomData<&'a ()>,
 }
 
@@ -55,8 +55,8 @@ impl<'a> Script<'a> {
         let ptr = unsafe {
             sys::ecs_script_parse(
                 world_ptr,
-                name.as_ptr() as *const i8,
-                code.as_ptr() as *const i8,
+                name.as_ptr() as *const _,
+                code.as_ptr() as *const _,
             )
         };
         if ptr.is_null() {
@@ -113,8 +113,8 @@ impl<'a> Script<'a> {
         unsafe {
             sys::ecs_script_run(
                 world_ptr,
-                name.as_ptr() as *const i8,
-                code.as_ptr() as *const i8,
+                name.as_ptr() as *const _,
+                code.as_ptr() as *const _,
             ) == 0
         }
     }
@@ -136,7 +136,7 @@ impl<'a> Script<'a> {
         let filename = compact_str::format_compact!("{}\0", filename);
         let world_ptr = world.world_ptr_mut();
 
-        unsafe { sys::ecs_script_run_file(world_ptr, filename.as_ptr() as *const i8) == 0 }
+        unsafe { sys::ecs_script_run_file(world_ptr, filename.as_ptr() as *const _) == 0 }
     }
 
     /// Convert script AST to string.

--- a/flecs_ecs/src/core/component_registration/registration.rs
+++ b/flecs_ecs/src/core/component_registration/registration.rs
@@ -12,7 +12,7 @@ pub fn internal_register_component<
     T,
 >(
     world: impl WorldProvider<'a>,
-    name: *const i8,
+    name: *const c_char,
 ) -> u64
 where
     T: ComponentId,
@@ -34,7 +34,7 @@ where
 #[doc(hidden)]
 pub(crate) fn external_register_component<'a, const COMPONENT_REGISTRATION: bool, T>(
     world: impl WorldProvider<'a>,
-    name: *const i8,
+    name: *const c_char,
 ) -> u64 {
     external_register_component_data::<COMPONENT_REGISTRATION, T>(world.world_ptr_mut(), name)
 }
@@ -205,7 +205,7 @@ where
     let id = if name.is_null() {
         let prev_scope = unsafe { sys::ecs_set_scope(world, 0) };
         let id = unsafe {
-            sys::ecs_lookup_symbol(world, only_type_name.as_ptr() as *const i8, false, false)
+            sys::ecs_lookup_symbol(world, only_type_name.as_ptr() as *const _, false, false)
         };
         unsafe { sys::ecs_set_scope(world, prev_scope) };
         id
@@ -252,7 +252,7 @@ pub(crate) fn external_register_componment_data_explicit<T>(
     let id = if name.is_null() {
         let prev_scope = unsafe { sys::ecs_set_scope(world, 0) };
         let id = unsafe {
-            sys::ecs_lookup_symbol(world, only_type_name.as_ptr() as *const i8, false, false)
+            sys::ecs_lookup_symbol(world, only_type_name.as_ptr() as *const _, false, false)
         };
         unsafe { sys::ecs_set_scope(world, prev_scope) };
         id

--- a/flecs_ecs/src/core/term.rs
+++ b/flecs_ecs/src/core/term.rs
@@ -65,7 +65,7 @@ pub mod internals {
     use crate::sys;
 
     pub(crate) struct StringToFree {
-        pub(crate) ptr: *mut i8,
+        pub(crate) ptr: *mut std::ffi::c_char,
         pub(crate) len: usize,
         pub(crate) capacity: usize,
     }
@@ -384,10 +384,10 @@ pub trait TermBuilderImpl<'a>: Sized + WorldProvider<'a> + internals::QueryConfi
         let name = format!("{}\0", name);
         let name = std::mem::ManuallyDrop::new(name);
         let term_ref = self.term_ref_mut();
-        term_ref.name = name.as_ptr() as *mut i8;
+        term_ref.name = name.as_ptr() as *mut _;
         term_ref.id |= flecs::IsEntity::ID;
         self.term_builder_mut().str_ptrs_to_free.push(StringToFree {
-            ptr: name.as_ptr() as *mut i8,
+            ptr: name.as_ptr() as *mut _,
             len: name.len(),
             capacity: name.capacity(),
         });
@@ -411,9 +411,9 @@ pub trait TermBuilderImpl<'a>: Sized + WorldProvider<'a> + internals::QueryConfi
         let var_name = std::mem::ManuallyDrop::new(var_name);
         let term_ref = self.term_ref_mut();
         term_ref.id |= flecs::IsVariable::ID;
-        term_ref.name = var_name.as_ptr() as *mut i8;
+        term_ref.name = var_name.as_ptr() as *mut _;
         self.term_builder_mut().str_ptrs_to_free.push(StringToFree {
-            ptr: var_name.as_ptr() as *mut i8,
+            ptr: var_name.as_ptr() as *mut _,
             len: var_name.len(),
             capacity: var_name.capacity(),
         });

--- a/flecs_ecs/tests/flecs/meta_macro_test.rs
+++ b/flecs_ecs/tests/flecs/meta_macro_test.rs
@@ -21,7 +21,7 @@ fn std_string_support(world: WorldRef) -> Opaque<String> {
     });
 
     // Serialize string into std::string
-    ts.assign_string(|data: &mut String, value: *const i8| {
+    ts.assign_string(|data: &mut String, value: *const std::ffi::c_char| {
         *data = unsafe { CStr::from_ptr(value).to_string_lossy().into_owned() }
     });
 

--- a/flecs_ecs/tests/flecs/meta_test.rs
+++ b/flecs_ecs/tests/flecs/meta_test.rs
@@ -22,7 +22,7 @@ fn std_string_support(world: WorldRef) -> Opaque<String> {
     });
 
     // Serialize string into std::string
-    ts.assign_string(|data: &mut String, value: *const i8| {
+    ts.assign_string(|data: &mut String, value: *const std::ffi::c_char| {
         *data = unsafe { CStr::from_ptr(value).to_string_lossy().into_owned() }
     });
 


### PR DESCRIPTION
This allows the project to compile on targets where `c_char` is `u8` instead of `i8`. It also changes some of the traits in `meta_functions.rs`  to use `c_char`, and I'm not sure if this would be considered a breaking change, 