### PR TITLE
Use `ManuallyDrop` better rather than `StringToFree`

### DIFF
--- a/flecs_ecs/src/addons/pipeline/pipeline_builder.rs
+++ b/flecs_ecs/src/addons/pipeline/pipeline_builder.rs
@@ -154,15 +154,10 @@ where
 
     fn build(&mut self) -> Self::BuiltType {
         let pipeline = Pipeline::<T>::new(self.world(), self.desc);
-        for string_parts in self.term_builder.str_ptrs_to_free.iter() {
-            unsafe {
-                String::from_raw_parts(
-                    string_parts.ptr as *mut u8,
-                    string_parts.len,
-                    string_parts.capacity,
-                );
-            }
+        for s in self.term_builder.str_ptrs_to_free.iter_mut() {
+            unsafe { std::mem::ManuallyDrop::drop(s) };
         }
+        self.term_builder.str_ptrs_to_free.clear();
         pipeline
     }
 }

--- a/flecs_ecs/src/addons/system/system_builder.rs
+++ b/flecs_ecs/src/addons/system/system_builder.rs
@@ -250,15 +250,10 @@ where
     #[doc(alias = "node_builder::build")]
     fn build(&mut self) -> Self::BuiltType {
         let system = System::new(self.world(), self.desc);
-        for string_parts in self.term_builder.str_ptrs_to_free.iter() {
-            unsafe {
-                String::from_raw_parts(
-                    string_parts.ptr as *mut u8,
-                    string_parts.len,
-                    string_parts.capacity,
-                );
-            }
+        for s in self.term_builder.str_ptrs_to_free.iter_mut() {
+            unsafe { std::mem::ManuallyDrop::drop(s) };
         }
+        self.term_builder.str_ptrs_to_free.clear();
         system
     }
 }

--- a/flecs_ecs/src/core/observer_builder.rs
+++ b/flecs_ecs/src/core/observer_builder.rs
@@ -239,15 +239,10 @@ where
     #[doc(alias = "node_builder::build")]
     fn build(&mut self) -> Self::BuiltType {
         let observer = Observer::new(self.world(), self.desc);
-        for string_parts in self.term_builder.str_ptrs_to_free.iter() {
-            unsafe {
-                String::from_raw_parts(
-                    string_parts.ptr as *mut u8,
-                    string_parts.len,
-                    string_parts.capacity,
-                );
-            }
+        for s in self.term_builder.str_ptrs_to_free.iter_mut() {
+            unsafe { std::mem::ManuallyDrop::drop(s) };
         }
+        self.term_builder.str_ptrs_to_free.clear();
         observer
     }
 }


### PR DESCRIPTION
Instead of storing string raw parts and re-creating them, we can use `ManuallyDrop<T>` instead.

Also, various builders were dropping the term builder string parts, but not clearing the vec, so if they were incorrectly used multiple times, they would have deallocated the same memory multiple times.

This also makes the fact that strings are being dropped more explicit (by calls to `ManuallyDrop::drop` rather than the implicit drop from `String::from_raw_parts`).

This will let us use `compact_str` in these places in the future.

This is an incremental change. Future commits will continue to improve upon this.