### PR TITLE
Use workspace dependencies for our own crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,11 @@ clippy.print_stdout = "warn"
 clippy.semicolon_if_nothing_returned = "warn"
 rust.unused_lifetimes = "warn"
 
+[workspace.dependencies]
+flecs_ecs = { version = "0.1.2", path = "flecs_ecs" }
+flecs_ecs_derive = { version = "0.1.0", path = "flecs_ecs_derive" }
+flecs_ecs_sys = { version = "0.1.2", path = "flecs_ecs_sys" }
+
 [profile.release]
 lto = true
 codegen-units = 1

--- a/flecs_ecs/Cargo.toml
+++ b/flecs_ecs/Cargo.toml
@@ -21,8 +21,8 @@ rustdoc-args = [ "-Zunstable-options", "--generate-link-to-definition"]
 cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]
 
 [dependencies]
-flecs_ecs_derive = { version = "0.1.0", path = "../flecs_ecs_derive" }
-flecs_ecs_sys = { version = "0.1.2", path = "../flecs_ecs_sys" }
+flecs_ecs_derive = { workspace = true }
+flecs_ecs_sys = { workspace = true }
 bitflags = "2.6.0"
 compact_str = "0.8.0"
 fxhash = "0.2.1"


### PR DESCRIPTION
This lets the crates that depend upon crates within the workspace not need to track the path and version numbers in multiple locations.