### PR TITLE
Use `hashbrown` for `FlecsIdMap`

### DIFF
--- a/flecs_ecs/Cargo.toml
+++ b/flecs_ecs/Cargo.toml
@@ -25,7 +25,7 @@ flecs_ecs_derive = { version = "0.1.0", path = "../flecs_ecs_derive" }
 flecs_ecs_sys = { version = "0.1.2", path = "../flecs_ecs_sys" }
 bitflags = "2.6.0"
 compact_str = "0.8.0"
-fxhash = "0.2.1"
+hashbrown = "0.15.0"
 
 # used for backtraces upon hardware exceptions during test
 # only used when "test-with-crash-handler" feature enabled

--- a/flecs_ecs/src/core/world.rs
+++ b/flecs_ecs/src/core/world.rs
@@ -51,7 +51,7 @@ impl Clone for World {
     }
 }
 
-pub(crate) type FlecsIdMap = std::collections::HashMap<TypeId, u64, fxhash::FxBuildHasher>;
+pub(crate) type FlecsIdMap = hashbrown::HashMap<TypeId, u64>;
 
 unsafe impl Send for World {}
 


### PR DESCRIPTION
This removes a dependency on `fxhash` and uses `hashbrown` which now defaults to `foldhash`.

`fxhash` hasn't been updated / maintained in 7 years and the Rust community has largely moved on to other hash algorithms over time.

(This is also more friendly for future potential `no_std` support.)