### PR TITLE
Upgrade to Flecs Core v4.0.3

### DIFF
--- a/flecs_ecs/src/addons/doc.rs
+++ b/flecs_ecs/src/addons/doc.rs
@@ -36,7 +36,7 @@ pub trait Doc<'a>: WorldProvider<'a> + Into<Entity> + Clone {
     ///
     /// # See also
     ///
-    /// * [`World::get_doc_name()`]
+    /// * [`World::doc_name()`]
     /// * C++ API: `doc::get_name()`
     fn doc_name(&self) -> Option<String> {
         self.world().doc_name_id(self.clone())
@@ -50,7 +50,7 @@ pub trait Doc<'a>: WorldProvider<'a> + Into<Entity> + Clone {
     ///
     /// # See also
     ///
-    /// * [`World::get_doc_brief()`]
+    /// * [`World::doc_brief()`]
     /// * C++ API: `doc::get_brief()`
     fn doc_brief(&self) -> Option<String> {
         self.world().doc_brief_id(self.clone())
@@ -64,7 +64,7 @@ pub trait Doc<'a>: WorldProvider<'a> + Into<Entity> + Clone {
     ///
     /// # See also
     ///
-    /// * [`World::get_doc_detail()`]
+    /// * [`World::doc_detail()`]
     /// * C++ API: `doc::get_detail()`
     fn doc_detail(&self) -> Option<String> {
         self.world().doc_detail_id(self.clone())
@@ -78,7 +78,7 @@ pub trait Doc<'a>: WorldProvider<'a> + Into<Entity> + Clone {
     ///
     /// # See also
     ///
-    /// * [`World::get_doc_link()`]
+    /// * [`World::doc_link()`]
     /// * C++ API: `doc::get_link()`
     fn doc_link(&self) -> Option<String> {
         self.world().doc_link_id(self.clone())
@@ -92,7 +92,7 @@ pub trait Doc<'a>: WorldProvider<'a> + Into<Entity> + Clone {
     ///
     /// # See also
     ///
-    /// * [`World::get_doc_color()`]
+    /// * [`World::doc_color()`]
     /// * C++ API: `doc::get_color()`
     fn doc_color(&self) -> Option<String> {
         self.world().doc_color_id(self.clone())
@@ -253,8 +253,8 @@ impl World {
     ///
     /// # See also
     ///
-    /// * [`Doc::get_doc_name()`]
-    /// * [`World::get_doc_name_id()`]
+    /// * [`Doc::doc_name()`]
+    /// * [`World::doc_name_id()`]
     /// * C++ API: `doc::get_name()`
     #[doc(alias = "doc::get_name")]
     #[inline(always)]
@@ -274,8 +274,8 @@ impl World {
     ///
     /// # See also
     ///
-    /// * [`Doc::get_doc_name()`]
-    /// * [`World::get_doc_name()`]
+    /// * [`Doc::doc_name()`]
+    /// * [`World::doc_name()`]
     /// * C++ API: `world::get_doc_name()`
     #[doc(alias = "doc::get_name")]
     #[inline(always)]
@@ -299,8 +299,8 @@ impl World {
     ///
     /// # See also
     ///
-    /// * [`Doc::get_doc_brief()`]
-    /// * [`World::get_doc_brief_id()`]
+    /// * [`Doc::doc_brief()`]
+    /// * [`World::doc_brief_id()`]
     /// * C++ API: `doc::get_brief()`
     #[doc(alias = "doc::get_brief")]
     #[inline(always)]
@@ -320,8 +320,8 @@ impl World {
     ///
     /// # See also
     ///
-    /// * [`Doc::get_doc_brief()`]
-    /// * [`World::get_doc_brief()`]
+    /// * [`Doc::doc_brief()`]
+    /// * [`World::doc_brief()`]
     /// * C++ API: `doc::get_brief`
     #[doc(alias = "doc::get_brief")]
     #[inline(always)]
@@ -344,8 +344,8 @@ impl World {
     ///
     /// # See also
     ///
-    /// * [`Doc::get_doc_detail()`]
-    /// * [`World::get_doc_detail_id()`]
+    /// * [`Doc::doc_detail()`]
+    /// * [`World::doc_detail_id()`]
     /// * C++ API: `doc::get_detail()`
     #[doc(alias = "doc::get_detail")]
     #[inline(always)]
@@ -365,8 +365,8 @@ impl World {
     ///
     /// # See also
     ///
-    /// * [`Doc::get_doc_detail()`]
-    /// * [`World::get_doc_detail()`]
+    /// * [`Doc::doc_detail()`]
+    /// * [`World::doc_detail()`]
     /// * C++ API: `doc::get_detail`
     #[doc(alias = "doc::get_detail")]
     #[inline(always)]
@@ -390,8 +390,8 @@ impl World {
     ///
     /// # See also
     ///
-    /// * [`Doc::get_doc_link()`]
-    /// * [`World::get_doc_link_id()`]
+    /// * [`Doc::doc_link()`]
+    /// * [`World::doc_link_id()`]
     /// * C++ API: `doc::get_link()`
     #[doc(alias = "doc::get_link")]
     #[inline(always)]
@@ -410,8 +410,8 @@ impl World {
     ///
     /// # See also
     ///
-    /// * [`Doc::get_doc_link()`]
-    /// * [`World::get_doc_link()`]
+    /// * [`Doc::doc_link()`]
+    /// * [`World::doc_link()`]
     /// * C++ API: `doc::get_link`
     #[doc(alias = "doc::get_link")]
     #[inline(always)]
@@ -434,8 +434,8 @@ impl World {
     ///
     /// # See also
     ///
-    /// * [`Doc::get_doc_color()`]
-    /// * [`World::get_doc_color_id()`]
+    /// * [`Doc::doc_color()`]
+    /// * [`World::doc_color_id()`]
     /// * C++ API: `doc::get_color()`
     #[doc(alias = "doc::get_color")]
     #[inline(always)]
@@ -454,8 +454,8 @@ impl World {
     ///
     /// # See also
     ///
-    /// * [`Doc::get_doc_color()`]
-    /// * [`World::get_doc_color()`]
+    /// * [`Doc::doc_color()`]
+    /// * [`World::doc_color()`]
     /// * C++ API: `doc::get_color`
     #[doc(alias = "doc::get_color")]
     #[inline(always)]
@@ -477,7 +477,7 @@ impl World {
     /// * [`Doc::set_doc_uuid()`]
     /// * C++ API: `doc::get_uuid`
     #[doc(alias = "doc::get_uuid")]
-    fn doc_uuid_id(&self, entity: impl Into<Entity>) -> Option<String> {
+    pub fn doc_uuid_id(&self, entity: impl Into<Entity>) -> Option<String> {
         let cstr = NonNull::new(
             unsafe { sys::ecs_doc_get_uuid(self.world_ptr(), *entity.into()) } as *mut _,
         )
@@ -499,7 +499,7 @@ impl World {
     /// * [`Doc::set_doc_uuid()`]
     /// * C++ API: `doc::get_uuid`
     #[doc(alias = "doc::get_uuid")]
-    fn doc_uuid<T: ComponentId>(&self) -> Option<String> {
+    pub fn doc_uuid<T: ComponentId>(&self) -> Option<String> {
         self.doc_uuid_id(T::get_id(self))
     }
 
@@ -738,7 +738,7 @@ impl World {
     /// * [`Doc::doc_uuid()`]
     /// * C++ API: `entity_builder::set_doc_uuid`
     #[doc(alias = "entity_builder::set_doc_uuid")]
-    fn set_doc_uuid_id(&self, entity: impl Into<Entity>, uuid: &str) {
+    pub fn set_doc_uuid_id(&self, entity: impl Into<Entity>, uuid: &str) {
         let uuid = compact_str::format_compact!("{}\0", uuid);
         unsafe {
             sys::ecs_doc_set_uuid(self.ptr_mut(), *entity.into(), uuid.as_ptr() as *const _);
@@ -765,7 +765,7 @@ impl World {
     /// * [`Doc::doc_uuid()`]
     /// * C++ API: `entity_builder::set_doc_uuid`
     #[doc(alias = "entity_builder::set_doc_uuid")]
-    fn set_doc_uuid<T: ComponentId>(&self, uuid: &str) {
+    pub fn set_doc_uuid<T: ComponentId>(&self, uuid: &str) {
         self.set_doc_uuid_id(T::get_id(self), uuid);
     }
 }

--- a/flecs_ecs/src/addons/doc.rs
+++ b/flecs_ecs/src/addons/doc.rs
@@ -217,7 +217,7 @@ pub trait Doc<'a>: WorldProvider<'a> + Into<Entity> + Clone {
     /// * [`World::doc_uuid()`]
     /// * [`World::doc_uuid_id()`]
     /// * [`Doc::doc_uuid()`]
-    /// C++ API: `entity_builder::set_doc_uuid`
+    /// * C++ API: `entity_builder::set_doc_uuid`
     #[doc(alias = "entity_builder::set_doc_uuid")]
     fn set_doc_uuid(&self, uuid: &str) -> &Self {
         self.world().set_doc_uuid_id(self.clone(), uuid);
@@ -763,7 +763,7 @@ impl World {
     /// * [`World::doc_uuid()`]
     /// * [`World::doc_uuid_id()`]
     /// * [`Doc::doc_uuid()`]
-    /// C++ API: `entity_builder::set_doc_uuid`
+    /// * C++ API: `entity_builder::set_doc_uuid`
     #[doc(alias = "entity_builder::set_doc_uuid")]
     fn set_doc_uuid<T: ComponentId>(&self, uuid: &str) {
         self.set_doc_uuid_id(T::get_id(self), uuid);

--- a/flecs_ecs/src/addons/doc.rs
+++ b/flecs_ecs/src/addons/doc.rs
@@ -38,8 +38,8 @@ pub trait Doc<'a>: WorldProvider<'a> + Into<Entity> + Clone {
     ///
     /// * [`World::get_doc_name()`]
     /// * C++ API: `doc::get_name()`
-    fn get_doc_name(&self) -> Option<String> {
-        self.world().get_doc_name_id(self.clone())
+    fn doc_name(&self) -> Option<String> {
+        self.world().doc_name_id(self.clone())
     }
 
     /// Get brief description for an entity.
@@ -52,8 +52,8 @@ pub trait Doc<'a>: WorldProvider<'a> + Into<Entity> + Clone {
     ///
     /// * [`World::get_doc_brief()`]
     /// * C++ API: `doc::get_brief()`
-    fn get_doc_brief(&self) -> Option<String> {
-        self.world().get_doc_brief_id(self.clone())
+    fn doc_brief(&self) -> Option<String> {
+        self.world().doc_brief_id(self.clone())
     }
 
     /// Get detailed description for an entity.
@@ -66,8 +66,8 @@ pub trait Doc<'a>: WorldProvider<'a> + Into<Entity> + Clone {
     ///
     /// * [`World::get_doc_detail()`]
     /// * C++ API: `doc::get_detail()`
-    fn get_doc_detail(&self) -> Option<String> {
-        self.world().get_doc_detail_id(self.clone())
+    fn doc_detail(&self) -> Option<String> {
+        self.world().doc_detail_id(self.clone())
     }
 
     /// Get link to external documentation for an entity.
@@ -80,8 +80,8 @@ pub trait Doc<'a>: WorldProvider<'a> + Into<Entity> + Clone {
     ///
     /// * [`World::get_doc_link()`]
     /// * C++ API: `doc::get_link()`
-    fn get_doc_link(&self) -> Option<String> {
-        self.world().get_doc_link_id(self.clone())
+    fn doc_link(&self) -> Option<String> {
+        self.world().doc_link_id(self.clone())
     }
 
     /// Get color for an entity.
@@ -94,8 +94,26 @@ pub trait Doc<'a>: WorldProvider<'a> + Into<Entity> + Clone {
     ///
     /// * [`World::get_doc_color()`]
     /// * C++ API: `doc::get_color()`
-    fn get_doc_color(&self) -> Option<String> {
-        self.world().get_doc_color_id(self.clone())
+    fn doc_color(&self) -> Option<String> {
+        self.world().doc_color_id(self.clone())
+    }
+
+    /// Get UUID for entity
+    ///
+    /// # Returns
+    ///
+    /// The UUID of the entity.
+    ///
+    /// # See also
+    ///
+    /// * [`World::doc_uuid_id()`]
+    /// * [`World::doc_uuid()`]
+    /// * [`Doc::set_doc_uuid()`]
+    /// * [`World::set_doc_uuid_id()`]
+    /// * [`World::set_doc_uuid()`]
+    /// * C++ API: `doc::get_uuid()`
+    fn doc_uuid(&self) -> Option<String> {
+        self.world().doc_uuid_id(self.clone())
     }
 
     //MARK: _setters
@@ -185,6 +203,26 @@ pub trait Doc<'a>: WorldProvider<'a> + Into<Entity> + Clone {
         self.world().set_doc_color_id(self.clone(), color);
         self
     }
+
+    /// Set doc UUID.
+    /// This adds `(flecs.doc.Description, flecs.doc.Uuid)` to the entity.
+    ///
+    /// # Arguments
+    ///
+    /// * `uuid` - The UUID to add.
+    ///
+    /// # See also
+    /// * [`World::set_doc_uuid_id()`]
+    /// * [`World::set_doc_uuid()`]
+    /// * [`World::doc_uuid()`]
+    /// * [`World::doc_uuid_id()`]
+    /// * [`Doc::doc_uuid()`]
+    /// C++ API: `entity_builder::set_doc_uuid`
+    #[doc(alias = "entity_builder::set_doc_uuid")]
+    fn set_doc_uuid(&self, uuid: &str) -> &Self {
+        self.world().set_doc_uuid_id(self.clone(), uuid);
+        self
+    }
 }
 
 impl<'a, T> Doc<'a> for T where T: Into<Entity> + WorldProvider<'a> + Clone {}
@@ -220,8 +258,8 @@ impl World {
     /// * C++ API: `doc::get_name()`
     #[doc(alias = "doc::get_name")]
     #[inline(always)]
-    pub fn get_doc_name<T: ComponentId>(&self) -> Option<String> {
-        self.get_doc_name_id(T::get_id(self))
+    pub fn doc_name<T: ComponentId>(&self) -> Option<String> {
+        self.doc_name_id(T::get_id(self))
     }
 
     /// Get human readable name for an entity.
@@ -241,7 +279,7 @@ impl World {
     /// * C++ API: `world::get_doc_name()`
     #[doc(alias = "doc::get_name")]
     #[inline(always)]
-    pub fn get_doc_name_id(&self, entity: impl Into<Entity>) -> Option<String> {
+    pub fn doc_name_id(&self, entity: impl Into<Entity>) -> Option<String> {
         let cstr = NonNull::new(
             unsafe { sys::ecs_doc_get_name(self.world_ptr(), *entity.into()) } as *mut _,
         )
@@ -266,8 +304,8 @@ impl World {
     /// * C++ API: `doc::get_brief()`
     #[doc(alias = "doc::get_brief")]
     #[inline(always)]
-    pub fn get_doc_brief<T: ComponentId>(&self) -> Option<String> {
-        self.get_doc_brief_id(T::get_id(self))
+    pub fn doc_brief<T: ComponentId>(&self) -> Option<String> {
+        self.doc_brief_id(T::get_id(self))
     }
 
     /// Get brief description for an entity.
@@ -287,7 +325,7 @@ impl World {
     /// * C++ API: `doc::get_brief`
     #[doc(alias = "doc::get_brief")]
     #[inline(always)]
-    pub fn get_doc_brief_id(&self, entity: impl Into<Entity>) -> Option<String> {
+    pub fn doc_brief_id(&self, entity: impl Into<Entity>) -> Option<String> {
         let cstr = NonNull::new(
             unsafe { sys::ecs_doc_get_brief(self.world_ptr(), *entity.into()) } as *mut _,
         )
@@ -311,8 +349,8 @@ impl World {
     /// * C++ API: `doc::get_detail()`
     #[doc(alias = "doc::get_detail")]
     #[inline(always)]
-    pub fn get_doc_detail<T: ComponentId>(&self) -> Option<String> {
-        self.get_doc_detail_id(T::get_id(self))
+    pub fn doc_detail<T: ComponentId>(&self) -> Option<String> {
+        self.doc_detail_id(T::get_id(self))
     }
 
     /// Get detailed description for an entity.
@@ -332,7 +370,7 @@ impl World {
     /// * C++ API: `doc::get_detail`
     #[doc(alias = "doc::get_detail")]
     #[inline(always)]
-    pub fn get_doc_detail_id(&self, entity: impl Into<Entity>) -> Option<String> {
+    pub fn doc_detail_id(&self, entity: impl Into<Entity>) -> Option<String> {
         let cstr = NonNull::new(
             unsafe { sys::ecs_doc_get_detail(self.world_ptr(), *entity.into()) } as *mut _,
         )
@@ -357,8 +395,8 @@ impl World {
     /// * C++ API: `doc::get_link()`
     #[doc(alias = "doc::get_link")]
     #[inline(always)]
-    pub fn get_doc_link<T: ComponentId>(&self) -> Option<String> {
-        self.get_doc_link_id(T::get_id(self))
+    pub fn doc_link<T: ComponentId>(&self) -> Option<String> {
+        self.doc_link_id(T::get_id(self))
     }
 
     /// Get link to external documentation for an entity.
@@ -377,7 +415,7 @@ impl World {
     /// * C++ API: `doc::get_link`
     #[doc(alias = "doc::get_link")]
     #[inline(always)]
-    pub fn get_doc_link_id(&self, entity: impl Into<Entity>) -> Option<String> {
+    pub fn doc_link_id(&self, entity: impl Into<Entity>) -> Option<String> {
         let cstr = NonNull::new(
             unsafe { sys::ecs_doc_get_link(self.world_ptr(), *entity.into()) } as *mut _,
         )
@@ -401,8 +439,8 @@ impl World {
     /// * C++ API: `doc::get_color()`
     #[doc(alias = "doc::get_color")]
     #[inline(always)]
-    pub fn get_doc_color<T: ComponentId>(&self) -> Option<String> {
-        self.get_doc_color_id(T::get_id(self))
+    pub fn doc_color<T: ComponentId>(&self) -> Option<String> {
+        self.doc_color_id(T::get_id(self))
     }
 
     /// Get color for an entity.
@@ -421,12 +459,48 @@ impl World {
     /// * C++ API: `doc::get_color`
     #[doc(alias = "doc::get_color")]
     #[inline(always)]
-    pub fn get_doc_color_id(&self, entity: impl Into<Entity>) -> Option<String> {
+    pub fn doc_color_id(&self, entity: impl Into<Entity>) -> Option<String> {
         let cstr = NonNull::new(
             unsafe { sys::ecs_doc_get_color(self.world_ptr(), *entity.into()) } as *mut _,
         )
         .map(|s| unsafe { CStr::from_ptr(s.as_ptr()) });
         cstr.and_then(|s| s.to_str().ok().map(|s| s.to_string()))
+    }
+
+    /// Get UUID for entity
+    ///
+    /// # See Also
+    ///
+    /// * [`World::doc_uuid()`]
+    /// * [`Doc::doc_uuid()`]
+    /// * [`World::set_doc_uuid_id()`]
+    /// * [`Doc::set_doc_uuid()`]
+    /// * C++ API: `doc::get_uuid`
+    #[doc(alias = "doc::get_uuid")]
+    fn doc_uuid_id(&self, entity: impl Into<Entity>) -> Option<String> {
+        let cstr = NonNull::new(
+            unsafe { sys::ecs_doc_get_uuid(self.world_ptr(), *entity.into()) } as *mut _,
+        )
+        .map(|s| unsafe { CStr::from_ptr(s.as_ptr()) });
+        cstr.and_then(|s| s.to_str().ok().map(|s| s.to_string()))
+    }
+
+    /// Get UUID for component
+    ///
+    /// # Type Parameters
+    ///
+    /// * `T` - The component.
+    ///
+    /// # See Also
+    ///
+    /// * [`World::doc_uuid_id()`]
+    /// * [`Doc::doc_uuid()`]
+    /// * [`World::set_doc_uuid_id()`]
+    /// * [`Doc::set_doc_uuid()`]
+    /// * C++ API: `doc::get_uuid`
+    #[doc(alias = "doc::get_uuid")]
+    fn doc_uuid<T: ComponentId>(&self) -> Option<String> {
+        self.doc_uuid_id(T::get_id(self))
     }
 
     //MARK: _World::setters
@@ -601,7 +675,7 @@ impl World {
         unsafe { sys::ecs_doc_set_link(self.ptr_mut(), *entity.into(), link.as_ptr() as *const _) };
     }
 
-    /// Add color to entity.
+    /// Add color to component.
     ///
     /// UIs can use color as hint to improve visualizing entities.
     ///
@@ -645,6 +719,54 @@ impl World {
         unsafe {
             sys::ecs_doc_set_color(self.ptr_mut(), *entity.into(), color.as_ptr() as *const _);
         };
+    }
+
+    /// Add UUID to entity.
+    /// This adds `(flecs.doc.Description, flecs.doc.Uuid)` to the entity.
+    ///
+    /// # Arguments
+    ///
+    /// * `entity` - The entity to which to add the UUID.
+    /// * `uuid` - The UUID to add.
+    ///
+    /// # See also
+    ///
+    /// * [`Doc::set_doc_uuid()`]
+    /// * [`World::set_doc_uuid()`]
+    /// * [`World::doc_uuid()`]
+    /// * [`World::doc_uuid_id()`]
+    /// * [`Doc::doc_uuid()`]
+    /// * C++ API: `entity_builder::set_doc_uuid`
+    #[doc(alias = "entity_builder::set_doc_uuid")]
+    fn set_doc_uuid_id(&self, entity: impl Into<Entity>, uuid: &str) {
+        let uuid = compact_str::format_compact!("{}\0", uuid);
+        unsafe {
+            sys::ecs_doc_set_uuid(self.ptr_mut(), *entity.into(), uuid.as_ptr() as *const _);
+        };
+    }
+
+    /// Add UUID to component
+    /// This adds `(flecs.doc.Description, flecs.doc.Uuid)` to the component
+    ///
+    /// # Type Parameters
+    ///
+    /// * `T` - The component.
+    ///
+    /// # Arguments
+    ///
+    /// * `uuid` - The UUID to add.
+    ///
+    /// # See also
+    ///
+    /// * [`World::set_doc_uuid_id()`]
+    /// * [`Doc::set_doc_uuid()`]
+    /// * [`World::doc_uuid()`]
+    /// * [`World::doc_uuid_id()`]
+    /// * [`Doc::doc_uuid()`]
+    /// C++ API: `entity_builder::set_doc_uuid`
+    #[doc(alias = "entity_builder::set_doc_uuid")]
+    fn set_doc_uuid<T: ComponentId>(&self, uuid: &str) {
+        self.set_doc_uuid_id(T::get_id(self), uuid);
     }
 }
 

--- a/flecs_ecs/src/addons/metrics/mod.rs
+++ b/flecs_ecs/src/addons/metrics/mod.rs
@@ -17,7 +17,7 @@ impl<'a> UntypedComponent<'a> {
     /// When the member name is `"value"`, the operation will use the name of the component instead.
     ///
     /// If the `brief` parameter is provided, it is set on the metric as if [`set_doc_brief`][crate::addons::doc::Doc::set_doc_brief] was called.
-    /// The brief description can be retrieved using [`get_doc_brief`][crate::addons::doc::Doc::get_doc_brief].
+    /// The brief description can be retrieved using [`get_doc_brief`][crate::addons::doc::Doc::doc_brief].
     ///
     /// # Type Parameters
     ///
@@ -31,7 +31,7 @@ impl<'a> UntypedComponent<'a> {
     ///
     /// # See also
     ///
-    /// * [`get_doc_brief`][crate::addons::doc::Doc::get_doc_brief]
+    /// * [`get_doc_brief`][crate::addons::doc::Doc::doc_brief]
     /// * [`set_doc_brief`][crate::addons::doc::Doc::set_doc_brief]
     pub fn metric<Kind>(
         &self,

--- a/flecs_ecs/src/addons/module.rs
+++ b/flecs_ecs/src/addons/module.rs
@@ -145,7 +145,6 @@ impl World {
     /// * [`World::import()`]
     /// * C++ API: `world::module`
     pub fn module<M: ComponentId>(&self, name: &str) -> EntityView {
-        self.defer_begin();
         let comp = self.component::<M>();
         let id = comp.id();
 
@@ -168,7 +167,7 @@ impl World {
             let mut cur = prev_parent;
             let mut next;
 
-            loop {
+            while cur.id != 0 {
                 next = cur.parent().unwrap_or(EntityView::new_null(self));
 
                 let mut it = unsafe {
@@ -188,7 +187,6 @@ impl World {
                 }
             }
         }
-        self.defer_end();
 
         //self.set_scope_id(id);
         EntityView::new_from(self, *id)

--- a/flecs_ecs/src/core/c_types.rs
+++ b/flecs_ecs/src/core/c_types.rs
@@ -477,9 +477,10 @@ pub(crate) const ECS_DOC_BRIEF: u64 = FLECS_HI_COMPONENT_ID + 114;
 pub(crate) const ECS_DOC_DETAIL: u64 = FLECS_HI_COMPONENT_ID + 115;
 pub(crate) const ECS_DOC_LINK: u64 = FLECS_HI_COMPONENT_ID + 116;
 pub(crate) const ECS_DOC_COLOR: u64 = FLECS_HI_COMPONENT_ID + 117;
+pub(crate) const ECS_DOC_UUID: u64 = FLECS_HI_COMPONENT_ID + 118;
 
 // REST module components
-pub(crate) const ECS_REST: u64 = FLECS_HI_COMPONENT_ID + 118;
+pub(crate) const ECS_REST: u64 = FLECS_HI_COMPONENT_ID + 119;
 
 macro_rules! impl_component_traits_binding_type_w_id {
     ($name:ident, $id:ident) => {

--- a/flecs_ecs/src/core/entity_view/entity_view_mut.rs
+++ b/flecs_ecs/src/core/entity_view/entity_view_mut.rs
@@ -1464,7 +1464,7 @@ impl<'a> EntityView<'a> {
     pub fn modified<T: ComponentOrPairId>(&self) {
         const {
             assert!(
-                std::mem::size_of::<T>() != 0,
+                std::mem::size_of::<T::CastType>() != 0,
                 "cannot modify zero-sized-type / tag components"
             );
         };
@@ -1513,12 +1513,12 @@ impl<'a> EntityView<'a> {
     ///
     /// * C++ API: `entity::get_ref`
     #[doc(alias = "entity::get_ref")]
-    pub fn get_ref<T>(&self) -> CachedRef<'a, T::UnderlyingType>
+    pub fn get_ref<T>(&self) -> CachedRef<'a, T::CastType>
     where
-        T: ComponentId + DataComponent,
-        T::UnderlyingType: DataComponent,
+        T: ComponentOrPairId,
+        T::CastType: DataComponent,
     {
-        CachedRef::<T::UnderlyingType>::new(self.world, *self.id, T::id(self.world))
+        CachedRef::<T::CastType>::new(self.world, *self.id, T::get_id(self.world))
     }
 
     /// Get a reference to the first component of pair
@@ -1546,11 +1546,20 @@ impl<'a> EntityView<'a> {
         self,
         second: impl Into<Entity>,
     ) -> CachedRef<'a, First> {
-        CachedRef::<First>::new(
-            self.world,
-            *self.id,
-            ecs_pair(First::id(self.world), *second.into()),
-        )
+        let first = First::id(self.world);
+        let second = *second.into();
+        let pair = ecs_pair(first, second);
+        ecs_assert!(
+            !(unsafe { sys::ecs_get_type_info(self.world.world_ptr(), pair,) }.is_null()),
+            FlecsErrorCode::InvalidParameter,
+            "pair is not a component"
+        );
+        ecs_assert!(
+            unsafe { *sys::ecs_get_type_info(self.world.world_ptr(), pair,) }.component == first,
+            FlecsErrorCode::InvalidParameter,
+            "type of pair is not First"
+        );
+        CachedRef::<First>::new(self.world, *self.id, pair)
     }
 
     /// Get a reference to the second component of pair
@@ -1578,11 +1587,21 @@ impl<'a> EntityView<'a> {
         &self,
         first: impl Into<Entity>,
     ) -> CachedRef<Second> {
-        CachedRef::<Second>::new(
-            self.world,
-            *self.id,
-            ecs_pair(*first.into(), Second::id(self.world)),
-        )
+        let first = *first.into();
+        let second = Second::id(self.world);
+        let pair = ecs_pair(first, second);
+        ecs_assert!(
+            !(unsafe { sys::ecs_get_type_info(self.world.world_ptr(), pair,) }.is_null()),
+            FlecsErrorCode::InvalidParameter,
+            "pair is not a component"
+        );
+        ecs_assert!(
+            unsafe { *sys::ecs_get_type_info(self.world.world_ptr(), pair,) }.component == second,
+            FlecsErrorCode::InvalidParameter,
+            "type of pair is not Second"
+        );
+
+        CachedRef::<Second>::new(self.world, *self.id, pair)
     }
 
     /// Clear an entity.

--- a/flecs_ecs/src/core/entity_view/entity_view_mut.rs
+++ b/flecs_ecs/src/core/entity_view/entity_view_mut.rs
@@ -1006,6 +1006,7 @@ impl<'a> EntityView<'a> {
         let first_id = *first.into();
         let second_id = Second::id(self.world);
         let pair_id = ecs_pair(first_id, second_id);
+        // NOTE: we could this safety check optional
         let data_id = unsafe { sys::ecs_get_typeid(world, pair_id) };
 
         if data_id != second_id {

--- a/flecs_ecs/src/core/flecs.rs
+++ b/flecs_ecs/src/core/flecs.rs
@@ -508,6 +508,7 @@ pub mod doc {
     create_pre_registered_component!(Detail, ECS_DOC_DETAIL);
     create_pre_registered_component!(Link, ECS_DOC_LINK);
     create_pre_registered_component!(Color, ECS_DOC_COLOR);
+    create_pre_registered_component!(UUID, ECS_DOC_UUID);
 }
 
 #[cfg(feature = "flecs_rest")]

--- a/flecs_ecs/src/core/observer_builder.rs
+++ b/flecs_ecs/src/core/observer_builder.rs
@@ -7,7 +7,7 @@ use crate::core::private::internal_SystemAPI;
 use crate::core::*;
 use crate::sys;
 
-/// `ObserverBuilder` is used to configure and build [`Observer`]s.
+/// [`ObserverBuilder`] is used to configure and build [`Observer`]s.
 ///
 /// Observers are systems that react to events.
 /// Observers let applications register callbacks for ECS events.
@@ -139,6 +139,21 @@ impl<'a, P, T: QueryTuple> ObserverBuilder<'a, P, T> {
 }
 
 impl<'a, P, T: QueryTuple> ObserverBuilder<'a, P, T> {
+    /// set observer flags, which are the same as Query flags
+    ///
+    /// # Arguments
+    ///
+    /// * `flags` - the flags to set
+    ///
+    /// # See also
+    ///
+    /// * C++ API: `query_builder_i::filter_flags`
+    #[doc(alias = "query_builder_i::filter_flags")]
+    fn observer_flags(&mut self, flags: QueryFlags) -> &mut Self {
+        self.desc.flags_ |= flags.bits();
+        self
+    }
+
     /// Specify the event(s) for when the observer should run.
     ///
     /// # Arguments

--- a/flecs_ecs/src/core/table/iter.rs
+++ b/flecs_ecs/src/core/table/iter.rs
@@ -994,7 +994,7 @@ where
             );
             let target = EntityView::new_from(self.world(), ecs_second(id));
             func(target);
-            i = i + 1;
+            i += 1;
         }
     }
 }

--- a/flecs_ecs/src/core/table/iter.rs
+++ b/flecs_ecs/src/core/table/iter.rs
@@ -920,6 +920,83 @@ where
             }
         }
     }
+
+    /// Iterate targets for pair field.
+    ///
+    /// # Arguments
+    ///
+    /// * index: the field index
+    /// * func: callback invoked for each target with the signature fn(EntityView entity)
+    ///
+    /// # Example
+    ///
+    /// ```
+    ///
+    /// use flecs_ecs::prelude::*;
+    ///
+    /// let world = World::new();
+    ///
+    /// let likes = world.entity();
+    /// let pizza = world.entity();
+    /// let salad = world.entity();
+    /// let alice = world.entity().add_id((likes, pizza)).add_id((likes, salad));
+    ///
+    /// let q = world.query::<()>().with_second::<flecs::Any>(likes).build();
+    ///
+    /// let mut count = 0;
+    /// let mut tgt_count = 0;
+    ///
+    /// q.each_iter(|mut it, row, _| {
+    ///     let e = it.entity(row);
+    ///     assert_eq!(e, alice);
+    ///
+    ///     it.targets(0, |tgt| {
+    ///         if tgt_count == 0 {
+    ///             assert_eq!(tgt, pizza);
+    ///         }
+    ///         if tgt_count == 1 {
+    ///             assert_eq!(tgt, salad);
+    ///         }
+    ///         tgt_count += 1;
+    ///     });
+    ///
+    ///     count += 1;
+    /// });
+    ///
+    /// assert_eq!(count, 1);
+    /// assert_eq!(tgt_count, 2);
+    /// ```
+    ///
+    /// # See Also
+    ///
+    /// * C++ API: `iter::targets`
+    #[doc(alias = "iter::targets")]
+    pub fn targets(&mut self, index: i8, mut func: impl FnMut(EntityView)) {
+        ecs_assert!(!self.iter.table.is_null(), FlecsErrorCode::InvalidOperation);
+        ecs_assert!(
+            index < self.iter.field_count,
+            FlecsErrorCode::InvalidOperation
+        );
+        ecs_assert!(
+            unsafe { sys::ecs_field_is_set(self.iter, index) },
+            FlecsErrorCode::InvalidOperation
+        );
+        let table_type = unsafe { sys::ecs_table_get_type(self.iter.table) };
+        let table_record = unsafe { *self.iter.trs.add(index as usize) };
+        let mut i = unsafe { (*table_record).index };
+        let end = i + unsafe { (*table_record).count };
+        while i < end {
+            let id = unsafe { *(*table_type).array.add(i as usize) };
+            ecs_assert!(
+                ecs_is_pair(id),
+                FlecsErrorCode::InvalidParameter,
+                "field does not match a pair"
+            );
+            let target = EntityView::new_from(self.world(), ecs_second(id));
+            func(target);
+            i = i + 1;
+        }
+    }
 }
 
 impl<'a, P> TableIter<'a, true, P>

--- a/flecs_ecs/src/core/world.rs
+++ b/flecs_ecs/src/core/world.rs
@@ -1976,12 +1976,12 @@ impl World {
     /// * C++ API: `world::get_ref`
     // #[doc(alias = "world::get_ref")]
     // #[inline(always)]
-    pub fn get_ref<T>(&self) -> CachedRef<T::UnderlyingType>
+    pub fn get_ref<T>(&self) -> CachedRef<T::CastType>
     where
-        T: ComponentId + DataComponent,
-        T::UnderlyingType: DataComponent,
+        T: ComponentOrPairId,
+        T::CastType: DataComponent,
     {
-        EntityView::new_from(self, T::id(self)).get_ref::<T>()
+        EntityView::new_from(self, T::get_id(self)).get_ref::<T>()
     }
 
     /// Get singleton entity for type.

--- a/flecs_ecs/tests/flecs/entity_test.rs
+++ b/flecs_ecs/tests/flecs/entity_test.rs
@@ -1476,7 +1476,7 @@ fn entity_path_from_type_custom_sep() {
 
     assert_eq!(
         &grandchild.path_w_sep("_", "?").unwrap(),
-        "?flecs_common_test_Parent_child_grandchild"
+        "?flecs_common\\_test_Parent_child_grandchild"
     );
     assert_eq!(
         &grandchild.path_from_id_w_sep(parent, "_", "::").unwrap(),

--- a/flecs_ecs/tests/flecs/query_test.rs
+++ b/flecs_ecs/tests/flecs/query_test.rs
@@ -199,6 +199,7 @@ fn query_iter_targets_second_field() {
 
 #[test]
 #[should_panic]
+#[cfg(debug_assertions)]
 fn query_iter_targets_field_out_of_range() {
     let world = World::new();
 
@@ -219,6 +220,7 @@ fn query_iter_targets_field_out_of_range() {
 
 #[test]
 #[should_panic]
+#[cfg(debug_assertions)]
 fn query_iter_targets_field_not_a_pair() {
     let world = World::new();
 
@@ -243,6 +245,7 @@ fn query_iter_targets_field_not_a_pair() {
 
 #[test]
 #[should_panic]
+#[cfg(debug_assertions)]
 fn query_iter_targets_field_not_set() {
     let world = World::new();
 

--- a/flecs_ecs/tests/flecs/query_test.rs
+++ b/flecs_ecs/tests/flecs/query_test.rs
@@ -119,3 +119,147 @@ fn query_each_sparse() {
         assert_eq!(p.y, 22);
     });
 }
+
+#[test]
+fn query_iter_targets() {
+    let world = World::new();
+
+    let likes = world.entity();
+    let pizza = world.entity();
+    let salad = world.entity();
+    let alice = world.entity().add_id((likes, pizza)).add_id((likes, salad));
+
+    let q = world.query::<()>().with_second::<flecs::Any>(likes).build();
+
+    let mut count = 0;
+    let mut tgt_count = 0;
+
+    q.each_iter(|mut it, row, _| {
+        let e = it.entity(row);
+        assert_eq!(e, alice);
+
+        it.targets(0, |tgt| {
+            if tgt_count == 0 {
+                assert_eq!(tgt, pizza);
+            }
+            if tgt_count == 1 {
+                assert_eq!(tgt, salad);
+            }
+            tgt_count += 1;
+        });
+
+        count += 1;
+    });
+
+    assert_eq!(count, 1);
+    assert_eq!(tgt_count, 2);
+}
+
+#[test]
+fn query_iter_targets_second_field() {
+    let world = World::new();
+
+    let likes = world.entity();
+    let pizza = world.entity();
+    let salad = world.entity();
+    let alice = world
+        .entity()
+        .add::<Position>()
+        .add_id((likes, pizza))
+        .add_id((likes, salad));
+
+    let q = world
+        .query::<&Position>()
+        .with_second::<flecs::Any>(likes)
+        .build();
+
+    let mut count = 0;
+    let mut tgt_count = 0;
+
+    q.each_iter(|mut it, row, _| {
+        let e = it.entity(row);
+        assert_eq!(e, alice);
+
+        it.targets(1, |tgt| {
+            if tgt_count == 0 {
+                assert_eq!(tgt, pizza);
+            }
+            if tgt_count == 1 {
+                assert_eq!(tgt, salad);
+            }
+            tgt_count += 1;
+        });
+
+        count += 1;
+    });
+
+    assert_eq!(count, 1);
+    assert_eq!(tgt_count, 2);
+}
+
+#[test]
+#[should_panic]
+fn query_iter_targets_field_out_of_range() {
+    let world = World::new();
+
+    let likes = world.entity();
+    let pizza = world.entity();
+    let salad = world.entity();
+    let alice = world.entity().add_id((likes, pizza)).add_id((likes, salad));
+
+    let q = world.query::<()>().with_second::<flecs::Any>(likes).build();
+
+    q.each_iter(|mut it, row, _| {
+        let e = it.entity(row);
+        assert_eq!(e, alice);
+
+        it.targets(1, |_| {});
+    });
+}
+
+#[test]
+#[should_panic]
+fn query_iter_targets_field_not_a_pair() {
+    let world = World::new();
+
+    let likes = world.entity();
+    let pizza = world.entity();
+    let salad = world.entity();
+    let alice = world
+        .entity()
+        .add::<Position>()
+        .add_id((likes, pizza))
+        .add_id((likes, salad));
+
+    let q = world.query::<&Position>().build();
+
+    q.each_iter(|mut it, row, _| {
+        let e = it.entity(row);
+        assert_eq!(e, alice);
+
+        it.targets(1, |_| {});
+    });
+}
+
+#[test]
+#[should_panic]
+fn query_iter_targets_field_not_set() {
+    let world = World::new();
+
+    let likes = world.entity();
+    let alice = world.entity().add::<Position>();
+
+    let q = world
+        .query::<&Position>()
+        .with_second::<flecs::Any>(likes)
+        .optional()
+        .build();
+
+    q.each_iter(|mut it, row, _| {
+        let e = it.entity(row);
+        assert_eq!(e, alice);
+        assert!(!it.is_set(1));
+
+        it.targets(1, |_| {});
+    });
+}


### PR DESCRIPTION
[Rust] 

feat(iter): add fn targets to iterate targets for pair field

feat(observer_builder): observer flags

refact(world): get_ref take pairs

fix(module): module renaming not working in nested scenario's

feat(doc): add doc_uuid + refact(doc): remove get_ prefix

refactor(entity_view): add input assert validation to get_ref functions and correct assert in modified()

[C] 
+ core fixes of v4.0.3 see [Flecs change logs](https://github.com/SanderMertens/flecs/releases/tag/v4.0.3)

