### PR TITLE
Add CachedRef borrowing

### DIFF
--- a/flecs_ecs/src/core/components/cached_ref.rs
+++ b/flecs_ecs/src/core/components/cached_ref.rs
@@ -105,4 +105,33 @@ impl<'a, T: ComponentId + DataComponent> CachedRef<'a, T> {
         }
         .is_null()
     }
+
+    /// Try to mutably borrow component from ref.
+    pub fn try_borrow_mut(&mut self) -> Option<&mut T> {
+        NonNull::new(unsafe {
+            sys::ecs_ref_get_id(
+                self.world.world_ptr_mut(),
+                &mut self.component_ref,
+                self.component_ref.id,
+            ) as *mut T
+        })
+        .map(|mut t| unsafe { t.as_mut() })
+    }
+
+    /// Mutably borrow component from ref.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the the ref does not refer to a component.
+    pub fn borrow_mut(&mut self) -> &mut T {
+        NonNull::new(unsafe {
+            sys::ecs_ref_get_id(
+                self.world.world_ptr_mut(),
+                &mut self.component_ref,
+                self.component_ref.id,
+            ) as *mut T
+        })
+        .map(|mut t| unsafe { t.as_mut() })
+        .expect("Component not found, use try_get if you want to handle this case")
+    }
 }


### PR DESCRIPTION
When using CachedRef one had to pass a closure or a function that takes the mutable reference to the component and returns something. This limits ergonomics as one has to either extract fields from the component, possibly requiring to clone them which might be expensive or move their entire code into the closure.

This adds `borrow_mut` and `try_borrow_mut` methods which return a mutable reference to the component (returning an immutable reference is useless as it would not make the method &self instead of &mut self).

If there are any unsoudness issues with this approach, notice me, this is my first time contributing to Flecs.