### PR TITLE
chore(flecs_ecs tests): Use `assert_ne!` more

### DIFF
--- a/flecs_ecs/tests/flecs/meta_macro_test.rs
+++ b/flecs_ecs/tests/flecs/meta_macro_test.rs
@@ -80,10 +80,10 @@ fn meta_struct() {
 
     let c = component!(&world, Test { a: i32, b: f32 });
 
-    assert!(c.id() != 0);
+    assert_ne!(c.id(), 0);
 
     let a = c.lookup("a");
-    assert!(a.id() != 0);
+    assert_ne!(a.id(), 0);
     assert!(a.has::<flecs::meta::Member>());
 
     a.get::<&flecs::meta::Member>(|mem| {
@@ -91,7 +91,7 @@ fn meta_struct() {
     });
 
     let b = c.lookup("b");
-    assert!(b.id() != 0);
+    assert_ne!(b.id(), 0);
     assert!(b.has::<flecs::meta::Member>());
 
     b.get::<&flecs::meta::Member>(|mem| {
@@ -117,10 +117,10 @@ fn meta_nested_struct() {
 
     let n = component!(&world, Nested { a: Test });
 
-    assert!(n.id() != 0);
+    assert_ne!(n.id(), 0);
 
     let a = n.lookup("a");
-    assert!(a.id() != 0);
+    assert_ne!(a.id(), 0);
     assert!(a.has::<flecs::meta::Member>());
 
     a.get::<&flecs::meta::Member>(|mem| {
@@ -150,10 +150,10 @@ fn meta_struct_w_portable_type() {
         }
     );
 
-    assert!(t.id() != 0);
+    assert_ne!(t.id(), 0);
 
     let a = t.lookup("a");
-    assert!(a.id() != 0);
+    assert_ne!(a.id(), 0);
     assert!(a.has::<flecs::meta::Member>());
 
     a.get::<&flecs::meta::Member>(|mem| {
@@ -161,7 +161,7 @@ fn meta_struct_w_portable_type() {
     });
 
     let b = t.lookup("b");
-    assert!(b.id() != 0);
+    assert_ne!(b.id(), 0);
     assert!(b.has::<flecs::meta::Member>());
 
     // b.get::<&flecs::meta::Member>(|mem| {
@@ -169,7 +169,7 @@ fn meta_struct_w_portable_type() {
     // });
 
     // let c = t.lookup("c");
-    // assert!(c.id() != 0);
+    // assert_ne!(c.id(), 0);
     // assert!(c.has::<flecs::meta::Member>());
 
     // c.get::<&flecs::meta::Member>(|mem| {
@@ -177,7 +177,7 @@ fn meta_struct_w_portable_type() {
     // });
 
     // let d = t.lookup("d");
-    // assert!(d.id() != 0);
+    // assert_!(d.id(), 0);
     // assert!(d.has::<flecs::meta::Member>());
 
     // d.get::<&flecs::meta::Member>(|mem| {
@@ -201,7 +201,7 @@ fn meta_partial_struct() {
 
     let c = component!(&world, Position { x: f32 });
 
-    assert!(c.id() != 0);
+    assert_ne!(c.id(), 0);
 
     c.get::<&flecs::Component>(|ptr| {
         assert_eq!(ptr.size, 4);
@@ -209,7 +209,7 @@ fn meta_partial_struct() {
     });
 
     let xe = c.lookup("x");
-    assert!(xe.id() != 0);
+    assert_ne!(xe.id(), 0);
     assert!(xe.has::<flecs::meta::Member>());
     xe.get::<&flecs::meta::Member>(|x| {
         assert_eq!(x.type_, flecs::meta::F32);
@@ -229,7 +229,7 @@ fn meta_partial_struct_custom_offset() {
 
     let c = component!(&world, Position { y: f32 });
 
-    assert!(c.id() != 0);
+    assert_ne!(c.id(), 0);
 
     c.get::<&flecs::Component>(|ptr| {
         assert_eq!(ptr.size, 8);
@@ -237,7 +237,7 @@ fn meta_partial_struct_custom_offset() {
     });
 
     let xe = c.lookup("y");
-    assert!(xe.id() != 0);
+    assert_ne!(xe.id(), 0);
     assert!(xe.has::<flecs::meta::Member>());
     xe.get::<&flecs::meta::Member>(|x| {
         assert_eq!(x.type_, flecs::meta::F32);
@@ -395,8 +395,8 @@ fn meta_new_world_ser_deser_flecs_entity() {
     let e1 = world.lookup("ent1");
     let e2 = world.lookup("ent2");
 
-    assert!(e1.id() != 0);
-    assert!(e2.id() != 0);
+    assert_ne!(e1.id(), 0);
+    assert_ne!(e2.id(), 0);
 
     assert!(e1.is_alive());
     assert!(e2.is_alive());
@@ -438,7 +438,7 @@ fn meta_new_world_ser_deser_empty_flecs_entity() {
 
     let e2 = world.lookup("ent2");
 
-    assert!(e2.id() != 0);
+    assert_ne!(e2.id(), 0);
 
     assert!(e2.is_alive());
 
@@ -505,10 +505,10 @@ fn meta_struct_member_ptr() {
     );
 
     //validate Test #1
-    assert!(t.id() != 0);
+    assert_ne!(t.id(), 0);
 
     let x = t.lookup("x");
-    assert!(x.id() != 0);
+    assert_ne!(x.id(), 0);
     assert!(x.has::<flecs::meta::Member>());
     x.get::<&flecs::meta::Member>(|xm| {
         assert_eq!(xm.type_, flecs::meta::I32);
@@ -516,10 +516,10 @@ fn meta_struct_member_ptr() {
     });
 
     //validate Test2 #2
-    assert!(t2.id() != 0);
+    assert_ne!(t2.id(), 0);
 
     let y = t2.lookup("y");
-    assert!(y.id() != 0);
+    assert_ne!(y.id(), 0);
     assert!(y.has::<flecs::meta::Member>());
     y.get::<&flecs::meta::Member>(|ym| {
         assert_eq!(ym.type_, flecs::meta::F64);
@@ -527,10 +527,10 @@ fn meta_struct_member_ptr() {
     });
 
     // Validate Nested
-    assert!(n.id() != 0);
+    assert_ne!(n.id(), 0);
 
     let a = n.lookup("a");
-    assert!(a.id() != 0);
+    assert_ne!(a.id(), 0);
     assert!(a.has::<flecs::meta::Member>());
     a.get::<&flecs::meta::Member>(|am| {
         assert_eq!(am.type_, t.id());
@@ -539,7 +539,7 @@ fn meta_struct_member_ptr() {
     });
 
     let b = n.lookup("b");
-    assert!(b.id() != 0);
+    assert_ne!(b.id(), 0);
     assert!(b.has::<flecs::meta::Member>());
     b.get::<&flecs::meta::Member>(|bm| {
         assert_eq!(bm.type_, t2.id());

--- a/flecs_ecs/tests/flecs/meta_test.rs
+++ b/flecs_ecs/tests/flecs/meta_test.rs
@@ -84,10 +84,10 @@ fn meta_struct() {
         .member::<i32>("a")
         .member::<f32>("b");
 
-    assert!(c.id() != 0);
+    assert_ne!(c.id(), 0);
 
     let a = c.lookup("a");
-    assert!(a.id() != 0);
+    assert_ne!(a.id(), 0);
     assert!(a.has::<flecs::meta::Member>());
 
     a.get::<&flecs::meta::Member>(|mem| {
@@ -95,7 +95,7 @@ fn meta_struct() {
     });
 
     let b = c.lookup("b");
-    assert!(b.id() != 0);
+    assert_ne!(b.id(), 0);
     assert!(b.has::<flecs::meta::Member>());
 
     b.get::<&flecs::meta::Member>(|mem| {
@@ -121,10 +121,10 @@ fn meta_nested_struct() {
 
     let n = world.component::<Nested>().member_id(t, "a");
 
-    assert!(n.id() != 0);
+    assert_ne!(n.id(), 0);
 
     let a = n.lookup("a");
-    assert!(a.id() != 0);
+    assert_ne!(a.id(), 0);
     assert!(a.has::<flecs::meta::Member>());
 
     a.get::<&flecs::meta::Member>(|mem| {
@@ -200,10 +200,10 @@ fn meta_struct_w_portable_type() {
         .member::<Entity>("c")
         .member::<Entity>("d");
 
-    assert!(t.id() != 0);
+    assert_ne!(t.id(), 0);
 
     let a = t.lookup("a");
-    assert!(a.id() != 0);
+    assert_ne!(a.id(), 0);
     assert!(a.has::<flecs::meta::Member>());
 
     a.get::<&flecs::meta::Member>(|mem| {
@@ -211,7 +211,7 @@ fn meta_struct_w_portable_type() {
     });
 
     let b = t.lookup("b");
-    assert!(b.id() != 0);
+    assert_ne!(b.id(), 0);
     assert!(b.has::<flecs::meta::Member>());
 
     // b.get::<&flecs::meta::Member>(|mem| {
@@ -219,7 +219,7 @@ fn meta_struct_w_portable_type() {
     // });
 
     // let c = t.lookup("c");
-    // assert!(c.id() != 0);
+    // assert_ne!(c.id(), 0);
     // assert!(c.has::<flecs::meta::Member>());
 
     // c.get::<&flecs::meta::Member>(|mem| {
@@ -227,7 +227,7 @@ fn meta_struct_w_portable_type() {
     // });
 
     // let d = t.lookup("d");
-    // assert!(d.id() != 0);
+    // assert_ne!(d.id(), 0);
     // assert!(d.has::<flecs::meta::Member>());
 
     // d.get::<&flecs::meta::Member>(|mem| {
@@ -251,7 +251,7 @@ fn meta_partial_struct() {
 
     let c = world.component::<Position>().member::<f32>("x");
 
-    assert!(c.id() != 0);
+    assert_ne!(c.id(), 0);
 
     c.get::<&flecs::Component>(|ptr| {
         assert_eq!(ptr.size, 4);
@@ -259,7 +259,7 @@ fn meta_partial_struct() {
     });
 
     let xe = c.lookup("x");
-    assert!(xe.id() != 0);
+    assert_ne!(xe.id(), 0);
     assert!(xe.has::<flecs::meta::Member>());
     xe.get::<&flecs::meta::Member>(|x| {
         assert_eq!(x.type_, flecs::meta::F32);
@@ -281,7 +281,7 @@ fn meta_partial_struct_custom_offset() {
         .component::<Position>()
         .member::<f32>(("y", Count(1), offset_of!(Position, y)));
 
-    assert!(c.id() != 0);
+    assert_ne!(c.id(), 0);
 
     c.get::<&flecs::Component>(|ptr| {
         assert_eq!(ptr.size, 8);
@@ -289,7 +289,7 @@ fn meta_partial_struct_custom_offset() {
     });
 
     let xe = c.lookup("y");
-    assert!(xe.id() != 0);
+    assert_ne!(xe.id(), 0);
     assert!(xe.has::<flecs::meta::Member>());
     xe.get::<&flecs::meta::Member>(|x| {
         assert_eq!(x.type_, flecs::meta::F32);
@@ -504,8 +504,8 @@ fn meta_new_world_ser_deser_flecs_entity() {
     let e1 = world.lookup("ent1");
     let e2 = world.lookup("ent2");
 
-    assert!(e1.id() != 0);
-    assert!(e2.id() != 0);
+    assert_ne!(e1.id(), 0);
+    assert_ne!(e2.id(), 0);
 
     assert!(e1.is_alive());
     assert!(e2.is_alive());
@@ -547,7 +547,7 @@ fn meta_new_world_ser_deser_empty_flecs_entity() {
 
     let e2 = world.lookup("ent2");
 
-    assert!(e2.id() != 0);
+    assert_ne!(e2.id(), 0);
 
     assert!(e2.is_alive());
 
@@ -682,7 +682,7 @@ fn meta_value_range() {
         .range(-2.0, 2.0);
 
     let x = c.lookup("x");
-    assert!(x.id() != 0);
+    assert_ne!(x.id(), 0);
     assert!(x.has::<flecs::meta::MemberRanges>());
 
     x.get::<&flecs::meta::MemberRanges>(|ranges| {
@@ -691,7 +691,7 @@ fn meta_value_range() {
     });
 
     let y = c.lookup("y");
-    assert!(y.id() != 0);
+    assert_ne!(y.id(), 0);
     assert!(y.has::<flecs::meta::MemberRanges>());
 
     y.get::<&flecs::meta::MemberRanges>(|ranges| {
@@ -718,7 +718,7 @@ fn meta_warning_range() {
         .warning_range(-2.0, 2.0);
 
     let x = c.lookup("x");
-    assert!(x.id() != 0);
+    assert_ne!(x.id(), 0);
     assert!(x.has::<flecs::meta::MemberRanges>());
 
     x.get::<&flecs::meta::MemberRanges>(|range| {
@@ -727,7 +727,7 @@ fn meta_warning_range() {
     });
 
     let y = c.lookup("y");
-    assert!(y.id() != 0);
+    assert_ne!(y.id(), 0);
     assert!(y.has::<flecs::meta::MemberRanges>());
 
     y.get::<&flecs::meta::MemberRanges>(|range| {
@@ -754,7 +754,7 @@ fn meta_error_range() {
         .error_range(-2.0, 2.0);
 
     let x = c.lookup("x");
-    assert!(x.id() != 0);
+    assert_ne!(x.id(), 0);
     assert!(x.has::<flecs::meta::MemberRanges>());
 
     x.get::<&flecs::meta::MemberRanges>(|range| {
@@ -763,7 +763,7 @@ fn meta_error_range() {
     });
 
     let y = c.lookup("y");
-    assert!(y.id() != 0);
+    assert_ne!(y.id(), 0);
     assert!(y.has::<flecs::meta::MemberRanges>());
 
     y.get::<&flecs::meta::MemberRanges>(|range| {
@@ -803,10 +803,10 @@ fn meta_struct_member_ptr() {
         .member_id(t2, ("b", Count(2), offset_of!(Nested, b)));
 
     //validate Test #1
-    assert!(t.id() != 0);
+    assert_ne!(t.id(), 0);
 
     let x = t.lookup("x");
-    assert!(x.id() != 0);
+    assert_ne!(x.id(), 0);
     assert!(x.has::<flecs::meta::Member>());
     x.get::<&flecs::meta::Member>(|xm| {
         assert_eq!(xm.type_, flecs::meta::I32);
@@ -814,10 +814,10 @@ fn meta_struct_member_ptr() {
     });
 
     //validate Test2 #2
-    assert!(t2.id() != 0);
+    assert_ne!(t2.id(), 0);
 
     let y = t2.lookup("y");
-    assert!(y.id() != 0);
+    assert_ne!(y.id(), 0);
     assert!(y.has::<flecs::meta::Member>());
     y.get::<&flecs::meta::Member>(|ym| {
         assert_eq!(ym.type_, flecs::meta::F64);
@@ -825,10 +825,10 @@ fn meta_struct_member_ptr() {
     });
 
     // Validate Nested
-    assert!(n.id() != 0);
+    assert_ne!(n.id(), 0);
 
     let a = n.lookup("a");
-    assert!(a.id() != 0);
+    assert_ne!(a.id(), 0);
     assert!(a.has::<flecs::meta::Member>());
     a.get::<&flecs::meta::Member>(|am| {
         assert_eq!(am.type_, t.id());
@@ -837,7 +837,7 @@ fn meta_struct_member_ptr() {
     });
 
     let b = n.lookup("b");
-    assert!(b.id() != 0);
+    assert_ne!(b.id(), 0);
     assert!(b.has::<flecs::meta::Member>());
     b.get::<&flecs::meta::Member>(|bm| {
         assert_eq!(bm.type_, t2.id());

--- a/flecs_ecs/tests/flecs/system_test.rs
+++ b/flecs_ecs/tests/flecs/system_test.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::float_cmp)]
 #![allow(dead_code)]
 
 use std::ffi::c_void;
@@ -587,7 +588,7 @@ fn system_copy_name_on_create() {
         .system_named::<&mut Position>(name)
         .run(|mut it| while it.next() {});
 
-    assert!(system_1.id() != system_2.id());
+    assert_ne!(system_1.id(), system_2.id());
 }
 
 #[test]
@@ -601,11 +602,11 @@ fn system_nested_system() {
     assert_eq!(system_1.name(), "bar");
 
     let e = world.lookup("foo");
-    assert!(e.id() != 0);
+    assert_ne!(e.id(), 0);
     assert_eq!(e.name(), "foo");
 
     let se = e.lookup("bar");
-    assert!(se.id() != 0);
+    assert_ne!(se.id(), 0);
     assert_eq!(se.name(), "bar");
 }
 
@@ -2030,7 +2031,7 @@ fn system_startup_system() {
         .run(|mut it| {
             let world = it.world();
             while it.next() {
-                assert!(it.delta_time() != 0.0);
+                assert_ne!(it.delta_time(), 0.0);
                 world.get::<&mut Count2>(|c| {
                     c.b += 1;
                 });
@@ -2203,7 +2204,7 @@ fn system_nested_rate_tick_source() {
 //         .each([&](flecs::iter& iter, size_t index) {
 //             let e = iter.entity(index);
 //             &Position *p = &iter.table().get<Position>()[index];
-//             assert!(p != nullptr);
+//             assert_ne!(p, nullptr);
 //             assert!(e == e1 || e == e2);
 //             if (e == e1) {
 //                 assert_eq!(p.x, 10);
@@ -2228,7 +2229,7 @@ fn system_nested_rate_tick_source() {
 //         .each([&](flecs::iter& iter, size_t index) {
 //             let e = iter.entity(index);
 //             &Position *p = &iter.range().get<Position>()[index];
-//             assert!(p != nullptr);
+//             assert_ne!(p, nullptr);
 //             assert!(e == e1 || e == e2);
 //             if (e == e1) {
 //                 assert_eq!(p.x, 10);
@@ -2267,13 +2268,13 @@ fn system_randomize_timers() {
     {
         let t = s1.try_cloned::<&flecs::timer::Timer>();
         assert!(t.is_some());
-        assert!(t.unwrap().time != 0.0);
+        assert_ne!(t.unwrap().time, 0.0);
     }
 
     {
         let t = s2.try_cloned::<&flecs::timer::Timer>();
         assert!(t.is_some());
-        assert!(t.unwrap().time != 0.0);
+        assert_ne!(t.unwrap().time, 0.0);
     }
 }
 


### PR DESCRIPTION
Allow `clippy::float_cmp` in the system tests as the current behavior worked.