### PR TITLE
fix(wasm32): Remove re-export of libc `srand` / `time`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ rust.unused_lifetimes = "warn"
 flecs_ecs = { version = "0.1.2", path = "flecs_ecs" }
 flecs_ecs_derive = { version = "0.1.0", path = "flecs_ecs_derive" }
 flecs_ecs_sys = { version = "0.1.2", path = "flecs_ecs_sys" }
+libc = "0.2.169"
 
 [profile.release]
 lto = true

--- a/flecs_ecs/Cargo.toml
+++ b/flecs_ecs/Cargo.toml
@@ -37,6 +37,7 @@ seq-macro = "0.3.5"
 rand = "0.9.0"
 ctor = "0.3.0"
 insta = { version = "1.42.1", features = ["yaml","filters"] }
+libc.workspace = true
 # used for capturing stdout in the examples test cases. Works only on Nightly, meant
 # to be used with flecs_nightly_tests feature flag
 #capture-stdio = "0.1.1" 

--- a/flecs_ecs/tests/flecs/system_test.rs
+++ b/flecs_ecs/tests/flecs/system_test.rs
@@ -2250,8 +2250,8 @@ fn system_randomize_timers() {
     // on musl builds, `rand` call always returns 0 until seeded, so we need to
     // call srand to seed the random number generator
     unsafe {
-        let seed = flecs_ecs_sys::time(core::ptr::null_mut()) as u32;
-        flecs_ecs_sys::srand(seed);
+        let seed = libc::time(core::ptr::null_mut()) as u32;
+        libc::srand(seed);
     }
 
     let s1 = world

--- a/flecs_ecs_sys/Cargo.toml
+++ b/flecs_ecs_sys/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["flecs", "ecs", "sys"]
 workspace = true
 
 [dependencies]
-libc = "0.2.167"
+libc.workspace = true
 
 [build-dependencies]
 bindgen = "0.71.1"

--- a/flecs_ecs_sys/src/lib.rs
+++ b/flecs_ecs_sys/src/lib.rs
@@ -15,5 +15,3 @@ mod mbindings;
 
 pub use bindings::*;
 pub use mbindings::*;
-//exposed for musl test case (system_randomize_timers)
-pub use libc::{srand, time};


### PR DESCRIPTION
This can be used from the `flecs_ecs` tests as a dev-dependency directly.

Make `libc` a workspace dependency to share the version between the `flecs_ecs_sys` and `flecs_ecs` crates. Require the current version as well.

Not all platforms have these functions in the `libc` crate. Notably, this is missing on `wasm32-unknown-unknown`.