### PR TITLE
fix(docs,clippy): Most `clippy::doc_overindented_list_items` lints

### DIFF
--- a/flecs_ecs/src/core/components/component.rs
+++ b/flecs_ecs/src/core/components/component.rs
@@ -118,7 +118,7 @@ impl<'a, T> Component<'a, T> {
     ///
     /// * `world`: the world.
     /// * `name`: the name of the component.
-    ///    Return the component as an entity
+    ///   Return the component as an entity
     ///
     /// # See also
     ///

--- a/flecs_ecs/src/core/entity_view/entity_view_mut.rs
+++ b/flecs_ecs/src/core/entity_view/entity_view_mut.rs
@@ -880,11 +880,11 @@ impl<'a> EntityView<'a> {
     ///
     /// # See also
     ///
+    /// * [`EntityView::add`]
+    /// * [`EntityView::add_id`]
+    /// * [`EntityView::set`]
+    /// * [`EntityView::set_pair`]
     /// * C++ API: `entity_builder::set`
-    ///     [`EntityView::add`]
-    ///     [`EntityView::add_id`]
-    ///     [`EntityView::set`]
-    ///     [`EntityView::set_pair`]
     #[doc(alias = "entity_builder::set")]
     pub fn set_id<T>(self, data: T, id: impl IntoId) -> Self
     where

--- a/flecs_ecs/src/core/query_builder.rs
+++ b/flecs_ecs/src/core/query_builder.rs
@@ -862,7 +862,7 @@ pub trait QueryBuilderImpl<'a>: TermBuilderImpl<'a> {
     /// # Arguments
     ///
     /// * `compare`: The compare function used to sort the components.
-    ///     The signature of the function must be `fn(Entity, &T, Entity, &T) -> i32`.
+    ///   The signature of the function must be `fn(Entity, &T, Entity, &T) -> i32`.
     ///
     /// # See also
     ///

--- a/flecs_ecs/src/core/world.rs
+++ b/flecs_ecs/src/core/world.rs
@@ -1752,8 +1752,8 @@ pub trait WorldGet<Return> {
     /// use `Option` wrapper to indicate if the component is optional.
     ///
     /// - `try_get` assumes when not using `Option` wrapper, that the entity has the component.
-    ///    If it does not, it will not run the callback.
-    ///    If unsure and you still want to have the callback be ran, use `Option` wrapper instead.
+    ///   If it does not, it will not run the callback.
+    ///   If unsure and you still want to have the callback be ran, use `Option` wrapper instead.
     ///
     /// # Note
     ///


### PR DESCRIPTION
(This is new in currently nightlies.)