### PR TITLE
Add safety tests

### DIFF
--- a/flecs_ecs/tests/flecs/main.rs
+++ b/flecs_ecs/tests/flecs/main.rs
@@ -24,5 +24,6 @@ mod observer_test;
 mod query_builder_test;
 mod query_rust_test;
 mod query_test;
+mod safety;
 mod system_test;
 mod world_test;

--- a/flecs_ecs/tests/flecs/safety.rs
+++ b/flecs_ecs/tests/flecs/safety.rs
@@ -403,7 +403,7 @@ mod entity_view {
 mod table_iter {
     use super::*;
 
-    mod from_query {
+    mod field {
         use super::*;
 
         #[test]
@@ -417,7 +417,7 @@ mod table_iter {
 
         #[test]
         #[should_panic]
-        fn field_field() {
+        fn double_field() {
             let world = World::new();
             world.entity().set(Foo(0));
             query!(world, Foo).build().each_iter(|iter, _, _| {
@@ -443,6 +443,82 @@ mod table_iter {
             world.entity().set(Foo(0));
             query!(world, &mut Foo).build().each_iter(|iter, _, _| {
                 iter.field::<Foo>(0);
+            });
+        }
+    }
+
+    mod field_at {
+        use super::*;
+
+        #[test]
+        fn filter() {
+            let world = World::new();
+            world.entity().set(Foo(0));
+            query!(world, Foo).build().each_iter(|iter, _, _| {
+                iter.field_at::<Foo>(0, 0);
+            });
+        }
+
+        #[test]
+        fn query_read() {
+            let world = World::new();
+            world.entity().set(Foo(0));
+            query!(world, &Foo).build().each_iter(|iter, _, _| {
+                iter.field_at::<Foo>(0, 0);
+            });
+        }
+
+        #[test]
+        #[should_panic]
+        fn query_write() {
+            let world = World::new();
+            world.entity().set(Foo(0));
+            query!(world, &mut Foo).build().each_iter(|iter, _, _| {
+                iter.field_at::<Foo>(0, 0);
+            });
+        }
+    }
+
+    mod field_at_mut {
+        use super::*;
+
+        #[test]
+        fn filter() {
+            let world = World::new();
+            world.entity().set(Foo(0));
+            query!(world, Foo).build().each_iter(|iter, _, _| {
+                iter.field_at_mut::<Foo>(0, 0);
+            });
+        }
+
+        #[test]
+        #[should_panic]
+        fn filter_double_field_at_mut() {
+            let world = World::new();
+            world.entity().set(Foo(0));
+            query!(world, Foo).build().each_iter(|iter, _, _| {
+                iter.field_at_mut::<Foo>(0, 0);
+                iter.field_at_mut::<Foo>(0, 0);
+            });
+        }
+
+        #[test]
+        #[should_panic]
+        fn query_read() {
+            let world = World::new();
+            world.entity().set(Foo(0));
+            query!(world, &Foo).build().each_iter(|iter, _, _| {
+                iter.field_at_mut::<Foo>(0, 0);
+            });
+        }
+
+        #[test]
+        #[should_panic]
+        fn query_write() {
+            let world = World::new();
+            world.entity().set(Foo(0));
+            query!(world, &mut Foo).build().each_iter(|iter, _, _| {
+                iter.field_at::<Foo>(0, 0);
             });
         }
     }

--- a/flecs_ecs/tests/flecs/safety.rs
+++ b/flecs_ecs/tests/flecs/safety.rs
@@ -57,36 +57,90 @@ fn running_conflicting_queries_no_violations() {
 mod entity_view {
     use super::*;
 
-    fn read_write() {
-        let world = World::new();
-        let entity = world.entity().set(Foo(0));
-        entity.get::<&Foo>(|_| {
-            entity.get::<&mut Foo>(|_| {});
-        });
+    mod get {
+        use super::*;
+        #[test]
+        #[should_panic]
+        fn read_write() {
+            let world = World::new();
+            let entity = world.entity().set(Foo(0));
+            entity.get::<&Foo>(|_| {
+                entity.get::<&mut Foo>(|_| {});
+            });
+        }
+
+        #[test]
+        #[should_panic]
+        fn write_read() {
+            let world = World::new();
+            let entity = world.entity().set(Foo(0));
+            entity.get::<&mut Foo>(|_| {
+                entity.get::<&Foo>(|_| {});
+            });
+        }
+
+        #[test]
+        #[should_panic]
+        fn write_cloned() {
+            let world = World::new();
+            let entity = world.entity().set(Foo(0));
+            entity.get::<&mut Foo>(|_| {
+                let _ = entity.cloned::<&Foo>();
+            });
+        }
+
+        #[test]
+        #[should_panic]
+        fn write_write() {
+            let world = World::new();
+            let entity = world.entity().set(Foo(0));
+            entity.get::<&mut Foo>(|_| {
+                entity.get::<&mut Foo>(|_| {});
+            });
+        }
     }
 
-    fn write_read() {
-        let world = World::new();
-        let entity = world.entity().set(Foo(0));
-        entity.get::<&mut Foo>(|_| {
-            entity.get::<&Foo>(|_| {});
-        });
-    }
+    mod try_get {
+        use super::*;
+        #[test]
+        #[should_panic]
+        fn read_write() {
+            let world = World::new();
+            let entity = world.entity().set(Foo(0));
+            entity.try_get::<&Foo>(|_| {
+                entity.try_get::<&mut Foo>(|_| {});
+            });
+        }
 
-    fn write_cloned() {
-        let world = World::new();
-        let entity = world.entity().set(Foo(0));
-        entity.get::<&mut Foo>(|_| {
-            let _ = entity.cloned::<&Foo>();
-        });
-    }
+        #[test]
+        #[should_panic]
+        fn write_read() {
+            let world = World::new();
+            let entity = world.entity().set(Foo(0));
+            entity.try_get::<&mut Foo>(|_| {
+                entity.try_get::<&Foo>(|_| {});
+            });
+        }
 
-    fn write_write() {
-        let world = World::new();
-        let entity = world.entity().set(Foo(0));
-        entity.get::<&mut Foo>(|_| {
-            entity.get::<&mut Foo>(|_| {});
-        });
+        #[test]
+        #[should_panic]
+        fn write_cloned() {
+            let world = World::new();
+            let entity = world.entity().set(Foo(0));
+            entity.try_get::<&mut Foo>(|_| {
+                let _ = entity.cloned::<&Foo>();
+            });
+        }
+
+        #[test]
+        #[should_panic]
+        fn write_write() {
+            let world = World::new();
+            let entity = world.entity().set(Foo(0));
+            entity.try_get::<&mut Foo>(|_| {
+                entity.try_get::<&mut Foo>(|_| {});
+            });
+        }
     }
 
     mod from_query {

--- a/flecs_ecs/tests/flecs/safety.rs
+++ b/flecs_ecs/tests/flecs/safety.rs
@@ -9,6 +9,9 @@ struct Foo(u8);
 struct Bar(u8);
 
 #[derive(Component)]
+struct Event;
+
+#[derive(Component)]
 struct A;
 
 #[derive(Component)]
@@ -397,6 +400,54 @@ mod entity_view {
     }
 }
 
+mod table_iter {
+    use super::*;
+
+    mod from_query {
+        use super::*;
+
+        #[test]
+        fn field() {
+            let world = World::new();
+            world.entity().set(Foo(0));
+            query!(world, Foo).build().each_iter(|iter, _, _| {
+                iter.field::<Foo>(0);
+            });
+        }
+
+        #[test]
+        #[should_panic]
+        fn field_field() {
+            let world = World::new();
+            world.entity().set(Foo(0));
+            query!(world, Foo).build().each_iter(|iter, _, _| {
+                iter.field::<Foo>(0);
+                iter.field::<Foo>(0);
+            });
+        }
+
+        #[test]
+        #[should_panic]
+        fn query_read_field() {
+            let world = World::new();
+            world.entity().set(Foo(0));
+            query!(world, &Foo).build().each_iter(|iter, _, _| {
+                iter.field::<Foo>(0);
+            });
+        }
+
+        #[test]
+        #[should_panic]
+        fn query_write_field() {
+            let world = World::new();
+            world.entity().set(Foo(0));
+            query!(world, &mut Foo).build().each_iter(|iter, _, _| {
+                iter.field::<Foo>(0);
+            });
+        }
+    }
+}
+
 mod query_in_query {
     use super::*;
 
@@ -407,6 +458,7 @@ mod query_in_query {
         #[should_panic]
         fn run_violation() {
             let world = World::new();
+            world.entity().set(Foo(0));
             let query0 = query!(world, &Foo).build();
             let query1 = query!(world, &mut Foo).build();
             query0.run(|iter| {
@@ -421,6 +473,7 @@ mod query_in_query {
         #[should_panic]
         fn each_violation() {
             let world = World::new();
+            world.entity().set(Foo(0));
             let query0 = query!(world, &Foo).build();
             let query1 = query!(world, &mut Foo).build();
             query0.each(|_| {
@@ -432,6 +485,7 @@ mod query_in_query {
         #[should_panic]
         fn each_entity_violation() {
             let world = World::new();
+            world.entity().set(Foo(0));
             let query0 = query!(world, &Foo).build();
             let query1 = query!(world, &mut Foo).build();
             query0.each_entity(|_, _| {
@@ -443,6 +497,7 @@ mod query_in_query {
         #[should_panic]
         fn each_iter_query_violation() {
             let world = World::new();
+            world.entity().set(Foo(0));
             let query0 = query!(world, &Foo).build();
             let query1 = query!(world, &mut Foo).build();
             query0.each_iter(|_, _, _| {
@@ -458,6 +513,7 @@ mod query_in_query {
         #[should_panic]
         fn run_violation() {
             let world = World::new();
+            world.entity().set(Foo(0));
             let query0 = query!(world, &mut Foo).build();
             let query1 = query!(world, &Foo).build();
             query0.run(|iter| {
@@ -472,6 +528,7 @@ mod query_in_query {
         #[should_panic]
         fn each_violation() {
             let world = World::new();
+            world.entity().set(Foo(0));
             let query0 = query!(world, &mut Foo).build();
             let query1 = query!(world, &Foo).build();
             query0.each(|_| {
@@ -483,6 +540,7 @@ mod query_in_query {
         #[should_panic]
         fn each_entity_violation() {
             let world = World::new();
+            world.entity().set(Foo(0));
             let query0 = query!(world, &mut Foo).build();
             let query1 = query!(world, &Foo).build();
             query0.each_entity(|_, _| {
@@ -509,6 +567,7 @@ mod query_in_query {
         #[should_panic]
         fn run_violation() {
             let world = World::new();
+            world.entity().set(Foo(0));
             let query0 = query!(world, &mut Foo).build();
             let query1 = query!(world, &mut Foo).build();
             query0.run(|iter| {
@@ -523,6 +582,7 @@ mod query_in_query {
         #[should_panic]
         fn each_violation() {
             let world = World::new();
+            world.entity().set(Foo(0));
             let query0 = query!(world, &mut Foo).build();
             let query1 = query!(world, &mut Foo).build();
             query0.each(|_| {
@@ -534,6 +594,7 @@ mod query_in_query {
         #[should_panic]
         fn each_entity_violation() {
             let world = World::new();
+            world.entity().set(Foo(0));
             let query0 = query!(world, &mut Foo).build();
             let query1 = query!(world, &mut Foo).build();
             query0.each_entity(|_, _| {
@@ -545,6 +606,7 @@ mod query_in_query {
         #[should_panic]
         fn each_iter_violation() {
             let world = World::new();
+            world.entity().set(Foo(0));
             let query0 = query!(world, &mut Foo).build();
             let query1 = query!(world, &mut Foo).build();
             query0.each_iter(|_, _, _| {
@@ -854,6 +916,7 @@ mod query_in_system {
         #[should_panic]
         fn run_violation() {
             let world = World::new();
+            world.entity().set(Foo(0));
             let query = query!(world, &mut Foo).build();
             system!(world, &Foo).run(move |iter| {
                 query.run(|iter| {
@@ -868,6 +931,7 @@ mod query_in_system {
         #[should_panic]
         fn each_violation() {
             let world = World::new();
+            world.entity().set(Foo(0));
             let query = query!(world, &mut Foo).build();
             system!(world, &Foo).each(move |_| {
                 query.each(|_| {});
@@ -879,6 +943,7 @@ mod query_in_system {
         #[should_panic]
         fn each_entity_violation() {
             let world = World::new();
+            world.entity().set(Foo(0));
             let query = query!(world, &mut Foo).build();
             system!(world, &Foo).each_entity(move |_, _| {
                 query.each_entity(|_, _| {});
@@ -890,6 +955,7 @@ mod query_in_system {
         #[should_panic]
         fn each_iter_violation() {
             let world = World::new();
+            world.entity().set(Foo(0));
             let query = query!(world, &mut Foo).build();
             system!(world, &Foo).each_iter(move |_, _, _| {
                 query.each_iter(|_, _, _| {});
@@ -905,6 +971,7 @@ mod query_in_system {
         #[should_panic]
         fn run_violation() {
             let world = World::new();
+            world.entity().set(Foo(0));
             let query = query!(world, &Foo).build();
             system!(world, &mut Foo).run(move |iter| {
                 query.run(|iter| {
@@ -919,6 +986,7 @@ mod query_in_system {
         #[should_panic]
         fn each_violation() {
             let world = World::new();
+            world.entity().set(Foo(0));
             let query = query!(world, &Foo).build();
             system!(world, &mut Foo).each(move |_| {
                 query.each(|_| {});
@@ -930,6 +998,7 @@ mod query_in_system {
         #[should_panic]
         fn each_entity_violation() {
             let world = World::new();
+            world.entity().set(Foo(0));
             let query = query!(world, &Foo).build();
             system!(world, &mut Foo).each_entity(move |_, _| {
                 query.each_entity(|_, _| {});
@@ -941,6 +1010,7 @@ mod query_in_system {
         #[should_panic]
         fn each_iter_violation() {
             let world = World::new();
+            world.entity().set(Foo(0));
             let query = query!(world, &Foo).build();
             system!(world, &mut Foo).each_iter(move |_, _, _| {
                 query.each_iter(|_, _, _| {});
@@ -956,6 +1026,7 @@ mod query_in_system {
         #[should_panic]
         fn run_violation() {
             let world = World::new();
+            world.entity().set(Foo(0));
             let query = query!(world, &mut Foo).build();
             system!(world, &mut Foo).run(move |iter| {
                 query.run(|iter| {
@@ -970,6 +1041,7 @@ mod query_in_system {
         #[should_panic]
         fn each_violation() {
             let world = World::new();
+            world.entity().set(Foo(0));
             let query = query!(world, &mut Foo).build();
             system!(world, &mut Foo).each(move |_| {
                 query.each(|_| {});
@@ -981,6 +1053,7 @@ mod query_in_system {
         #[should_panic]
         fn each_entity_violation() {
             let world = World::new();
+            world.entity().set(Foo(0));
             let query = query!(world, &mut Foo).build();
             system!(world, &mut Foo).each_entity(move |_, _| {
                 query.each_entity(|_, _| {});
@@ -992,6 +1065,7 @@ mod query_in_system {
         #[should_panic]
         fn each_iter_violation() {
             let world = World::new();
+            world.entity().set(Foo(0));
             let query = query!(world, &mut Foo).build();
             system!(world, &mut Foo).each_iter(move |_, _, _| {
                 query.each_iter(|_, _, _| {});
@@ -1011,23 +1085,11 @@ mod observer_in_system {
         #[should_panic]
         fn run_violation() {
             let world = World::new();
-            let query = query!(world, &mut Foo).build();
+            world.entity().set(Foo(0));
+            observer!(world, Event, &mut Foo).each(|_| {});
             system!(world, &Foo).run(move |iter| {
-                query.run(|iter| {
-                    iter.fini();
-                });
+                iter.entity(0).emit(&Event);
                 iter.fini();
-            });
-            world.progress();
-        }
-
-        #[test]
-        #[should_panic]
-        fn each_violation() {
-            let world = World::new();
-            let query = query!(world, &mut Foo).build();
-            system!(world, &Foo).each(move |_| {
-                query.each(|_| {});
             });
             world.progress();
         }
@@ -1036,9 +1098,10 @@ mod observer_in_system {
         #[should_panic]
         fn each_entity_violation() {
             let world = World::new();
-            let query = query!(world, &mut Foo).build();
-            system!(world, &Foo).each_entity(move |_, _| {
-                query.each_entity(|_, _| {});
+            world.entity().set(Foo(0));
+            observer!(world, Event, &mut Foo).each(|_| {});
+            system!(world, &Foo).each_entity(move |entity, _| {
+                entity.emit(&Event);
             });
             world.progress();
         }
@@ -1047,9 +1110,10 @@ mod observer_in_system {
         #[should_panic]
         fn each_iter_violation() {
             let world = World::new();
-            let query = query!(world, &mut Foo).build();
-            system!(world, &Foo).each_iter(move |_, _, _| {
-                query.each_iter(|_, _, _| {});
+            world.entity().set(Foo(0));
+            observer!(world, Event, &mut Foo).each(|_| {});
+            system!(world, &Foo).each_iter(move |iter, _, _| {
+                iter.entity(0).emit(&Event);
             });
             world.progress();
         }
@@ -1062,23 +1126,11 @@ mod observer_in_system {
         #[should_panic]
         fn run_violation() {
             let world = World::new();
-            let query = query!(world, &Foo).build();
+            world.entity().set(Foo(0));
+            observer!(world, Event, &Foo).each(|_| {});
             system!(world, &mut Foo).run(move |iter| {
-                query.run(|iter| {
-                    iter.fini();
-                });
+                iter.entity(0).emit(&Event);
                 iter.fini();
-            });
-            world.progress();
-        }
-
-        #[test]
-        #[should_panic]
-        fn each_violation() {
-            let world = World::new();
-            let query = query!(world, &Foo).build();
-            system!(world, &mut Foo).each(move |_| {
-                query.each(|_| {});
             });
             world.progress();
         }
@@ -1087,9 +1139,10 @@ mod observer_in_system {
         #[should_panic]
         fn each_entity_violation() {
             let world = World::new();
-            let query = query!(world, &Foo).build();
-            system!(world, &mut Foo).each_entity(move |_, _| {
-                query.each_entity(|_, _| {});
+            world.entity().set(Foo(0));
+            observer!(world, Event, &Foo).each(|_| {});
+            system!(world, &mut Foo).each_entity(move |entity, _| {
+                entity.emit(&Event);
             });
             world.progress();
         }
@@ -1098,9 +1151,10 @@ mod observer_in_system {
         #[should_panic]
         fn each_iter_violation() {
             let world = World::new();
-            let query = query!(world, &Foo).build();
-            system!(world, &mut Foo).each_iter(move |_, _, _| {
-                query.each_iter(|_, _, _| {});
+            world.entity().set(Foo(0));
+            observer!(world, Event, &Foo).each(|_| {});
+            system!(world, &mut Foo).each_iter(move |iter, _, _| {
+                iter.entity(0).emit(&Event);
             });
             world.progress();
         }
@@ -1113,23 +1167,11 @@ mod observer_in_system {
         #[should_panic]
         fn run_violation() {
             let world = World::new();
-            let query = query!(world, &mut Foo).build();
+            world.entity().set(Foo(0));
+            observer!(world, Event, &mut Foo).each(|_| {});
             system!(world, &mut Foo).run(move |iter| {
-                query.run(|iter| {
-                    iter.fini();
-                });
+                iter.entity(0).emit(&Event);
                 iter.fini();
-            });
-            world.progress();
-        }
-
-        #[test]
-        #[should_panic]
-        fn each_violation() {
-            let world = World::new();
-            let query = query!(world, &mut Foo).build();
-            system!(world, &mut Foo).each(move |_| {
-                query.each(|_| {});
             });
             world.progress();
         }
@@ -1138,9 +1180,10 @@ mod observer_in_system {
         #[should_panic]
         fn each_entity_violation() {
             let world = World::new();
-            let query = query!(world, &mut Foo).build();
-            system!(world, &mut Foo).each_entity(move |_, _| {
-                query.each_entity(|_, _| {});
+            world.entity().set(Foo(0));
+            observer!(world, Event, &mut Foo).each(|_| {});
+            system!(world, &mut Foo).each_entity(move |entity, _| {
+                entity.emit(&Event);
             });
             world.progress();
         }
@@ -1149,9 +1192,10 @@ mod observer_in_system {
         #[should_panic]
         fn each_iter_violation() {
             let world = World::new();
-            let query = query!(world, &mut Foo).build();
-            system!(world, &mut Foo).each_iter(move |_, _, _| {
-                query.each_iter(|_, _, _| {});
+            world.entity().set(Foo(0));
+            observer!(world, Event, &mut Foo).each(|_| {});
+            system!(world, &mut Foo).each_iter(move |iter, _, _| {
+                iter.entity(0).emit(&Event);
             });
             world.progress();
         }

--- a/flecs_ecs/tests/flecs/safety.rs
+++ b/flecs_ecs/tests/flecs/safety.rs
@@ -1,0 +1,816 @@
+#![allow(dead_code)]
+use flecs_ecs::core::*;
+use flecs_ecs::macros::*;
+
+#[derive(Component)]
+struct Foo(u8);
+
+#[derive(Component)]
+struct Bar(u8);
+
+#[derive(Component)]
+struct A;
+
+#[derive(Component)]
+struct B;
+
+#[test]
+fn building_conflicting_queries_no_violations() {
+    let world = World::new();
+    // building queries that overlap without running them is ok
+    let _read = query!(world, &Foo).build();
+    let _write0 = query!(world, &mut Foo).build();
+    let _write1 = query!(world, &mut Foo).build();
+}
+
+#[test]
+fn running_conflicting_queries_no_violations() {
+    let world = World::new();
+    let read = query!(world, &Foo).build();
+    let write0 = query!(world, &mut Foo).build();
+    let write1 = query!(world, &mut Foo).build();
+
+    // running queries that overlap individually is ok
+    read.run(|iter| {
+        iter.fini();
+    });
+    write0.run(|iter| {
+        iter.fini();
+    });
+    write1.run(|iter| {
+        iter.fini();
+    });
+
+    read.each(|_| {});
+    write0.each(|_| {});
+    write1.each(|_| {});
+
+    read.each_entity(|_, _| {});
+    write0.each_entity(|_, _| {});
+    write1.each_entity(|_, _| {});
+
+    read.each_iter(|_, _, _| {});
+    write0.each_iter(|_, _, _| {});
+    write1.each_iter(|_, _, _| {});
+}
+
+mod query_in_query {
+    use super::*;
+
+    mod read_write {
+        use super::*;
+
+        #[test]
+        #[should_panic]
+        fn run_violation() {
+            let world = World::new();
+            let query0 = query!(world, &Foo).build();
+            let query1 = query!(world, &mut Foo).build();
+            query0.run(|iter| {
+                query1.run(|iter| {
+                    iter.fini();
+                });
+                iter.fini();
+            });
+        }
+
+        #[test]
+        #[should_panic]
+        fn each_violation() {
+            let world = World::new();
+            let query0 = query!(world, &Foo).build();
+            let query1 = query!(world, &mut Foo).build();
+            query0.each(|_| {
+                query1.each(|_| {});
+            });
+        }
+
+        #[test]
+        #[should_panic]
+        fn each_entity_violation() {
+            let world = World::new();
+            let query0 = query!(world, &Foo).build();
+            let query1 = query!(world, &mut Foo).build();
+            query0.each_entity(|_, _| {
+                query1.each_entity(|_, _| {});
+            });
+        }
+
+        #[test]
+        #[should_panic]
+        fn each_iter_query_violation() {
+            let world = World::new();
+            let query0 = query!(world, &Foo).build();
+            let query1 = query!(world, &mut Foo).build();
+            query0.each_iter(|_, _, _| {
+                query1.each_iter(|_, _, _| {});
+            });
+        }
+    }
+
+    mod write_read {
+        use super::*;
+
+        #[test]
+        #[should_panic]
+        fn run_violation() {
+            let world = World::new();
+            let query0 = query!(world, &mut Foo).build();
+            let query1 = query!(world, &Foo).build();
+            query0.run(|iter| {
+                query1.run(|iter| {
+                    iter.fini();
+                });
+                iter.fini();
+            });
+        }
+
+        #[test]
+        #[should_panic]
+        fn each_violation() {
+            let world = World::new();
+            let query0 = query!(world, &mut Foo).build();
+            let query1 = query!(world, &Foo).build();
+            query0.each(|_| {
+                query1.each(|_| {});
+            });
+        }
+
+        #[test]
+        #[should_panic]
+        fn each_entity_violation() {
+            let world = World::new();
+            let query0 = query!(world, &mut Foo).build();
+            let query1 = query!(world, &Foo).build();
+            query0.each_entity(|_, _| {
+                query1.each_entity(|_, _| {});
+            });
+        }
+
+        #[test]
+        #[should_panic]
+        fn each_iter_violation() {
+            let world = World::new();
+            let query0 = query!(world, &mut Foo).build();
+            let query1 = query!(world, &Foo).build();
+            query0.each_iter(|_, _, _| {
+                query1.each_iter(|_, _, _| {});
+            });
+        }
+    }
+
+    mod write_write {
+        use super::*;
+
+        #[test]
+        #[should_panic]
+        fn run_violation() {
+            let world = World::new();
+            let query0 = query!(world, &mut Foo).build();
+            let query1 = query!(world, &mut Foo).build();
+            query0.run(|iter| {
+                query1.run(|iter| {
+                    iter.fini();
+                });
+                iter.fini();
+            });
+        }
+
+        #[test]
+        #[should_panic]
+        fn each_violation() {
+            let world = World::new();
+            let query0 = query!(world, &mut Foo).build();
+            let query1 = query!(world, &mut Foo).build();
+            query0.each(|_| {
+                query1.each(|_| {});
+            });
+        }
+
+        #[test]
+        #[should_panic]
+        fn each_entity_violation() {
+            let world = World::new();
+            let query0 = query!(world, &mut Foo).build();
+            let query1 = query!(world, &mut Foo).build();
+            query0.each_entity(|_, _| {
+                query1.each_entity(|_, _| {});
+            });
+        }
+
+        #[test]
+        #[should_panic]
+        fn each_iter_violation() {
+            let world = World::new();
+            let query0 = query!(world, &mut Foo).build();
+            let query1 = query!(world, &mut Foo).build();
+            query0.each_iter(|_, _, _| {
+                query1.each_iter(|_, _, _| {});
+            });
+        }
+    }
+}
+
+mod observer_in_observer {
+    use super::*;
+
+    mod read_write {
+        use super::*;
+
+        #[test]
+        #[should_panic]
+        fn run_violation() {
+            let world = World::new();
+            let e = world.entity().set(Foo(0)).id();
+            observer!(world, A, &Foo).run(|iter| {
+                iter.fini();
+            });
+            observer!(world, B, &mut Foo).run(move |iter| {
+                iter.world().event().add::<Foo>().entity(e).emit(&A);
+                iter.fini();
+            });
+            world.event().add::<Foo>().entity(e).emit(&B);
+        }
+
+        #[test]
+        #[should_panic]
+        fn each_entity_violation() {
+            let world = World::new();
+            let e = world.entity().set(Foo(0)).id();
+            observer!(world, A, &Foo).each_entity(|_, _| {});
+            observer!(world, B, &mut Foo).each_entity(move |entity, _| {
+                entity.world().event().add::<Foo>().entity(e).emit(&A);
+            });
+            world.event().add::<Foo>().entity(e).emit(&B);
+        }
+
+        #[test]
+        #[should_panic]
+        fn each_iter_violation() {
+            let world = World::new();
+            let e = world.entity().set(Foo(0)).id();
+            observer!(world, A, &Foo).each_iter(|_, _, _| {});
+            observer!(world, B, &mut Foo).each_iter(move |iter, _, _| {
+                iter.world().event().add::<Foo>().entity(e).emit(&A);
+            });
+            world.event().add::<Foo>().entity(e).emit(&B);
+        }
+    }
+
+    mod write_read {
+        use super::*;
+
+        #[test]
+        #[should_panic]
+        fn run_violation() {
+            let world = World::new();
+            let e = world.entity().set(Foo(0)).id();
+            observer!(world, A, &mut Foo).run(|iter| {
+                iter.fini();
+            });
+            observer!(world, B, &Foo).run(move |iter| {
+                iter.world().event().add::<Foo>().entity(e).emit(&A);
+                iter.fini();
+            });
+            world.event().add::<Foo>().entity(e).emit(&B);
+        }
+
+        #[test]
+        #[should_panic]
+        fn each_entity_violation() {
+            let world = World::new();
+            let e = world.entity().set(Foo(0)).id();
+            observer!(world, A, &mut Foo).each_entity(|_, _| {});
+            observer!(world, B, &Foo).each_entity(move |entity, _| {
+                entity.world().event().add::<Foo>().entity(e).emit(&A);
+            });
+            world.event().add::<Foo>().entity(e).emit(&B);
+        }
+
+        #[test]
+        #[should_panic]
+        fn each_iter_violation() {
+            let world = World::new();
+            let e = world.entity().set(Foo(0)).id();
+            observer!(world, A, &mut Foo).each_iter(|_, _, _| {});
+            observer!(world, B, &Foo).each_iter(move |iter, _, _| {
+                iter.world().event().add::<Foo>().entity(e).emit(&A);
+            });
+            world.event().add::<Foo>().entity(e).emit(&B);
+        }
+    }
+
+    mod write_write {
+        use super::*;
+
+        #[test]
+        #[should_panic]
+        fn run_violation() {
+            let world = World::new();
+            let e = world.entity().set(Foo(0)).id();
+            observer!(world, A, &mut Foo).run(|iter| {
+                iter.fini();
+            });
+            observer!(world, B, &mut Foo).run(move |iter| {
+                iter.world().event().add::<Foo>().entity(e).emit(&A);
+                iter.fini();
+            });
+            world.event().add::<Foo>().entity(e).emit(&B);
+        }
+
+        #[test]
+        #[should_panic]
+        fn each_entity_violation() {
+            let world = World::new();
+            let e = world.entity().set(Foo(0)).id();
+            observer!(world, A, &mut Foo).each_entity(|_, _| {});
+            observer!(world, B, &mut Foo).each_entity(move |entity, _| {
+                entity.world().event().add::<Foo>().entity(e).emit(&A);
+            });
+            world.event().add::<Foo>().entity(e).emit(&B);
+        }
+
+        #[test]
+        #[should_panic]
+        fn each_iter_violation() {
+            let world = World::new();
+            let e = world.entity().set(Foo(0)).id();
+            observer!(world, A, &mut Foo).each_iter(|_, _, _| {});
+            observer!(world, B, &mut Foo).each_iter(move |iter, _, _| {
+                iter.world().event().add::<Foo>().entity(e).emit(&A);
+            });
+            world.event().add::<Foo>().entity(e).emit(&B);
+        }
+    }
+}
+
+mod query_in_observer {
+    use super::*;
+
+    mod read_write {
+        use super::*;
+
+        #[test]
+        #[should_panic]
+        fn run_violation() {
+            let world = World::new();
+            let query = query!(world, &mut Foo).build();
+            observer!(world, flecs::OnSet, &Foo).run(move |iter| {
+                query.run(|iter| {
+                    iter.fini();
+                });
+                iter.fini();
+            });
+            world.entity().set(Foo(0));
+        }
+
+        #[test]
+        #[should_panic]
+        fn each_violation() {
+            let world = World::new();
+            let query = query!(world, &mut Foo).build();
+            observer!(world, flecs::OnSet, &Foo).each(move |_| {
+                query.each(|_| {});
+            });
+            world.entity().set(Foo(0));
+        }
+
+        #[test]
+        #[should_panic]
+        fn each_entity_violation() {
+            let world = World::new();
+            let query = query!(world, &mut Foo).build();
+            observer!(world, flecs::OnSet, &Foo).each_entity(move |_, _| {
+                query.each_entity(|_, _| {});
+            });
+            world.entity().set(Foo(0));
+        }
+
+        #[test]
+        #[should_panic]
+        fn each_iter_violation() {
+            let world = World::new();
+            let query = query!(world, &mut Foo).build();
+            observer!(world, flecs::OnSet, &Foo).each_iter(move |_, _, _| {
+                query.each_iter(|_, _, _| {});
+            });
+            world.entity().set(Foo(0));
+        }
+    }
+
+    mod write_read {
+        use super::*;
+
+        #[test]
+        #[should_panic]
+        fn run_violation() {
+            let world = World::new();
+            let query = query!(world, &Foo).build();
+            observer!(world, flecs::OnSet, &mut Foo).run(move |iter| {
+                query.run(|iter| {
+                    iter.fini();
+                });
+                iter.fini();
+            });
+            world.entity().set(Foo(0));
+        }
+
+        #[test]
+        #[should_panic]
+        fn each_violation() {
+            let world = World::new();
+            let query = query!(world, &Foo).build();
+            observer!(world, flecs::OnSet, &mut Foo).each(move |_| {
+                query.each(|_| {});
+            });
+            world.entity().set(Foo(0));
+        }
+
+        #[test]
+        #[should_panic]
+        fn each_entity_violation() {
+            let world = World::new();
+            let query = query!(world, &Foo).build();
+            observer!(world, flecs::OnSet, &mut Foo).each_entity(move |_, _| {
+                query.each_entity(|_, _| {});
+            });
+            world.entity().set(Foo(0));
+        }
+
+        #[test]
+        #[should_panic]
+        fn each_iter_violation() {
+            let world = World::new();
+            let query = query!(world, &Foo).build();
+            observer!(world, flecs::OnSet, &mut Foo).each_iter(move |_, _, _| {
+                query.each_iter(|_, _, _| {});
+            });
+            world.entity().set(Foo(0));
+        }
+    }
+
+    mod write_write {
+        use super::*;
+
+        #[test]
+        #[should_panic]
+        fn run_violation() {
+            let world = World::new();
+            let query = query!(world, &mut Foo).build();
+            observer!(world, flecs::OnSet, &mut Foo).run(move |iter| {
+                query.run(|iter| {
+                    iter.fini();
+                });
+                iter.fini();
+            });
+            world.entity().set(Foo(0));
+        }
+
+        #[test]
+        #[should_panic]
+        fn each_violation() {
+            let world = World::new();
+            let query = query!(world, &mut Foo).build();
+            observer!(world, flecs::OnSet, &mut Foo).each(move |_| {
+                query.each(|_| {});
+            });
+            world.entity().set(Foo(0));
+        }
+
+        #[test]
+        #[should_panic]
+        fn each_entity_violation() {
+            let world = World::new();
+            let query = query!(world, &mut Foo).build();
+            observer!(world, flecs::OnSet, &mut Foo).each_entity(move |_, _| {
+                query.each_entity(|_, _| {});
+            });
+            world.entity().set(Foo(0));
+        }
+
+        #[test]
+        #[should_panic]
+        fn each_iter_violation() {
+            let world = World::new();
+            let query = query!(world, &mut Foo).build();
+            observer!(world, flecs::OnSet, &mut Foo).each_iter(move |_, _, _| {
+                query.each_iter(|_, _, _| {});
+            });
+            world.entity().set(Foo(0));
+        }
+    }
+}
+
+mod query_in_system {
+    use super::*;
+
+    mod read_write {
+        use super::*;
+
+        #[test]
+        #[should_panic]
+        fn run_violation() {
+            let world = World::new();
+            let query = query!(world, &mut Foo).build();
+            system!(world, &Foo).run(move |iter| {
+                query.run(|iter| {
+                    iter.fini();
+                });
+                iter.fini();
+            });
+            world.progress();
+        }
+
+        #[test]
+        #[should_panic]
+        fn each_violation() {
+            let world = World::new();
+            let query = query!(world, &mut Foo).build();
+            system!(world, &Foo).each(move |_| {
+                query.each(|_| {});
+            });
+            world.progress();
+        }
+
+        #[test]
+        #[should_panic]
+        fn each_entity_violation() {
+            let world = World::new();
+            let query = query!(world, &mut Foo).build();
+            system!(world, &Foo).each_entity(move |_, _| {
+                query.each_entity(|_, _| {});
+            });
+            world.progress();
+        }
+
+        #[test]
+        #[should_panic]
+        fn each_iter_violation() {
+            let world = World::new();
+            let query = query!(world, &mut Foo).build();
+            system!(world, &Foo).each_iter(move |_, _, _| {
+                query.each_iter(|_, _, _| {});
+            });
+            world.progress();
+        }
+    }
+
+    mod write_read {
+        use super::*;
+
+        #[test]
+        #[should_panic]
+        fn run_violation() {
+            let world = World::new();
+            let query = query!(world, &Foo).build();
+            system!(world, &mut Foo).run(move |iter| {
+                query.run(|iter| {
+                    iter.fini();
+                });
+                iter.fini();
+            });
+            world.progress();
+        }
+
+        #[test]
+        #[should_panic]
+        fn each_violation() {
+            let world = World::new();
+            let query = query!(world, &Foo).build();
+            system!(world, &mut Foo).each(move |_| {
+                query.each(|_| {});
+            });
+            world.progress();
+        }
+
+        #[test]
+        #[should_panic]
+        fn each_entity_violation() {
+            let world = World::new();
+            let query = query!(world, &Foo).build();
+            system!(world, &mut Foo).each_entity(move |_, _| {
+                query.each_entity(|_, _| {});
+            });
+            world.progress();
+        }
+
+        #[test]
+        #[should_panic]
+        fn each_iter_violation() {
+            let world = World::new();
+            let query = query!(world, &Foo).build();
+            system!(world, &mut Foo).each_iter(move |_, _, _| {
+                query.each_iter(|_, _, _| {});
+            });
+            world.progress();
+        }
+    }
+
+    mod write_write {
+        use super::*;
+
+        #[test]
+        #[should_panic]
+        fn run_violation() {
+            let world = World::new();
+            let query = query!(world, &mut Foo).build();
+            system!(world, &mut Foo).run(move |iter| {
+                query.run(|iter| {
+                    iter.fini();
+                });
+                iter.fini();
+            });
+            world.progress();
+        }
+
+        #[test]
+        #[should_panic]
+        fn each_violation() {
+            let world = World::new();
+            let query = query!(world, &mut Foo).build();
+            system!(world, &mut Foo).each(move |_| {
+                query.each(|_| {});
+            });
+            world.progress();
+        }
+
+        #[test]
+        #[should_panic]
+        fn each_entity_violation() {
+            let world = World::new();
+            let query = query!(world, &mut Foo).build();
+            system!(world, &mut Foo).each_entity(move |_, _| {
+                query.each_entity(|_, _| {});
+            });
+            world.progress();
+        }
+
+        #[test]
+        #[should_panic]
+        fn each_iter_violation() {
+            let world = World::new();
+            let query = query!(world, &mut Foo).build();
+            system!(world, &mut Foo).each_iter(move |_, _, _| {
+                query.each_iter(|_, _, _| {});
+            });
+            world.progress();
+        }
+    }
+}
+
+mod observer_in_system {
+    use super::*;
+
+    mod read_write {
+        use super::*;
+
+        #[test]
+        #[should_panic]
+        fn run_violation() {
+            let world = World::new();
+            let query = query!(world, &mut Foo).build();
+            system!(world, &Foo).run(move |iter| {
+                query.run(|iter| {
+                    iter.fini();
+                });
+                iter.fini();
+            });
+            world.progress();
+        }
+
+        #[test]
+        #[should_panic]
+        fn each_violation() {
+            let world = World::new();
+            let query = query!(world, &mut Foo).build();
+            system!(world, &Foo).each(move |_| {
+                query.each(|_| {});
+            });
+            world.progress();
+        }
+
+        #[test]
+        #[should_panic]
+        fn each_entity_violation() {
+            let world = World::new();
+            let query = query!(world, &mut Foo).build();
+            system!(world, &Foo).each_entity(move |_, _| {
+                query.each_entity(|_, _| {});
+            });
+            world.progress();
+        }
+
+        #[test]
+        #[should_panic]
+        fn each_iter_violation() {
+            let world = World::new();
+            let query = query!(world, &mut Foo).build();
+            system!(world, &Foo).each_iter(move |_, _, _| {
+                query.each_iter(|_, _, _| {});
+            });
+            world.progress();
+        }
+    }
+
+    mod write_read {
+        use super::*;
+
+        #[test]
+        #[should_panic]
+        fn run_violation() {
+            let world = World::new();
+            let query = query!(world, &Foo).build();
+            system!(world, &mut Foo).run(move |iter| {
+                query.run(|iter| {
+                    iter.fini();
+                });
+                iter.fini();
+            });
+            world.progress();
+        }
+
+        #[test]
+        #[should_panic]
+        fn each_violation() {
+            let world = World::new();
+            let query = query!(world, &Foo).build();
+            system!(world, &mut Foo).each(move |_| {
+                query.each(|_| {});
+            });
+            world.progress();
+        }
+
+        #[test]
+        #[should_panic]
+        fn each_entity_violation() {
+            let world = World::new();
+            let query = query!(world, &Foo).build();
+            system!(world, &mut Foo).each_entity(move |_, _| {
+                query.each_entity(|_, _| {});
+            });
+            world.progress();
+        }
+
+        #[test]
+        #[should_panic]
+        fn each_iter_violation() {
+            let world = World::new();
+            let query = query!(world, &Foo).build();
+            system!(world, &mut Foo).each_iter(move |_, _, _| {
+                query.each_iter(|_, _, _| {});
+            });
+            world.progress();
+        }
+    }
+
+    mod write_write {
+        use super::*;
+
+        #[test]
+        #[should_panic]
+        fn run_violation() {
+            let world = World::new();
+            let query = query!(world, &mut Foo).build();
+            system!(world, &mut Foo).run(move |iter| {
+                query.run(|iter| {
+                    iter.fini();
+                });
+                iter.fini();
+            });
+            world.progress();
+        }
+
+        #[test]
+        #[should_panic]
+        fn each_violation() {
+            let world = World::new();
+            let query = query!(world, &mut Foo).build();
+            system!(world, &mut Foo).each(move |_| {
+                query.each(|_| {});
+            });
+            world.progress();
+        }
+
+        #[test]
+        #[should_panic]
+        fn each_entity_violation() {
+            let world = World::new();
+            let query = query!(world, &mut Foo).build();
+            system!(world, &mut Foo).each_entity(move |_, _| {
+                query.each_entity(|_, _| {});
+            });
+            world.progress();
+        }
+
+        #[test]
+        #[should_panic]
+        fn each_iter_violation() {
+            let world = World::new();
+            let query = query!(world, &mut Foo).build();
+            system!(world, &mut Foo).each_iter(move |_, _, _| {
+                query.each_iter(|_, _, _| {});
+            });
+            world.progress();
+        }
+    }
+}

--- a/flecs_ecs/tests/flecs/safety/mod.rs
+++ b/flecs_ecs/tests/flecs/safety/mod.rs
@@ -2,20 +2,19 @@
 use flecs_ecs::core::*;
 use flecs_ecs::macros::*;
 
+mod pairs;
+
 #[derive(Clone, Component)]
 struct Foo(u8);
 
 #[derive(Component)]
-struct Bar(u8);
+struct Bar;
 
 #[derive(Component)]
-struct Event;
+struct EventA;
 
 #[derive(Component)]
-struct A;
-
-#[derive(Component)]
-struct B;
+struct EventB;
 
 #[test]
 fn building_conflicting_queries_no_violations() {
@@ -703,14 +702,14 @@ mod observer_in_observer {
         fn run_violation() {
             let world = World::new();
             let e = world.entity().set(Foo(0)).id();
-            observer!(world, A, &Foo).run(|iter| {
+            observer!(world, EventA, &Foo).run(|iter| {
                 iter.fini();
             });
-            observer!(world, B, &mut Foo).run(move |iter| {
-                iter.world().event().add::<Foo>().entity(e).emit(&A);
+            observer!(world, EventB, &mut Foo).run(move |iter| {
+                iter.world().event().add::<Foo>().entity(e).emit(&EventA);
                 iter.fini();
             });
-            world.event().add::<Foo>().entity(e).emit(&B);
+            world.event().add::<Foo>().entity(e).emit(&EventB);
         }
 
         #[test]
@@ -718,11 +717,11 @@ mod observer_in_observer {
         fn each_entity_violation() {
             let world = World::new();
             let e = world.entity().set(Foo(0)).id();
-            observer!(world, A, &Foo).each_entity(|_, _| {});
-            observer!(world, B, &mut Foo).each_entity(move |entity, _| {
-                entity.world().event().add::<Foo>().entity(e).emit(&A);
+            observer!(world, EventA, &Foo).each_entity(|_, _| {});
+            observer!(world, EventB, &mut Foo).each_entity(move |entity, _| {
+                entity.world().event().add::<Foo>().entity(e).emit(&EventA);
             });
-            world.event().add::<Foo>().entity(e).emit(&B);
+            world.event().add::<Foo>().entity(e).emit(&EventB);
         }
 
         #[test]
@@ -730,11 +729,11 @@ mod observer_in_observer {
         fn each_iter_violation() {
             let world = World::new();
             let e = world.entity().set(Foo(0)).id();
-            observer!(world, A, &Foo).each_iter(|_, _, _| {});
-            observer!(world, B, &mut Foo).each_iter(move |iter, _, _| {
-                iter.world().event().add::<Foo>().entity(e).emit(&A);
+            observer!(world, EventA, &Foo).each_iter(|_, _, _| {});
+            observer!(world, EventB, &mut Foo).each_iter(move |iter, _, _| {
+                iter.world().event().add::<Foo>().entity(e).emit(&EventA);
             });
-            world.event().add::<Foo>().entity(e).emit(&B);
+            world.event().add::<Foo>().entity(e).emit(&EventB);
         }
     }
 
@@ -746,14 +745,14 @@ mod observer_in_observer {
         fn run_violation() {
             let world = World::new();
             let e = world.entity().set(Foo(0)).id();
-            observer!(world, A, &mut Foo).run(|iter| {
+            observer!(world, EventA, &mut Foo).run(|iter| {
                 iter.fini();
             });
-            observer!(world, B, &Foo).run(move |iter| {
-                iter.world().event().add::<Foo>().entity(e).emit(&A);
+            observer!(world, EventB, &Foo).run(move |iter| {
+                iter.world().event().add::<Foo>().entity(e).emit(&EventA);
                 iter.fini();
             });
-            world.event().add::<Foo>().entity(e).emit(&B);
+            world.event().add::<Foo>().entity(e).emit(&EventB);
         }
 
         #[test]
@@ -761,11 +760,11 @@ mod observer_in_observer {
         fn each_entity_violation() {
             let world = World::new();
             let e = world.entity().set(Foo(0)).id();
-            observer!(world, A, &mut Foo).each_entity(|_, _| {});
-            observer!(world, B, &Foo).each_entity(move |entity, _| {
-                entity.world().event().add::<Foo>().entity(e).emit(&A);
+            observer!(world, EventA, &mut Foo).each_entity(|_, _| {});
+            observer!(world, EventB, &Foo).each_entity(move |entity, _| {
+                entity.world().event().add::<Foo>().entity(e).emit(&EventA);
             });
-            world.event().add::<Foo>().entity(e).emit(&B);
+            world.event().add::<Foo>().entity(e).emit(&EventB);
         }
 
         #[test]
@@ -773,11 +772,11 @@ mod observer_in_observer {
         fn each_iter_violation() {
             let world = World::new();
             let e = world.entity().set(Foo(0)).id();
-            observer!(world, A, &mut Foo).each_iter(|_, _, _| {});
-            observer!(world, B, &Foo).each_iter(move |iter, _, _| {
-                iter.world().event().add::<Foo>().entity(e).emit(&A);
+            observer!(world, EventA, &mut Foo).each_iter(|_, _, _| {});
+            observer!(world, EventB, &Foo).each_iter(move |iter, _, _| {
+                iter.world().event().add::<Foo>().entity(e).emit(&EventA);
             });
-            world.event().add::<Foo>().entity(e).emit(&B);
+            world.event().add::<Foo>().entity(e).emit(&EventB);
         }
     }
 
@@ -789,14 +788,14 @@ mod observer_in_observer {
         fn run_violation() {
             let world = World::new();
             let e = world.entity().set(Foo(0)).id();
-            observer!(world, A, &mut Foo).run(|iter| {
+            observer!(world, EventA, &mut Foo).run(|iter| {
                 iter.fini();
             });
-            observer!(world, B, &mut Foo).run(move |iter| {
-                iter.world().event().add::<Foo>().entity(e).emit(&A);
+            observer!(world, EventB, &mut Foo).run(move |iter| {
+                iter.world().event().add::<Foo>().entity(e).emit(&EventA);
                 iter.fini();
             });
-            world.event().add::<Foo>().entity(e).emit(&B);
+            world.event().add::<Foo>().entity(e).emit(&EventB);
         }
 
         #[test]
@@ -804,11 +803,11 @@ mod observer_in_observer {
         fn each_entity_violation() {
             let world = World::new();
             let e = world.entity().set(Foo(0)).id();
-            observer!(world, A, &mut Foo).each_entity(|_, _| {});
-            observer!(world, B, &mut Foo).each_entity(move |entity, _| {
-                entity.world().event().add::<Foo>().entity(e).emit(&A);
+            observer!(world, EventA, &mut Foo).each_entity(|_, _| {});
+            observer!(world, EventB, &mut Foo).each_entity(move |entity, _| {
+                entity.world().event().add::<Foo>().entity(e).emit(&EventA);
             });
-            world.event().add::<Foo>().entity(e).emit(&B);
+            world.event().add::<Foo>().entity(e).emit(&EventB);
         }
 
         #[test]
@@ -816,11 +815,11 @@ mod observer_in_observer {
         fn each_iter_violation() {
             let world = World::new();
             let e = world.entity().set(Foo(0)).id();
-            observer!(world, A, &mut Foo).each_iter(|_, _, _| {});
-            observer!(world, B, &mut Foo).each_iter(move |iter, _, _| {
-                iter.world().event().add::<Foo>().entity(e).emit(&A);
+            observer!(world, EventA, &mut Foo).each_iter(|_, _, _| {});
+            observer!(world, EventB, &mut Foo).each_iter(move |iter, _, _| {
+                iter.world().event().add::<Foo>().entity(e).emit(&EventA);
             });
-            world.event().add::<Foo>().entity(e).emit(&B);
+            world.event().add::<Foo>().entity(e).emit(&EventB);
         }
     }
 }
@@ -1162,9 +1161,9 @@ mod observer_in_system {
         fn run_violation() {
             let world = World::new();
             world.entity().set(Foo(0));
-            observer!(world, Event, &mut Foo).each(|_| {});
+            observer!(world, EventA, &mut Foo).each(|_| {});
             system!(world, &Foo).run(move |iter| {
-                iter.entity(0).emit(&Event);
+                iter.entity(0).emit(&EventA);
                 iter.fini();
             });
             world.progress();
@@ -1175,9 +1174,9 @@ mod observer_in_system {
         fn each_entity_violation() {
             let world = World::new();
             world.entity().set(Foo(0));
-            observer!(world, Event, &mut Foo).each(|_| {});
+            observer!(world, EventA, &mut Foo).each(|_| {});
             system!(world, &Foo).each_entity(move |entity, _| {
-                entity.emit(&Event);
+                entity.emit(&EventA);
             });
             world.progress();
         }
@@ -1187,9 +1186,9 @@ mod observer_in_system {
         fn each_iter_violation() {
             let world = World::new();
             world.entity().set(Foo(0));
-            observer!(world, Event, &mut Foo).each(|_| {});
+            observer!(world, EventA, &mut Foo).each(|_| {});
             system!(world, &Foo).each_iter(move |iter, _, _| {
-                iter.entity(0).emit(&Event);
+                iter.entity(0).emit(&EventA);
             });
             world.progress();
         }
@@ -1203,9 +1202,9 @@ mod observer_in_system {
         fn run_violation() {
             let world = World::new();
             world.entity().set(Foo(0));
-            observer!(world, Event, &Foo).each(|_| {});
+            observer!(world, EventA, &Foo).each(|_| {});
             system!(world, &mut Foo).run(move |iter| {
-                iter.entity(0).emit(&Event);
+                iter.entity(0).emit(&EventA);
                 iter.fini();
             });
             world.progress();
@@ -1216,9 +1215,9 @@ mod observer_in_system {
         fn each_entity_violation() {
             let world = World::new();
             world.entity().set(Foo(0));
-            observer!(world, Event, &Foo).each(|_| {});
+            observer!(world, EventA, &Foo).each(|_| {});
             system!(world, &mut Foo).each_entity(move |entity, _| {
-                entity.emit(&Event);
+                entity.emit(&EventA);
             });
             world.progress();
         }
@@ -1228,9 +1227,9 @@ mod observer_in_system {
         fn each_iter_violation() {
             let world = World::new();
             world.entity().set(Foo(0));
-            observer!(world, Event, &Foo).each(|_| {});
+            observer!(world, EventA, &Foo).each(|_| {});
             system!(world, &mut Foo).each_iter(move |iter, _, _| {
-                iter.entity(0).emit(&Event);
+                iter.entity(0).emit(&EventA);
             });
             world.progress();
         }
@@ -1244,9 +1243,9 @@ mod observer_in_system {
         fn run_violation() {
             let world = World::new();
             world.entity().set(Foo(0));
-            observer!(world, Event, &mut Foo).each(|_| {});
+            observer!(world, EventA, &mut Foo).each(|_| {});
             system!(world, &mut Foo).run(move |iter| {
-                iter.entity(0).emit(&Event);
+                iter.entity(0).emit(&EventA);
                 iter.fini();
             });
             world.progress();
@@ -1257,9 +1256,9 @@ mod observer_in_system {
         fn each_entity_violation() {
             let world = World::new();
             world.entity().set(Foo(0));
-            observer!(world, Event, &mut Foo).each(|_| {});
+            observer!(world, EventA, &mut Foo).each(|_| {});
             system!(world, &mut Foo).each_entity(move |entity, _| {
-                entity.emit(&Event);
+                entity.emit(&EventA);
             });
             world.progress();
         }
@@ -1269,9 +1268,9 @@ mod observer_in_system {
         fn each_iter_violation() {
             let world = World::new();
             world.entity().set(Foo(0));
-            observer!(world, Event, &mut Foo).each(|_| {});
+            observer!(world, EventA, &mut Foo).each(|_| {});
             system!(world, &mut Foo).each_iter(move |iter, _, _| {
-                iter.entity(0).emit(&Event);
+                iter.entity(0).emit(&EventA);
             });
             world.progress();
         }

--- a/flecs_ecs/tests/flecs/safety/pairs.rs
+++ b/flecs_ecs/tests/flecs/safety/pairs.rs
@@ -1,0 +1,685 @@
+use super::*;
+
+mod wildcard_into_id {
+    use super::*;
+
+    mod entity_view {
+        use super::*;
+
+        fn read_read() {
+            let world = World::new();
+            let bar_id = world.component::<Bar>().id();
+            let entity = world.entity().set_first(Foo(0), bar_id);
+            entity.get::<&(Foo, flecs::Wildcard)>(|_| {
+                entity.get::<&(Foo, Bar)>(|_| {});
+            });
+        }
+
+        fn read_write() {
+            let world = World::new();
+            let bar_id = world.component::<Bar>().id();
+            let entity = world.entity().set_first(Foo(0), bar_id);
+            entity.get::<&(Foo, flecs::Wildcard)>(|_| {
+                entity.get::<&mut (Foo, Bar)>(|_| {});
+            });
+        }
+
+        fn write_read() {
+            let world = World::new();
+            let bar_id = world.component::<Bar>().id();
+            let entity = world.entity().set_first(Foo(0), bar_id);
+            entity.get::<&mut (Foo, flecs::Wildcard)>(|_| {
+                entity.get::<&(Foo, Bar)>(|_| {});
+            });
+        }
+
+        fn write_cloned() {
+            let world = World::new();
+            let bar_id = world.component::<Bar>().id();
+            let entity = world.entity().set_first(Foo(0), bar_id);
+            entity.get::<&mut (Foo, flecs::Wildcard)>(|_| {
+                let _ = entity.cloned::<&(Foo, Bar)>();
+            });
+        }
+
+        fn write_write() {
+            let world = World::new();
+            let bar_id = world.component::<Bar>().id();
+            let entity = world.entity().set_first(Foo(0), bar_id);
+            entity.get::<&mut (Foo, flecs::Wildcard)>(|_| {
+                entity.get::<&mut (Foo, Bar)>(|_| {});
+            });
+        }
+    }
+
+    mod query_in_query {
+        use super::*;
+
+        mod read_read {
+            use super::*;
+
+            #[test]
+            fn run() {
+                let world = World::new();
+                let bar_id = world.component::<Bar>().id();
+                world.entity().set_first(Foo(0), bar_id);
+                let q0 = query!(world, &(Foo, flecs::Wildcard)).build();
+                let q1 = query!(world, &(Foo, Bar)).build();
+                q0.run(|iter| {
+                    q1.run(|iter| {
+                        iter.fini();
+                    });
+                    iter.fini();
+                });
+            }
+
+            #[test]
+            fn each() {
+                let world = World::new();
+                let bar_id = world.component::<Bar>().id();
+                world.entity().set_first(Foo(0), bar_id);
+                let q0 = query!(world, &(Foo, flecs::Wildcard)).build();
+                let q1 = query!(world, &(Foo, Bar)).build();
+                q0.each(|_| {
+                    q1.each(|_| {});
+                });
+            }
+
+            #[test]
+            fn each_entity() {
+                let world = World::new();
+                let bar_id = world.component::<Bar>().id();
+                world.entity().set_first(Foo(0), bar_id);
+                let q0 = query!(world, &(Foo, flecs::Wildcard)).build();
+                let q1 = query!(world, &(Foo, Bar)).build();
+                q0.each_entity(|_, _| {
+                    q1.each_entity(|_, _| {});
+                });
+            }
+
+            #[test]
+            fn each_iter() {
+                let world = World::new();
+                let bar_id = world.component::<Bar>().id();
+                world.entity().set_first(Foo(0), bar_id);
+                let q0 = query!(world, &(Foo, flecs::Wildcard)).build();
+                let q1 = query!(world, &(Foo, Bar)).build();
+                q0.each_iter(|_, _, _| {
+                    q1.each_iter(|_, _, _| {});
+                });
+            }
+        }
+
+        mod read_write {
+            use super::*;
+
+            #[test]
+            #[should_panic]
+            fn run() {
+                let world = World::new();
+                let bar_id = world.component::<Bar>().id();
+                world.entity().set_first(Foo(0), bar_id);
+                let q0 = query!(world, &(Foo, flecs::Wildcard)).build();
+                let q1 = query!(world, &mut (Foo, Bar)).build();
+                q0.run(|iter| {
+                    q1.run(|iter| {
+                        iter.fini();
+                    });
+                    iter.fini();
+                });
+            }
+
+            #[test]
+            #[should_panic]
+            fn each() {
+                let world = World::new();
+                let bar_id = world.component::<Bar>().id();
+                world.entity().set_first(Foo(0), bar_id);
+                let q0 = query!(world, &(Foo, flecs::Wildcard)).build();
+                let q1 = query!(world, &mut (Foo, Bar)).build();
+                q0.each(|_| {
+                    q1.each(|_| {});
+                });
+            }
+
+            #[test]
+            #[should_panic]
+            fn each_entity() {
+                let world = World::new();
+                let bar_id = world.component::<Bar>().id();
+                world.entity().set_first(Foo(0), bar_id);
+                let q0 = query!(world, &(Foo, flecs::Wildcard)).build();
+                let q1 = query!(world, &mut (Foo, Bar)).build();
+                q0.each_entity(|_, _| {
+                    q1.each_entity(|_, _| {});
+                });
+            }
+
+            #[test]
+            #[should_panic]
+            fn each_iter() {
+                let world = World::new();
+                let bar_id = world.component::<Bar>().id();
+                world.entity().set_first(Foo(0), bar_id);
+                let q0 = query!(world, &(Foo, flecs::Wildcard)).build();
+                let q1 = query!(world, &mut (Foo, Bar)).build();
+                q0.each_iter(|_, _, _| {
+                    q1.each_iter(|_, _, _| {});
+                });
+            }
+        }
+
+        mod write_read {
+            use super::*;
+
+            #[test]
+            #[should_panic]
+            fn run() {
+                let world = World::new();
+                let bar_id = world.component::<Bar>().id();
+                world.entity().set_first(Foo(0), bar_id);
+                let q0 = query!(world, &mut (Foo, flecs::Wildcard)).build();
+                let q1 = query!(world, &(Foo, Bar)).build();
+                q0.run(|iter| {
+                    q1.run(|iter| {
+                        iter.fini();
+                    });
+                    iter.fini();
+                });
+            }
+
+            #[test]
+            #[should_panic]
+            fn each() {
+                let world = World::new();
+                let bar_id = world.component::<Bar>().id();
+                world.entity().set_first(Foo(0), bar_id);
+                let q0 = query!(world, &mut (Foo, flecs::Wildcard)).build();
+                let q1 = query!(world, &(Foo, Bar)).build();
+                q0.each(|_| {
+                    q1.each(|_| {});
+                });
+            }
+
+            #[test]
+            #[should_panic]
+            fn each_entity() {
+                let world = World::new();
+                let bar_id = world.component::<Bar>().id();
+                world.entity().set_first(Foo(0), bar_id);
+                let q0 = query!(world, &mut (Foo, flecs::Wildcard)).build();
+                let q1 = query!(world, &(Foo, Bar)).build();
+                q0.each_entity(|_, _| {
+                    q1.each_entity(|_, _| {});
+                });
+            }
+
+            #[test]
+            #[should_panic]
+            fn each_iter() {
+                let world = World::new();
+                let bar_id = world.component::<Bar>().id();
+                world.entity().set_first(Foo(0), bar_id);
+                let q0 = query!(world, &mut (Foo, flecs::Wildcard)).build();
+                let q1 = query!(world, &(Foo, Bar)).build();
+                q0.each_iter(|_, _, _| {
+                    q1.each_iter(|_, _, _| {});
+                });
+            }
+        }
+
+        mod write_write {
+            use super::*;
+
+            #[test]
+            #[should_panic]
+            fn run() {
+                let world = World::new();
+                let bar_id = world.component::<Bar>().id();
+                world.entity().set_first(Foo(0), bar_id);
+                let q0 = query!(world, &mut (Foo, flecs::Wildcard)).build();
+                let q1 = query!(world, &mut (Foo, Bar)).build();
+                q0.run(|iter| {
+                    q1.run(|iter| {
+                        iter.fini();
+                    });
+                    iter.fini();
+                });
+            }
+
+            #[test]
+            #[should_panic]
+            fn each() {
+                let world = World::new();
+                let bar_id = world.component::<Bar>().id();
+                world.entity().set_first(Foo(0), bar_id);
+                let q0 = query!(world, &mut (Foo, flecs::Wildcard)).build();
+                let q1 = query!(world, &mut (Foo, Bar)).build();
+                q0.each(|_| {
+                    q1.each(|_| {});
+                });
+            }
+
+            #[test]
+            #[should_panic]
+            fn each_entity() {
+                let world = World::new();
+                let bar_id = world.component::<Bar>().id();
+                world.entity().set_first(Foo(0), bar_id);
+                let q0 = query!(world, &mut (Foo, flecs::Wildcard)).build();
+                let q1 = query!(world, &mut (Foo, Bar)).build();
+                q0.each_entity(|_, _| {
+                    q1.each_entity(|_, _| {});
+                });
+            }
+
+            #[test]
+            #[should_panic]
+            fn each_iter() {
+                let world = World::new();
+                let bar_id = world.component::<Bar>().id();
+                world.entity().set_first(Foo(0), bar_id);
+                let q0 = query!(world, &mut (Foo, flecs::Wildcard)).build();
+                let q1 = query!(world, &mut (Foo, Bar)).build();
+                q0.each_iter(|_, _, _| {
+                    q1.each_iter(|_, _, _| {});
+                });
+            }
+        }
+    }
+
+    mod query_entity_view {
+        use super::*;
+
+        #[test]
+        fn read_read() {
+            let world = World::new();
+            let bar_id = world.component::<Bar>().id();
+            world.entity().set_first(Foo(0), bar_id);
+            query!(world, &(Foo, flecs::Wildcard))
+                .build()
+                .each_entity(|entity, _| {
+                    entity.get::<&(Foo, Bar)>(|_| {});
+                });
+        }
+
+        #[test]
+        #[should_panic]
+        fn read_write() {
+            let world = World::new();
+            let bar_id = world.component::<Bar>().id();
+            world.entity().set_first(Foo(0), bar_id);
+            query!(world, &(Foo, flecs::Wildcard))
+                .build()
+                .each_entity(|entity, _| {
+                    entity.get::<&mut (Foo, Bar)>(|_| {});
+                });
+        }
+
+        #[test]
+        #[should_panic]
+        fn write_read() {
+            let world = World::new();
+            let bar_id = world.component::<Bar>().id();
+            world.entity().set_first(Foo(0), bar_id);
+            query!(world, &mut (Foo, flecs::Wildcard))
+                .build()
+                .each_entity(|entity, _| {
+                    entity.get::<&(Foo, Bar)>(|_| {});
+                });
+        }
+
+        #[test]
+        #[should_panic]
+        fn write_write() {
+            let world = World::new();
+            let bar_id = world.component::<Bar>().id();
+            world.entity().set_first(Foo(0), bar_id);
+            query!(world, &mut (Foo, flecs::Wildcard))
+                .build()
+                .each_entity(|entity, _| {
+                    entity.get::<&mut (Foo, Bar)>(|_| {});
+                });
+        }
+    }
+}
+
+mod id_into_wildcard {
+    use super::*;
+
+    mod entity_view {
+        use super::*;
+
+        fn read_read() {
+            let world = World::new();
+            let bar_id = world.component::<Bar>().id();
+            let entity = world.entity().set_first(Foo(0), bar_id);
+            entity.get::<&(Foo, Bar)>(|_| {
+                entity.get::<&(Foo, flecs::Wildcard)>(|_| {});
+            });
+        }
+
+        fn read_write() {
+            let world = World::new();
+            let bar_id = world.component::<Bar>().id();
+            let entity = world.entity().set_first(Foo(0), bar_id);
+            entity.get::<&(Foo, Bar)>(|_| {
+                entity.get::<&mut (Foo, flecs::Wildcard)>(|_| {});
+            });
+        }
+
+        fn write_read() {
+            let world = World::new();
+            let bar_id = world.component::<Bar>().id();
+            let entity = world.entity().set_first(Foo(0), bar_id);
+            entity.get::<&mut (Foo, Bar)>(|_| {
+                entity.get::<&(Foo, flecs::Wildcard)>(|_| {});
+            });
+        }
+
+        fn write_cloned() {
+            let world = World::new();
+            let bar_id = world.component::<Bar>().id();
+            let entity = world.entity().set_first(Foo(0), bar_id);
+            entity.get::<&mut (Foo, Bar)>(|_| {
+                let _ = entity.cloned::<&(Foo, flecs::Wildcard)>();
+            });
+        }
+
+        fn write_write() {
+            let world = World::new();
+            let bar_id = world.component::<Bar>().id();
+            let entity = world.entity().set_first(Foo(0), bar_id);
+            entity.get::<&mut (Foo, Bar)>(|_| {
+                entity.get::<&mut (Foo, flecs::Wildcard)>(|_| {});
+            });
+        }
+    }
+
+    mod query_in_query {
+        use super::*;
+
+        mod read_read {
+            use super::*;
+
+            #[test]
+            fn run() {
+                let world = World::new();
+                let bar_id = world.component::<Bar>().id();
+                world.entity().set_first(Foo(0), bar_id);
+                let q0 = query!(world, &(Foo, Bar)).build();
+                let q1 = query!(world, &(Foo, flecs::Wildcard)).build();
+                q0.run(|iter| {
+                    q1.run(|iter| {
+                        iter.fini();
+                    });
+                    iter.fini();
+                });
+            }
+
+            #[test]
+            fn each() {
+                let world = World::new();
+                let bar_id = world.component::<Bar>().id();
+                world.entity().set_first(Foo(0), bar_id);
+                let q0 = query!(world, &(Foo, Bar)).build();
+                let q1 = query!(world, &(Foo, flecs::Wildcard)).build();
+                q0.each(|_| {
+                    q1.each(|_| {});
+                });
+            }
+
+            #[test]
+            fn each_entity() {
+                let world = World::new();
+                let bar_id = world.component::<Bar>().id();
+                world.entity().set_first(Foo(0), bar_id);
+                let q0 = query!(world, &(Foo, Bar)).build();
+                let q1 = query!(world, &(Foo, flecs::Wildcard)).build();
+                q0.each_entity(|_, _| {
+                    q1.each_entity(|_, _| {});
+                });
+            }
+
+            #[test]
+            fn each_iter() {
+                let world = World::new();
+                let bar_id = world.component::<Bar>().id();
+                world.entity().set_first(Foo(0), bar_id);
+                let q0 = query!(world, &(Foo, Bar)).build();
+                let q1 = query!(world, &(Foo, flecs::Wildcard)).build();
+                q0.each_iter(|_, _, _| {
+                    q1.each_iter(|_, _, _| {});
+                });
+            }
+        }
+
+        mod read_write {
+            use super::*;
+
+            #[test]
+            #[should_panic]
+            fn run() {
+                let world = World::new();
+                let bar_id = world.component::<Bar>().id();
+                world.entity().set_first(Foo(0), bar_id);
+                let q0 = query!(world, &(Foo, Bar)).build();
+                let q1 = query!(world, &mut (Foo, flecs::Wildcard)).build();
+                q0.run(|iter| {
+                    q1.run(|iter| {
+                        iter.fini();
+                    });
+                    iter.fini();
+                });
+            }
+
+            #[test]
+            #[should_panic]
+            fn each() {
+                let world = World::new();
+                let bar_id = world.component::<Bar>().id();
+                world.entity().set_first(Foo(0), bar_id);
+                let q0 = query!(world, &(Foo, Bar)).build();
+                let q1 = query!(world, &mut (Foo, flecs::Wildcard)).build();
+                q0.each(|_| {
+                    q1.each(|_| {});
+                });
+            }
+
+            #[test]
+            #[should_panic]
+            fn each_entity() {
+                let world = World::new();
+                let bar_id = world.component::<Bar>().id();
+                world.entity().set_first(Foo(0), bar_id);
+                let q0 = query!(world, &(Foo, Bar)).build();
+                let q1 = query!(world, &mut (Foo, flecs::Wildcard)).build();
+                q0.each_entity(|_, _| {
+                    q1.each_entity(|_, _| {});
+                });
+            }
+
+            #[test]
+            #[should_panic]
+            fn each_iter() {
+                let world = World::new();
+                let bar_id = world.component::<Bar>().id();
+                world.entity().set_first(Foo(0), bar_id);
+                let q0 = query!(world, &(Foo, Bar)).build();
+                let q1 = query!(world, &mut (Foo, flecs::Wildcard)).build();
+                q0.each_iter(|_, _, _| {
+                    q1.each_iter(|_, _, _| {});
+                });
+            }
+        }
+
+        mod write_read {
+            use super::*;
+
+            #[test]
+            #[should_panic]
+            fn run() {
+                let world = World::new();
+                let bar_id = world.component::<Bar>().id();
+                world.entity().set_first(Foo(0), bar_id);
+                let q0 = query!(world, &mut (Foo, Bar)).build();
+                let q1 = query!(world, &(Foo, flecs::Wildcard)).build();
+                q0.run(|iter| {
+                    q1.run(|iter| {
+                        iter.fini();
+                    });
+                    iter.fini();
+                });
+            }
+
+            #[test]
+            #[should_panic]
+            fn each() {
+                let world = World::new();
+                let bar_id = world.component::<Bar>().id();
+                world.entity().set_first(Foo(0), bar_id);
+                let q0 = query!(world, &mut (Foo, Bar)).build();
+                let q1 = query!(world, &(Foo, flecs::Wildcard)).build();
+                q0.each(|_| {
+                    q1.each(|_| {});
+                });
+            }
+
+            #[test]
+            #[should_panic]
+            fn each_entity() {
+                let world = World::new();
+                let bar_id = world.component::<Bar>().id();
+                world.entity().set_first(Foo(0), bar_id);
+                let q0 = query!(world, &mut (Foo, Bar)).build();
+                let q1 = query!(world, &(Foo, flecs::Wildcard)).build();
+                q0.each_entity(|_, _| {
+                    q1.each_entity(|_, _| {});
+                });
+            }
+
+            #[test]
+            #[should_panic]
+            fn each_iter() {
+                let world = World::new();
+                let bar_id = world.component::<Bar>().id();
+                world.entity().set_first(Foo(0), bar_id);
+                let q0 = query!(world, &mut (Foo, Bar)).build();
+                let q1 = query!(world, &(Foo, flecs::Wildcard)).build();
+                q0.each_iter(|_, _, _| {
+                    q1.each_iter(|_, _, _| {});
+                });
+            }
+        }
+
+        mod write_write {
+            use super::*;
+
+            #[test]
+            #[should_panic]
+            fn run() {
+                let world = World::new();
+                let bar_id = world.component::<Bar>().id();
+                world.entity().set_first(Foo(0), bar_id);
+                let q0 = query!(world, &mut (Foo, Bar)).build();
+                let q1 = query!(world, &mut (Foo, flecs::Wildcard)).build();
+                q0.run(|iter| {
+                    q1.run(|iter| {
+                        iter.fini();
+                    });
+                    iter.fini();
+                });
+            }
+
+            #[test]
+            #[should_panic]
+            fn each() {
+                let world = World::new();
+                let bar_id = world.component::<Bar>().id();
+                world.entity().set_first(Foo(0), bar_id);
+                let q0 = query!(world, &mut (Foo, Bar)).build();
+                let q1 = query!(world, &mut (Foo, flecs::Wildcard)).build();
+                q0.each(|_| {
+                    q1.each(|_| {});
+                });
+            }
+
+            #[test]
+            #[should_panic]
+            fn each_entity() {
+                let world = World::new();
+                let bar_id = world.component::<Bar>().id();
+                world.entity().set_first(Foo(0), bar_id);
+                let q0 = query!(world, &mut (Foo, Bar)).build();
+                let q1 = query!(world, &mut (Foo, flecs::Wildcard)).build();
+                q0.each_entity(|_, _| {
+                    q1.each_entity(|_, _| {});
+                });
+            }
+
+            #[test]
+            #[should_panic]
+            fn each_iter() {
+                let world = World::new();
+                let bar_id = world.component::<Bar>().id();
+                world.entity().set_first(Foo(0), bar_id);
+                let q0 = query!(world, &mut (Foo, Bar)).build();
+                let q1 = query!(world, &mut (Foo, flecs::Wildcard)).build();
+                q0.each_iter(|_, _, _| {
+                    q1.each_iter(|_, _, _| {});
+                });
+            }
+        }
+    }
+
+    mod query_entity_view {
+        use super::*;
+
+        #[test]
+        fn read_read() {
+            let world = World::new();
+            let bar_id = world.component::<Bar>().id();
+            world.entity().set_first(Foo(0), bar_id);
+            query!(world, &(Foo, Bar)).build().each_entity(|entity, _| {
+                entity.get::<&(Foo, flecs::Wildcard)>(|_| {});
+            });
+        }
+
+        #[test]
+        #[should_panic]
+        fn read_write() {
+            let world = World::new();
+            let bar_id = world.component::<Bar>().id();
+            world.entity().set_first(Foo(0), bar_id);
+            query!(world, &(Foo, Bar)).build().each_entity(|entity, _| {
+                entity.get::<&mut (Foo, flecs::Wildcard)>(|_| {});
+            });
+        }
+
+        #[test]
+        #[should_panic]
+        fn write_read() {
+            let world = World::new();
+            let bar_id = world.component::<Bar>().id();
+            world.entity().set_first(Foo(0), bar_id);
+            query!(world, &mut (Foo, Bar))
+                .build()
+                .each_entity(|entity, _| {
+                    entity.get::<&(Foo, flecs::Wildcard)>(|_| {});
+                });
+        }
+
+        #[test]
+        #[should_panic]
+        fn write_write() {
+            let world = World::new();
+            let bar_id = world.component::<Bar>().id();
+            world.entity().set_first(Foo(0), bar_id);
+            query!(world, &mut (Foo, Bar))
+                .build()
+                .each_entity(|entity, _| {
+                    entity.get::<&mut (Foo, flecs::Wildcard)>(|_| {});
+                });
+        }
+    }
+}


### PR DESCRIPTION
### Follow up work:
Right now queries can have signatures like `&mut Foo, &Foo` or `&mut Foo, &mut Foo`. This becomes a problem with multi source queries & self multiplying queries like `&mut Foo($x), &mut Foo($y)` that might have 1 variable unset. To address this a new feature & breaking changes have to be added that prevents queries, systems, observers, etc from having multiple of the same component in their signature if any one of them is a writer. Then we can do something like force the user to go through `iter`. Example pseudo code:
```rs
world.query::<()>()
    .with::<&mut Foo>().set_src_name("x")
    .with::<&mut Foo>().set_src_name("y")
    .each_iter(|iter, _, _| {
        // Will give `Ok` for the first instance of an entity & `Err` for any instance after
        let [Ok(a), Ok(b)] = iter.get::<&mut Foo>(["x", "y"]) else {
            return
        };
    });
```