### PR TITLE
Breaking change: feat(API): merge typed and id, pair, name API

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ fn main() {
         .entity_named("Bob")
         .set(Position { x: 0.0, y: 0.0 })
         .set(Velocity { x: 1.0, y: 2.0 })
-        .add::<(Eats, Apples)>();
+        .add((id::<Eats>(), id::<Apples>()));
 
     // Show us what you got
     println!("{}'s got [{:?}]", bob.name(), bob.archetype());
@@ -172,7 +172,7 @@ Some of the features that make Flecs stand out are:
     * [Builder API]
     ```rust
     world.system::<&A>()
-    .with::<B>()
+    .with(id::<B>())
     .each(|| { });
     ```
     * [DSL API]

--- a/flecs_ecs/README.md
+++ b/flecs_ecs/README.md
@@ -131,7 +131,7 @@ fn main() {
         .entity_named("Bob")
         .set(Position { x: 0.0, y: 0.0 })
         .set(Velocity { x: 1.0, y: 2.0 })
-        .add::<(Eats, Apples)>();
+        .add((id::<Eats>(), id::<Apples>()));
 
     // Show us what you got
     println!("{}'s got [{:?}]", bob.name(), bob.archetype());
@@ -172,7 +172,7 @@ Some of the features that make Flecs stand out are:
     * [Builder API]
     ```rust
     world.system::<&A>()
-    .with::<B>()
+    .with(id::<B>())
     .each(|| { });
     ```
     * [DSL API]

--- a/flecs_ecs/doc/flecs/src/quickstart.md
+++ b/flecs_ecs/doc/flecs/src/quickstart.md
@@ -88,7 +88,7 @@ let e = world.entity();
 // Add a component. This creates the component in the ECS storage, but does not
 // assign it with a value. To add a component, it needs to be derived with the
 // Default trait otherwise it will panic at compile time.
-e.add::<Velocity>();
+e.add(id::<Velocity>());
 
 // Set the value for the Position & Velocity components. A component will be
 // added if the entity doesn't have it yet.
@@ -101,7 +101,7 @@ e.get::<&Position>(|p| {
 });
 
 // Remove component
-e.remove::<Position>();
+e.remove(id::<Position>());
 # }
 ```
 
@@ -123,7 +123,7 @@ let pos_e = world.entity_from::<Position>();
 println!("Name: {}", pos_e.name()); // outputs 'Name: Position'
 
 // It's possible to add components like you would for any entity
-pos_e.add::<Serializable>();
+pos_e.add(id::<Serializable>());
 # }
 ```
 
@@ -162,21 +162,21 @@ A tag is a component that does not have any data. In Flecs tags are empty types 
 struct Enemy;
 
 // Create entity, add Enemy tag
-let e = world.entity().add::<Enemy>();
-e.has::<Enemy>(); // true!
+let e = world.entity().add(id::<Enemy>());
+e.has(id::<Enemy>()); // true!
 
-e.remove::<Enemy>();
-e.has::<Enemy>(); // false!
+e.remove(id::<Enemy>());
+e.has(id::<Enemy>()); // false!
 
 // Option 2: create Tag as entity
 let enemy = world.entity();
 
 // Create entity, add Enemy tag
-let e = world.entity().add_id(enemy);
-e.has_id(enemy); // true!
+let e = world.entity().add(enemy);
+e.has(enemy); // true!
 
-e.remove_id(enemy);
-e.has_id(enemy); // false!
+e.remove(enemy);
+e.has(enemy); // false!
 # }
 ```
 
@@ -201,12 +201,12 @@ struct Likes;
 let bob = world.entity();
 let alice = world.entity();
 
-bob.add_first::<Likes>(alice); // bob likes alice
-alice.add_first::<Likes>(bob); // alice likes bob
-bob.has_first::<Likes>(alice); // true!
+bob.add((id::<Likes>(), alice)); // bob likes alice
+alice.add((id::<Likes>(), bob)); // alice likes bob
+bob.has((id::<Likes>(), alice)); // true!
 
-bob.remove_first::<Likes>(alice);
-bob.has_first::<Likes>(alice); // false!
+bob.remove((id::<Likes>(), alice));
+bob.has((id::<Likes>(), alice)); // false!
 # }
 ```
 
@@ -222,7 +222,7 @@ A pair can be encoded in a single 64 bit identifier using the `world.id_first` f
 # fn main() {
 # let world = World::new();
 # let bob = world.entity();
-let id = world.id_first::<Likes>(bob);
+let id = world.id_view_from(id::<Likes>(),bob);
 # }
 ```
 
@@ -239,7 +239,7 @@ The following examples show how to get back the elements from a pair:
 # 
 # fn main() {
 # let world = World::new();
-let id = world.id_from::<(Likes, Apples)>();
+let id = world.id_view_from((id::<Likes>(), id::<Apples>()));
 if id.is_pair() {
     let relationship = id.first_id();
     let target = id.second_id();
@@ -260,13 +260,13 @@ A component or tag can be added multiple times to the same entity as long as it 
 # let apples = world.entity();
 # let pears = world.entity();
 let bob = world.entity();
-bob.add_id((eats, apples));
-bob.add_id((eats, pears));
-bob.add_id((grows, pears));
+bob.add((eats, apples));
+bob.add((eats, pears));
+bob.add((grows, pears));
 
-bob.has_id((eats, apples)); // true!
-bob.has_id((eats, pears)); // true!
-bob.has_id((grows, pears)); // true!
+bob.has((eats, apples)); // true!
+bob.has((eats, pears)); // true!
+bob.has((grows, pears)); // true!
 # }
 ```
 
@@ -282,15 +282,15 @@ The `target` function can be used to get the object for a relationship:
 # fn main() {
 # let world = World::new();
 # let bob = world.entity();
-let alice = world.entity().add_first::<Likes>(bob);
-let o = alice.target::<Likes>(0); // Returns bob
+let alice = world.entity().add((id::<Likes>(), bob));
+let o = alice.target(id::<Likes>(),0); // Returns bob
 # }
 ```
 
 Entity relationships enable lots of interesting patterns and possibilities. Make sure to check out the [Relationships manual](Relationships.md).
 
 ### Hierarchies
-Flecs has builtin support for hierarchies with the builtin `ChildOf` relationship. A hierarchy can be created with the regular relationship API or with the `child_of_id` function:
+Flecs has builtin support for hierarchies with the builtin `ChildOf` relationship. A hierarchy can be created with the regular relationship API or with the .child_of` function:
 
 ```rust
 # extern crate flecs_ecs;
@@ -299,7 +299,7 @@ Flecs has builtin support for hierarchies with the builtin `ChildOf` relationshi
 # fn main() {
 # let world = World::new();
 let parent = world.entity();
-let child = world.entity().child_of_id(parent);
+let child = world.entity().child_of(parent);
 
 // Deleting the parent also deletes its children
 parent.destruct();
@@ -315,7 +315,7 @@ When entities have names, they can be used together with hierarchies to generate
 # fn main() {
 # let world = World::new();
 let parent = world.entity_named("parent");
-let child = world.entity_named("child").child_of_id(parent);
+let child = world.entity_named("child").child_of(parent);
 
 println!("Child path: {}", child.path().unwrap()); // output: 'parent::child'
 
@@ -364,7 +364,7 @@ The type (often referred to as "archetype") is the list of ids an entity has. Ty
 # 
 # fn main() {
 # let world = World::new();
-let e = world.entity().add::<Position>().add::<Velocity>();
+let e = world.entity().add(id::<Position>()).add(id::<Velocity>());
 
 println!("Components: {}", e.archetype().to_string().unwrap()); // output: 'Position,Velocity'
 # }
@@ -381,7 +381,7 @@ A type can also be iterated by an application:
 # 
 # fn main() {
 # let world = World::new();
-# let e = world.entity().add::<Position>();
+# let e = world.entity().add(id::<Position>());
 e.each_component(|id| {
     if id == world.component_id::<Position>() {
         // Found Position component!
@@ -497,7 +497,7 @@ q.run(|mut it| {
         let p = it.field::<Position>(0).unwrap();
 
         for i in it.iter() {
-            println!("{}: ({}, {})", it.entity(i).name(), p[i].x, p[i].y);
+            println!("{}: ({}, {})", it.entity(i).unwrap().name(), p[i].x, p[i].y);
         }
     }
 });
@@ -520,7 +520,7 @@ The following example shows a query that matches all entities with a parent that
 let q = world
     .query::<()>()
     .with::<(flecs::ChildOf, flecs::Wildcard)>()
-    .with::<Position>()
+    .with(id::<Position>())
     .set_oper(OperKind::Not)
     .build();
 
@@ -579,7 +579,7 @@ Systems are stored as entities with additional components, similar to components
 #        p.y += v.y * it.delta_time();
 #    });
 println!("System: {}", move_sys.name());
-move_sys.add::<flecs::pipeline::OnUpdate>();
+move_sys.add(id::<flecs::pipeline::OnUpdate>());
 move_sys.destruct();
 # }
 ```
@@ -623,17 +623,17 @@ When a pipeline is executed, systems are ran in the order of the phases. This ma
 # let world = World::new();
 world
     .system_named::<(&mut Position, &Velocity)>("Move")
-    .kind::<flecs::pipeline::OnUpdate>()
+    .has(id::<flecs::pipeline::OnUpdate>())
     .each(|(p, v)| {});
 
 world
     .system_named::<(&mut Position, &Transform)>("Transform")
-    .kind::<flecs::pipeline::PostUpdate>()
+    .has(id::<flecs::pipeline::PostUpdate>())
     .each(|(p, t)| {});
     
 world
     .system_named::<(&Transform, &mut Mesh)>("Render")
-    .kind::<flecs::pipeline::OnStore>()
+    .has(id::<flecs::pipeline::OnStore>())
     .each(|(t, m)| {});
 
 world.progress();
@@ -659,8 +659,8 @@ Because phases are just tags that are added to systems, applications can use the
 #        p.x += v.x * it.delta_time();
 #        p.y += v.y * it.delta_time();
 #    });
-move_sys.add::<flecs::pipeline::OnUpdate>();
-move_sys.remove::<flecs::pipeline::PostUpdate>();
+move_sys.add(id::<flecs::pipeline::OnUpdate>());
+move_sys.remove(id::<flecs::pipeline::PostUpdate>());
 # }
 ```
 

--- a/flecs_ecs/examples/flecs/entities/entity_basics.rs
+++ b/flecs_ecs/examples/flecs/entities/entity_basics.rs
@@ -28,7 +28,7 @@ fn main() {
         .set(Position { x: 10.0, y: 20.0 })
         // The add operation adds a component without setting a value. This is
         // useful for tags, or when adding a component with its default value.
-        .add::<Walking>();
+        .add(id::<Walking>());
 
     // Get the value for the Position component
     // - get panics if the component is not present, use try_get for a non-panicking version which does not run the callback.
@@ -48,14 +48,14 @@ fn main() {
         .set(Position { x: 10.0, y: 20.0 });
 
     // Add a tag after entity is created
-    alice.add::<Walking>();
+    alice.add(id::<Walking>());
 
     // Print all of the components the entity has. This will output:
     //    Position, Walking, (Identifier,Name)
     println!("[{}]", alice.archetype());
 
     // Remove tag
-    alice.remove::<Walking>();
+    alice.remove(id::<Walking>());
 
     // Iterate all entities with position
     world.each_entity::<&Position>(|entity, pos| {

--- a/flecs_ecs/examples/flecs/entities/entity_hierarchy.rs
+++ b/flecs_ecs/examples/flecs/entities/entity_hierarchy.rs
@@ -51,32 +51,32 @@ fn main() {
     world
         .entity_named("Mercury")
         .set(Position { x: 1.0, y: 1.0 })
-        .add::<Planet>()
-        .child_of_id(sun); // Shortcut for add(flecs::ChildOf, sun)
+        .add(id::<Planet>())
+        .child_of(sun); // Shortcut for add(flecs::ChildOf, sun)
 
     world
         .entity_named("Venus")
         .set(Position { x: 2.0, y: 2.0 })
-        .add::<Planet>()
-        .child_of_id(sun);
+        .add(id::<Planet>())
+        .child_of(sun);
 
     let earth = world
         .entity_named("Earth")
         .set(Position { x: 3.0, y: 3.0 })
-        .add::<Planet>()
-        .child_of_id(sun);
+        .add(id::<Planet>())
+        .child_of(sun);
 
     let moon = world
         .entity_named("Moon")
         .set(Position { x: 0.1, y: 0.1 })
-        .add::<Moon>()
-        .child_of_id(earth);
+        .add(id::<Moon>())
+        .child_of(earth);
 
     // Is the Moon a child of the Earth?
     println!(
         "Is the Moon a child of the Earth? {} / {}",
-        moon.has_id((flecs::ChildOf::ID, earth)), //or you can do
-        moon.has_first::<flecs::ChildOf>(earth)
+        moon.has((flecs::ChildOf::ID, earth)), //or you can do
+        moon.has((id::<flecs::ChildOf>(), earth))
     );
 
     println!();

--- a/flecs_ecs/examples/flecs/entities/entity_hooks.rs
+++ b/flecs_ecs/examples/flecs/entities/entity_hooks.rs
@@ -32,7 +32,7 @@ fn main() {
 
     // This operation changes the entity's archetype, which invokes a move
     // add is used for adding tags.
-    entity.add::<Tag>();
+    entity.add(id::<Tag>());
 
     entity.destruct();
 

--- a/flecs_ecs/examples/flecs/entities/entity_iterate_components.rs
+++ b/flecs_ecs/examples/flecs/entities/entity_iterate_components.rs
@@ -67,8 +67,8 @@ fn main() {
         .entity_named("Bob")
         .set(Position { x: 10.0, y: 20.0 })
         .set(Velocity { x: 1.0, y: 1.0 })
-        .add::<Human>()
-        .add::<(Eats, Apples)>();
+        .add(id::<Human>())
+        .add((id::<Eats>(), id::<Apples>()));
 
     println!("Bob's components:");
     iterate_components(bob);

--- a/flecs_ecs/examples/flecs/entities/entity_prefab.rs
+++ b/flecs_ecs/examples/flecs/entities/entity_prefab.rs
@@ -61,25 +61,25 @@ fn main() {
         // By default components in an inheritance hierarchy are shared between
         // entities. The override function ensures that instances have a private
         // copy of the component.
-        .auto_override::<Position>();
+        .auto_override(id::<Position>());
 
     let freighter = world
         .prefab_named("Freighter")
-        .is_a_id(spaceship)
+        .is_a(spaceship)
         .set(FreightCapacity { value: 100.0 })
         .set(Defence { value: 100.0 })
-        .add::<HasFlt>();
+        .add(id::<HasFlt>());
 
     let mammoth_freighter = world
         .prefab_named("MammothFreighter")
-        .is_a_id(freighter)
+        .is_a(freighter)
         .set(FreightCapacity { value: 500.0 })
         .set(Defence { value: 300.0 });
 
     world
         .prefab_named("Frigate")
-        .is_a_id(spaceship)
-        .add::<HasFlt>()
+        .is_a(spaceship)
+        .add(id::<HasFlt>())
         .set(Attack { value: 100.0 })
         .set(Defence { value: 75.0 })
         .set(ImpulseSpeed { value: 125.0 });
@@ -89,7 +89,7 @@ fn main() {
     // of the override in the spaceship entity. All other components are shared.
     let inst = world
         .entity_named("my_mammoth_freighter")
-        .is_a_id(mammoth_freighter);
+        .is_a(mammoth_freighter);
 
     // Inspect the type of the entity. This outputs:
     //    Position,(Identifier,Name),(IsA,MammothFreighter)

--- a/flecs_ecs/examples/flecs/hello_world.rs
+++ b/flecs_ecs/examples/flecs/hello_world.rs
@@ -38,7 +38,7 @@ fn main() {
         .entity_named("Bob")
         .set(Position { x: 0.0, y: 0.0 })
         .set(Velocity { x: 1.0, y: 2.0 })
-        .add::<(Eats, Apples)>();
+        .add((id::<Eats>(), id::<Apples>()));
 
     // Show us what you got
     // println!( "{}'s got [{:?}]", bob.name(), bob.archetype());

--- a/flecs_ecs/examples/flecs/observers/observer_basics.rs
+++ b/flecs_ecs/examples/flecs/observers/observer_basics.rs
@@ -13,24 +13,28 @@ fn main() {
 
     world
         .observer::<flecs::OnAdd, ()>()
-        .with::<Position>()
+        .with(id::<Position>())
         .each_iter(|it, index, _| {
-            // We use .with::<Position>() because we cannot safely access the component
+            // We use .with(id::<Position>()) because we cannot safely access the component
             // value here. The component value is uninitialized when the OnAdd event
             // is emitted, which is UB in Rust. To work around this, we use .with::<T>
-            println!(" - OnAdd: {}: {}", it.event_id().to_str(), it.entity(index));
+            println!(
+                " - OnAdd: {}: {}",
+                it.event_id().to_str(),
+                it.entity(index).unwrap()
+            );
         });
 
     // Create an observer for three events
     world
         .observer::<flecs::OnSet, &Position>()
-        .add_event::<flecs::OnRemove>() //or .add_event_id(OnRemove::ID)
+        .add_event(id::<flecs::OnRemove>())
         .each_iter(|it, index, pos| {
             println!(
                 " - {}: {}: {}: with {:?}",
                 it.event().name(),
                 it.event_id().to_str(),
-                it.entity(index),
+                it.entity(index).unwrap(),
                 pos
             );
         });
@@ -39,10 +43,10 @@ fn main() {
     let entity = world.entity_named("e1").set(Position { x: 10.0, y: 20.0 });
 
     // Remove Position (emits EcsOnRemove)
-    entity.remove::<Position>();
+    entity.remove(id::<Position>());
 
     // Remove Position again (no event emitted)
-    entity.remove::<Position>();
+    entity.remove(id::<Position>());
 
     // Output:
     //  - OnAdd: Position: e1

--- a/flecs_ecs/examples/flecs/observers/observer_custom_event.rs
+++ b/flecs_ecs/examples/flecs/observers/observer_custom_event.rs
@@ -22,7 +22,7 @@ fn main() {
                 " - {}: {}: {}",
                 it.event().name(),
                 it.event_id().to_str(),
-                it.entity(index)
+                it.entity(index).unwrap()
             );
         });
 
@@ -34,7 +34,7 @@ fn main() {
     // Emit the custom event. This triggers the observer.
     world
         .event()
-        .add::<Position>()
+        .add(id::<Position>())
         .entity(entity)
         .emit(&MyEvent);
 

--- a/flecs_ecs/examples/flecs/observers/observer_entity_event.rs
+++ b/flecs_ecs/examples/flecs/observers/observer_entity_event.rs
@@ -38,7 +38,7 @@ fn main() {
     // Create an observer for the CloseRequested event to listen to any entity.
     world
         .observer::<CloseRequested, ()>()
-        .with::<flecs::Any>()
+        .with(id::<flecs::Any>())
         .each_iter(|it, _index, _| {
             let reason = it.param().reason;
             println!("Close request with reason: {:?}", reason);

--- a/flecs_ecs/examples/flecs/observers/observer_monitor.rs
+++ b/flecs_ecs/examples/flecs/observers/observer_monitor.rs
@@ -34,13 +34,13 @@ fn main() {
                 println!(
                     " - Enter: {}: {}",
                     it.event_id().to_str(),
-                    it.entity(index).name()
+                    it.entity(index).unwrap().name()
                 );
             } else if it.event() == flecs::OnRemove::ID {
                 println!(
                     " - Leave: {}: {}",
                     it.event_id().to_str(),
-                    it.entity(index).name()
+                    it.entity(index).unwrap().name()
                 );
             }
         });
@@ -55,7 +55,7 @@ fn main() {
     entity.set(Velocity { x: 1.0, y: 2.0 });
 
     // This triggers the monitor with EcsOnRemove, as the entity no longer matches.
-    entity.remove::<Position>();
+    entity.remove(id::<Position>());
 
     // Output:
     //  - Enter: Velocity: e

--- a/flecs_ecs/examples/flecs/observers/observer_propagate.rs
+++ b/flecs_ecs/examples/flecs/observers/observer_propagate.rs
@@ -32,7 +32,7 @@ fn main() {
                 " - {}: {}: {}: self: {{ {}, {} }}, parent: {{ {}, {} }}",
                 it.event().name(),
                 it.event_id().to_str(),
-                it.entity(index).name(),
+                it.entity(index).unwrap().name(),
                 pos_self.x,
                 pos_self.y,
                 pos_parent.x,
@@ -42,7 +42,7 @@ fn main() {
 
     // Create entity and parent
     let parent = world.entity_named("p");
-    let entity = world.entity_named("e").child_of_id(parent);
+    let entity = world.entity_named("e").child_of(parent);
 
     // Set Position on entity. This doesn't trigger the observer yet, since the
     // parent doesn't have Position yet.

--- a/flecs_ecs/examples/flecs/observers/observer_two_components.rs
+++ b/flecs_ecs/examples/flecs/observers/observer_two_components.rs
@@ -29,7 +29,7 @@ fn main() {
                 " - {}: {}: {}: p: {{ {}, {} }}, v: {{ {}, {} }}",
                 it.event().name(),
                 it.event_id().to_str(),
-                it.entity(index).name(),
+                it.entity(index).unwrap().name(),
                 pos.x,
                 pos.y,
                 vel.x,

--- a/flecs_ecs/examples/flecs/observers/observer_yield_existing.rs
+++ b/flecs_ecs/examples/flecs/observers/observer_yield_existing.rs
@@ -28,7 +28,7 @@ fn main() {
                 " - {}: {}: {}: {{ {}, {} }}",
                 it.event().name(),
                 it.event_id().to_str(),
-                it.entity(index),
+                it.entity(index).unwrap(),
                 pos.x,
                 pos.y
             );

--- a/flecs_ecs/examples/flecs/prefabs/prefab_basics.rs
+++ b/flecs_ecs/examples/flecs/prefabs/prefab_basics.rs
@@ -37,7 +37,7 @@ fn main() {
     let spaceship = world.prefab_named("Prefab").set(Defence { value: 50.0 });
 
     // Create a prefab instance
-    let inst = world.entity_named("my_spaceship").is_a_id(spaceship);
+    let inst = world.entity_named("my_spaceship").is_a(spaceship);
 
     // Because of the IsA relationship, the instance now shares the Defense
     // component with the prefab, and can be retrieved as a regular component:

--- a/flecs_ecs/examples/flecs/prefabs/prefab_hierarchy.rs
+++ b/flecs_ecs/examples/flecs/prefabs/prefab_hierarchy.rs
@@ -9,12 +9,12 @@ fn main() {
 
     // Create a prefab hierarchy.
     let spaceship = world.prefab_named("SpaceShip");
-    world.prefab_named("Engine").child_of_id(spaceship);
-    world.prefab_named("Cockpit").child_of_id(spaceship);
+    world.prefab_named("Engine").child_of(spaceship);
+    world.prefab_named("Cockpit").child_of(spaceship);
 
     // Instantiate the prefab. This also creates an Engine and Cockpit child
     // for the instance.
-    let inst = world.entity_named("my_spaceship").is_a_id(spaceship);
+    let inst = world.entity_named("my_spaceship").is_a(spaceship);
 
     // Because of the IsA relationship, the instance now has the Engine and Cockpit
     // children of the prefab. This means that the instance can look up the Engine

--- a/flecs_ecs/examples/flecs/prefabs/prefab_nested.rs
+++ b/flecs_ecs/examples/flecs/prefabs/prefab_nested.rs
@@ -31,18 +31,18 @@ fn main() {
     // method, which has the same effect as adding the (ChildOf, Car) pair.
     let car = world.prefab_named("Car");
     car.run_in_scope(|| {
-        world.prefab_named("FrontLeft").is_a_id(wheel);
+        world.prefab_named("FrontLeft").is_a(wheel);
 
-        world.prefab_named("FrontRight").is_a_id(wheel);
+        world.prefab_named("FrontRight").is_a(wheel);
 
-        world.prefab_named("BackLeft").is_a_id(wheel);
+        world.prefab_named("BackLeft").is_a(wheel);
 
-        world.prefab_named("BackRight").is_a_id(wheel);
+        world.prefab_named("BackRight").is_a(wheel);
     });
 
     // Create a prefab instance.
     let inst_car = world.entity_named("my_car");
-    inst_car.is_a_id(car);
+    inst_car.is_a(car);
 
     // Lookup one of the wheels
     if let Some(inst) = inst_car.try_lookup_recursive("FrontLeft") {

--- a/flecs_ecs/examples/flecs/prefabs/prefab_override.rs
+++ b/flecs_ecs/examples/flecs/prefabs/prefab_override.rs
@@ -54,7 +54,7 @@ fn main() {
         .set(Damage { value: 50.0 });
 
     // Create a prefab instance.
-    let inst = world.entity_named("my_spaceship").is_a_id(spaceship);
+    let inst = world.entity_named("my_spaceship").is_a(spaceship);
 
     // The entity will now have a private copy of the Damage component, but not
     // of the Attack and Defense components. We can see this when we look at the

--- a/flecs_ecs/examples/flecs/prefabs/prefab_slots.rs
+++ b/flecs_ecs/examples/flecs/prefabs/prefab_slots.rs
@@ -32,13 +32,13 @@ fn main() {
     let spaceship = world.prefab_named("SpaceShip");
     let engine = world
         .prefab_named("Engine")
-        .child_of_id(spaceship)
-        .slot_of_id(spaceship);
+        .child_of(spaceship)
+        .slot_of(spaceship);
 
     let cockpit = world
         .prefab_named("Cockpit")
-        .child_of_id(spaceship)
-        .slot_of_id(spaceship);
+        .child_of(spaceship)
+        .slot_of(spaceship);
 
     // Add an additional child to the Cockpit prefab to demonstrate how
     // slots can be different from the parent. This slot could have been
@@ -47,16 +47,16 @@ fn main() {
 
     let pilot_seat = world
         .prefab_named("PilotSeat")
-        .child_of_id(cockpit)
-        .slot_of_id(spaceship);
+        .child_of(cockpit)
+        .slot_of(spaceship);
 
     // Create a prefab instance.
-    let inst = world.entity_named("my_spaceship").is_a_id(spaceship);
+    let inst = world.entity_named("my_spaceship").is_a(spaceship);
 
     // Get the instantiated entities for the prefab slots
-    let inst_engine = inst.target_id(engine, 0).unwrap();
-    let inst_cockpit = inst.target_id(cockpit, 0).unwrap();
-    let inst_seat = inst.target_id(pilot_seat, 0).unwrap();
+    let inst_engine = inst.target(engine, 0).unwrap();
+    let inst_cockpit = inst.target(cockpit, 0).unwrap();
+    let inst_seat = inst.target(pilot_seat, 0).unwrap();
 
     println!("instance engine: {}", inst_engine.path().unwrap());
 

--- a/flecs_ecs/examples/flecs/prefabs/prefab_typed.rs
+++ b/flecs_ecs/examples/flecs/prefabs/prefab_typed.rs
@@ -35,27 +35,27 @@ fn main() {
 
     world
         .prefab_type::<Base>()
-        .child_of::<Turret>()
-        .slot_of::<Turret>();
+        .child_of(id::<Turret>())
+        .slot_of(id::<Turret>());
 
     world
         .prefab_type::<Head>()
-        .child_of::<Turret>()
-        .slot_of::<Turret>();
+        .child_of(id::<Turret>())
+        .slot_of(id::<Turret>());
 
-    world.prefab_type::<Railgun>().is_a::<Turret>();
+    world.prefab_type::<Railgun>().is_a(id::<Turret>());
     world
         .prefab_type::<Beam>()
-        .slot_of::<Railgun>()
-        .child_of::<Railgun>();
+        .slot_of(id::<Railgun>())
+        .child_of(id::<Railgun>());
 
     // Create prefab instance.
-    let inst = world.entity_named("my_railgun").is_a::<Railgun>();
+    let inst = world.entity_named("my_railgun").is_a(id::<Railgun>());
 
     // Get entities for slots
-    let inst_base = inst.target::<Base>(0).unwrap();
-    let inst_head = inst.target::<Head>(0).unwrap();
-    let inst_beam = inst.target::<Beam>(0).unwrap();
+    let inst_base = inst.target(id::<Base>(), 0).unwrap();
+    let inst_head = inst.target(id::<Head>(), 0).unwrap();
+    let inst_beam = inst.target(id::<Beam>(), 0).unwrap();
 
     println!("instance base: {}", inst_base.path().unwrap());
     println!("instance head: {}", inst_head.path().unwrap());

--- a/flecs_ecs/examples/flecs/prefabs/prefab_variant.rs
+++ b/flecs_ecs/examples/flecs/prefabs/prefab_variant.rs
@@ -43,20 +43,20 @@ fn main() {
     // Create a Freighter variant which inherits from SpaceShip
     let freighter = world
         .prefab_named("Freighter")
-        .is_a_id(spaceship)
+        .is_a(spaceship)
         .set(FreightCapacity { value: 100.0 })
         .set(Defence { value: 50.0 });
 
     // Create a MammotFreighter variant which inherits from Freighter
     let mammoth_freighter = world
         .prefab_named("MammothFreighter")
-        .is_a_id(freighter)
+        .is_a(freighter)
         .set(FreightCapacity { value: 500.0 });
 
     // Create a Frigate variant which inherits from SpaceShip
     world
         .prefab_named("Frigate")
-        .is_a_id(spaceship)
+        .is_a(spaceship)
         .set(Attack { value: 100.0 })
         .set(Defence { value: 75.0 })
         .set(ImpulseSpeed { value: 125.0 });
@@ -64,9 +64,7 @@ fn main() {
     // Create an instance of the MammothFreighter. This entity will inherit the
     // ImpulseSpeed from SpaceShip, Defence from Freighter and FreightCapacity
     // from MammothFreighter.
-    let inst = world
-        .entity_named("my_freighter")
-        .is_a_id(mammoth_freighter);
+    let inst = world.entity_named("my_freighter").is_a(mammoth_freighter);
 
     // Add a private Position component.
     inst.set(Position { x: 10.0, y: 20.0 });

--- a/flecs_ecs/examples/flecs/queries/query_chaining_queries.rs
+++ b/flecs_ecs/examples/flecs/queries/query_chaining_queries.rs
@@ -39,7 +39,7 @@ fn main() {
             });
 
         if i % 2 == 0 {
-            creature.add::<Enchanted>();
+            creature.add(id::<Enchanted>());
         }
     }
 
@@ -54,7 +54,7 @@ fn main() {
 
         if i % 2 != 0 {
             // Differentiate enchantment condition to diversify
-            artifact.add::<Enchanted>();
+            artifact.add(id::<Enchanted>());
         }
     }
 
@@ -62,7 +62,7 @@ fn main() {
     let query_creatures = forest.query::<(&Location, &Ability)>().set_cached().build();
 
     // Filter specifically for enchanted things in the world
-    let mut query_enchanted = forest.query::<()>().with::<&Enchanted>().build();
+    let mut query_enchanted = forest.query::<()>().with(id::<&Enchanted>()).build();
 
     // Iterate over creatures to find the enchanted ones
     query_creatures.run(|mut iter| {
@@ -77,7 +77,7 @@ fn main() {
             .each_iter( |it, index ,_| {
                 let pos = &loc[index];
                 let abil_power = ability[index].power;
-                let entity = it.entity(index);
+                let entity = it.entity(index).unwrap();
                 println!(
                     "Creature id: {entity} at location {},{} is enchanted with mystical energy, ability power: {} "
                     , pos.x, pos.y, abil_power

--- a/flecs_ecs/examples/flecs/queries/query_change_tracking_1.rs
+++ b/flecs_ecs/examples/flecs/queries/query_change_tracking_1.rs
@@ -89,14 +89,14 @@ fn main() {
         .entity_named("child")
         .set(Position { x: 10.0, y: 20.0 })
         .set(WorldPosition { x: 0.0, y: 0.0 })
-        .child_of_id(parent);
+        .child_of(parent);
 
     let independent = world
         .entity_named("independent")
         .set(Position { x: 50.0, y: 30.0 })
         .set(WorldPosition { x: 0.0, y: 0.0 })
         // this is to make sure independent entity is in a different archetype
-        .add::<DummyTag>();
+        .add(id::<DummyTag>());
 
     // Since this is the first time the query is iterated, all tables
     // will show up as changed and not skipped

--- a/flecs_ecs/examples/flecs/queries/query_change_tracking_2.rs
+++ b/flecs_ecs/examples/flecs/queries/query_change_tracking_2.rs
@@ -42,7 +42,7 @@ fn main() {
     let query_write = world
         .query::<(&Dirty, &mut Position)>()
         .term_at(0)
-        .up_type::<flecs::IsA>() // Only match Dirty from prefab
+        .up_id(id::<flecs::IsA>()) // Only match Dirty from prefab
         .build();
 
     // Create two prefabs with a Dirty component. We can use this to share a
@@ -59,22 +59,22 @@ fn main() {
     // prefabs, they end up in different tables.
     world
         .entity_named("e1_dirty_false")
-        .is_a_id(prefab_dirty_false)
+        .is_a(prefab_dirty_false)
         .set(Position { x: 10.0, y: 20.0 });
 
     world
         .entity_named("e2_dirty_false")
-        .is_a_id(prefab_dirty_false)
+        .is_a(prefab_dirty_false)
         .set(Position { x: 30.0, y: 40.0 });
 
     world
         .entity_named("e3_dirty_true")
-        .is_a_id(prefab_dirty_true)
+        .is_a(prefab_dirty_true)
         .set(Position { x: 40.0, y: 50.0 });
 
     world
         .entity_named("e4_dirty_true")
-        .is_a_id(prefab_dirty_true)
+        .is_a(prefab_dirty_true)
         .set(Position { x: 50.0, y: 60.0 });
 
     // We can use the changed() function on the query to check if any of the

--- a/flecs_ecs/examples/flecs/queries/query_component_inheritance.rs
+++ b/flecs_ecs/examples/flecs/queries/query_component_inheritance.rs
@@ -32,30 +32,30 @@ fn main() {
 
     // Make the ECS aware of the inheritance relationships. Note that IsA
     // relationship used here is the same as in the prefab example.
-    world.component::<CombatUnit>().is_a::<Unit>();
-    world.component::<MeleeUnit>().is_a::<CombatUnit>();
-    world.component::<RangedUnit>().is_a::<CombatUnit>();
+    world.component::<CombatUnit>().is_a(id::<Unit>());
+    world.component::<MeleeUnit>().is_a(id::<CombatUnit>());
+    world.component::<RangedUnit>().is_a(id::<CombatUnit>());
 
-    world.component::<Warrior>().is_a::<MeleeUnit>();
-    world.component::<Wizard>().is_a::<RangedUnit>();
-    world.component::<Marksman>().is_a::<RangedUnit>();
-    world.component::<BuilderX>().is_a::<Unit>();
+    world.component::<Warrior>().is_a(id::<MeleeUnit>());
+    world.component::<Wizard>().is_a(id::<RangedUnit>());
+    world.component::<Marksman>().is_a(id::<RangedUnit>());
+    world.component::<BuilderX>().is_a(id::<Unit>());
 
     // Create a few units
-    world.entity_named("warrior_1").add::<Warrior>();
-    world.entity_named("warrior_2").add::<Warrior>();
+    world.entity_named("warrior_1").add(id::<Warrior>());
+    world.entity_named("warrior_2").add(id::<Warrior>());
 
-    world.entity_named("marksman_1").add::<Marksman>();
-    world.entity_named("marksman_2").add::<Marksman>();
+    world.entity_named("marksman_1").add(id::<Marksman>());
+    world.entity_named("marksman_2").add(id::<Marksman>());
 
-    world.entity_named("wizard_1").add::<Wizard>();
-    world.entity_named("wizard_2").add::<Wizard>();
+    world.entity_named("wizard_1").add(id::<Wizard>());
+    world.entity_named("wizard_2").add(id::<Wizard>());
 
-    world.entity_named("builder_1").add::<BuilderX>();
-    world.entity_named("builder_2").add::<BuilderX>();
+    world.entity_named("builder_1").add(id::<BuilderX>());
+    world.entity_named("builder_2").add(id::<BuilderX>());
 
     // Create a rule to find all ranged units
-    let r = world.query::<()>().with::<RangedUnit>().build();
+    let r = world.query::<()>().with(id::<RangedUnit>()).build();
 
     // Iterate the rule
     r.each_entity(|e, rangedunit| {

--- a/flecs_ecs/examples/flecs/queries/query_cyclic_variables.rs
+++ b/flecs_ecs/examples/flecs/queries/query_cyclic_variables.rs
@@ -37,9 +37,9 @@ fn main() {
 
     let rule = world
         .query::<()>()
-        .with_name_second(id::<Likes>(), "$Y")
+        .with((id::<Likes>(), "$Y"))
         .set_src_name("$X")
-        .with_name_second(id::<Likes>(), "$X")
+        .with((id::<Likes>(), "$X"))
         .set_src_name("$Y")
         .build();
 

--- a/flecs_ecs/examples/flecs/queries/query_cyclic_variables.rs
+++ b/flecs_ecs/examples/flecs/queries/query_cyclic_variables.rs
@@ -38,9 +38,9 @@ fn main() {
     let rule = world
         .query::<()>()
         .with((id::<Likes>(), "$Y"))
-        .set_src_name("$X")
+        .set_src("$X")
         .with((id::<Likes>(), "$X"))
-        .set_src_name("$Y")
+        .set_src("$Y")
         .build();
 
     // Lookup the index of the variables. This will let us quickly lookup their

--- a/flecs_ecs/examples/flecs/queries/query_cyclic_variables.rs
+++ b/flecs_ecs/examples/flecs/queries/query_cyclic_variables.rs
@@ -15,11 +15,11 @@ fn main() {
     let john = world.entity_named("John");
     let jane = world.entity_named("Jane");
 
-    bob.add_first::<Likes>(alice);
-    alice.add_first::<Likes>(bob);
-    john.add_first::<Likes>(jane);
-    jane.add_first::<Likes>(john);
-    bob.add_first::<Likes>(jane); // inserting a bit of drama
+    bob.add((id::<Likes>(), alice));
+    alice.add((id::<Likes>(), bob));
+    john.add((id::<Likes>(), jane));
+    jane.add((id::<Likes>(), john));
+    bob.add((id::<Likes>(), jane)); // inserting a bit of drama
 
     // The following rule will only return entities that have a cyclic Likes
     // relationship- that is they must both like each other.
@@ -37,9 +37,9 @@ fn main() {
 
     let rule = world
         .query::<()>()
-        .with_first_name::<&Likes>("$Y")
+        .with_name_second(id::<Likes>(), "$Y")
         .set_src_name("$X")
-        .with_first_name::<&Likes>("$X")
+        .with_name_second(id::<Likes>(), "$X")
         .set_src_name("$Y")
         .build();
 

--- a/flecs_ecs/examples/flecs/queries/query_facts.rs
+++ b/flecs_ecs/examples/flecs/queries/query_facts.rs
@@ -49,9 +49,9 @@ fn main() {
 
     let mut friends = world
         .query::<()>()
-        .with_name_second(id::<Likes>(), "$Y")
+        .with((id::<Likes>(), "$Y"))
         .set_src_name("$X")
-        .with_name_second(id::<Likes>(), "$X")
+        .with((id::<Likes>(), "$X"))
         .set_src_name("$Y")
         .build();
 

--- a/flecs_ecs/examples/flecs/queries/query_facts.rs
+++ b/flecs_ecs/examples/flecs/queries/query_facts.rs
@@ -50,9 +50,9 @@ fn main() {
     let mut friends = world
         .query::<()>()
         .with((id::<Likes>(), "$Y"))
-        .set_src_name("$X")
+        .set_src("$X")
         .with((id::<Likes>(), "$X"))
-        .set_src_name("$Y")
+        .set_src("$Y")
         .build();
 
     let x_var = friends.find_var("X").unwrap();

--- a/flecs_ecs/examples/flecs/queries/query_facts.rs
+++ b/flecs_ecs/examples/flecs/queries/query_facts.rs
@@ -30,11 +30,11 @@ fn main() {
     let john = world.entity_named("John");
     let jane = world.entity_named("Jane");
 
-    bob.add_first::<Likes>(alice);
-    alice.add_first::<Likes>(bob);
-    john.add_first::<Likes>(jane);
-    jane.add_first::<Likes>(john);
-    bob.add_first::<Likes>(jane); // inserting a bit of drama
+    bob.add((id::<Likes>(), alice));
+    alice.add((id::<Likes>(), bob));
+    john.add((id::<Likes>(), jane));
+    jane.add((id::<Likes>(), john));
+    bob.add((id::<Likes>(), jane)); // inserting a bit of drama
 
     // Create a rule that checks if two entities like each other. By itself this
     // rule is not a fact, but we can use it to check facts by populating both
@@ -49,9 +49,9 @@ fn main() {
 
     let mut friends = world
         .query::<()>()
-        .with_first_name::<&Likes>("$Y")
+        .with_name_second(id::<Likes>(), "$Y")
         .set_src_name("$X")
-        .with_first_name::<&Likes>("$X")
+        .with_name_second(id::<Likes>(), "$X")
         .set_src_name("$Y")
         .build();
 

--- a/flecs_ecs/examples/flecs/queries/query_group_by.rs
+++ b/flecs_ecs/examples/flecs/queries/query_group_by.rs
@@ -30,36 +30,36 @@ fn main() {
     world.component::<Second>();
     world.component::<Third>();
 
-    let query = world.query::<&Position>().group_by::<Group>().build();
+    let query = world.query::<&Position>().group_by(id::<Group>()).build();
 
     world
         .entity()
-        .add::<(Group, Third)>()
+        .add((id::<Group>(), id::<Third>()))
         .set(Position { x: 1.0, y: 1.0 });
     world
         .entity()
-        .add::<(Group, Second)>()
+        .add((id::<Group>(), id::<Second>()))
         .set(Position { x: 2.0, y: 2.0 });
     world
         .entity()
-        .add::<(Group, First)>()
+        .add((id::<Group>(), id::<First>()))
         .set(Position { x: 3.0, y: 3.0 });
 
     world
         .entity()
-        .add::<(Group, Third)>()
+        .add((id::<Group>(), id::<Third>()))
         .set(Position { x: 4.0, y: 4.0 })
-        .add::<Tag>();
+        .add(id::<Tag>());
     world
         .entity()
-        .add::<(Group, Second)>()
+        .add((id::<Group>(), id::<Second>()))
         .set(Position { x: 5.0, y: 5.0 })
-        .add::<Tag>();
+        .add(id::<Tag>());
     world
         .entity()
-        .add::<(Group, First)>()
+        .add((id::<Group>(), id::<First>()))
         .set(Position { x: 6.0, y: 6.0 })
-        .add::<Tag>();
+        .add(id::<Tag>());
 
     println!();
 

--- a/flecs_ecs/examples/flecs/queries/query_group_by_callbacks.rs
+++ b/flecs_ecs/examples/flecs/queries/query_group_by_callbacks.rs
@@ -83,7 +83,7 @@ fn main() {
     // Grouped query
     let query = world
         .query::<(&Position,)>()
-        .group_by::<Group>()
+        .group_by(id::<Group>())
         // Callback invoked when a new group is created
         .on_group_create(Some(callback_group_create))
         // Callback invoked when a group is deleted
@@ -93,32 +93,32 @@ fn main() {
     // Create entities in 6 different tables with 3 group ids
     world
         .entity()
-        .add::<(Group, Third)>()
+        .add((id::<Group>(), id::<Third>()))
         .set(Position { x: 1.0, y: 1.0 });
     world
         .entity()
-        .add::<(Group, Second)>()
+        .add((id::<Group>(), id::<Second>()))
         .set(Position { x: 2.0, y: 2.0 });
     world
         .entity()
-        .add::<(Group, First)>()
+        .add((id::<Group>(), id::<First>()))
         .set(Position { x: 3.0, y: 3.0 });
 
     world
         .entity()
-        .add::<(Group, Third)>()
+        .add((id::<Group>(), id::<Third>()))
         .set(Position { x: 4.0, y: 4.0 })
-        .add::<Tag>();
+        .add(id::<Tag>());
     world
         .entity()
-        .add::<(Group, Second)>()
+        .add((id::<Group>(), id::<Second>()))
         .set(Position { x: 5.0, y: 5.0 })
-        .add::<Tag>();
+        .add(id::<Tag>());
     world
         .entity()
-        .add::<(Group, First)>()
+        .add((id::<Group>(), id::<First>()))
         .set(Position { x: 6.0, y: 6.0 })
-        .add::<Tag>();
+        .add(id::<Tag>());
 
     println!();
 

--- a/flecs_ecs/examples/flecs/queries/query_group_by_custom.rs
+++ b/flecs_ecs/examples/flecs/queries/query_group_by_custom.rs
@@ -54,38 +54,38 @@ fn main() {
     // Grouped query
     let query = world
         .query::<&Position>()
-        .group_by_fn::<Group>(Some(callback_group_by_relationship))
+        .group_by_fn(id::<Group>(), Some(callback_group_by_relationship))
         .build();
 
     // Create entities in 6 different tables with 3 group ids
     world
         .entity()
-        .add::<(Group, Third)>()
+        .add((id::<Group>(), id::<Third>()))
         .set(Position { x: 1.0, y: 1.0 });
     world
         .entity()
-        .add::<(Group, Second)>()
+        .add((id::<Group>(), id::<Second>()))
         .set(Position { x: 2.0, y: 2.0 });
     world
         .entity()
-        .add::<(Group, First)>()
+        .add((id::<Group>(), id::<First>()))
         .set(Position { x: 3.0, y: 3.0 });
 
     world
         .entity()
-        .add::<(Group, Third)>()
+        .add((id::<Group>(), id::<Third>()))
         .set(Position { x: 4.0, y: 4.0 })
-        .add::<Tag>();
+        .add(id::<Tag>());
     world
         .entity()
-        .add::<(Group, Second)>()
+        .add((id::<Group>(), id::<Second>()))
         .set(Position { x: 5.0, y: 5.0 })
-        .add::<Tag>();
+        .add(id::<Tag>());
     world
         .entity()
-        .add::<(Group, First)>()
+        .add((id::<Group>(), id::<First>()))
         .set(Position { x: 6.0, y: 6.0 })
-        .add::<Tag>();
+        .add(id::<Tag>());
 
     println!();
 

--- a/flecs_ecs/examples/flecs/queries/query_group_iter.rs
+++ b/flecs_ecs/examples/flecs/queries/query_group_iter.rs
@@ -55,50 +55,50 @@ fn main() {
     // Create npc's in world cell 0_0
     world
         .entity()
-        .add::<(WorldCell, Cell_0_0)>()
-        .add::<Merchant>()
-        .add::<Npc>();
+        .add((id::<WorldCell>(), id::<Cell_0_0>()))
+        .add(id::<Merchant>())
+        .add(id::<Npc>());
     world
         .entity()
-        .add::<(WorldCell, Cell_0_0)>()
-        .add::<Merchant>()
-        .add::<Npc>();
+        .add((id::<WorldCell>(), id::<Cell_0_0>()))
+        .add(id::<Merchant>())
+        .add(id::<Npc>());
 
     // Create npc's in world cell 0_1
     world
         .entity()
-        .add::<(WorldCell, Cell_0_1)>()
-        .add::<Beggar>()
-        .add::<Npc>();
+        .add((id::<WorldCell>(), id::<Cell_0_1>()))
+        .add(id::<Beggar>())
+        .add(id::<Npc>());
     world
         .entity()
-        .add::<(WorldCell, Cell_0_1)>()
-        .add::<Soldier>()
-        .add::<Npc>();
+        .add((id::<WorldCell>(), id::<Cell_0_1>()))
+        .add(id::<Soldier>())
+        .add(id::<Npc>());
 
     // Create npc's in world cell 1_0
     world
         .entity()
-        .add::<(WorldCell, Cell_1_0)>()
-        .add::<Mage>()
-        .add::<Npc>();
+        .add((id::<WorldCell>(), id::<Cell_1_0>()))
+        .add(id::<Mage>())
+        .add(id::<Npc>());
     world
         .entity()
-        .add::<(WorldCell, Cell_1_0)>()
-        .add::<Beggar>()
-        .add::<Npc>();
+        .add((id::<WorldCell>(), id::<Cell_1_0>()))
+        .add(id::<Beggar>())
+        .add(id::<Npc>());
 
     // Create npc's in world cell 1_1
     world
         .entity()
-        .add::<(WorldCell, Cell_1_1)>()
-        .add::<Soldier>()
-        .add::<Npc>();
+        .add((id::<WorldCell>(), id::<Cell_1_1>()))
+        .add(id::<Soldier>())
+        .add(id::<Npc>());
 
     let mut query = world
         .query::<()>()
-        .with::<&Npc>()
-        .group_by::<WorldCell>()
+        .with(id::<&Npc>())
+        .group_by(id::<WorldCell>())
         .build();
 
     // Iterate all tables
@@ -119,7 +119,7 @@ fn main() {
 
     println!("Tables for cell 1_0:");
 
-    query.set_group::<Cell_1_0>().run(|mut iter| {
+    query.set_group(id::<Cell_1_0>()).run(|mut iter| {
         while iter.next() {
             let world = iter.world();
             let group = world.entity_from_id(iter.group_id());

--- a/flecs_ecs/examples/flecs/queries/query_hierarchy.rs
+++ b/flecs_ecs/examples/flecs/queries/query_hierarchy.rs
@@ -24,25 +24,25 @@ fn main() {
 
     world
         .entity_named("Mercury")
-        .child_of_id(sun)
+        .child_of(sun)
         .set_pair::<Position, WorldX>(Position::default())
         .set_pair::<Position, Local>(Position { x: 1.0, y: 1.0 });
 
     world
         .entity_named("Venus")
-        .child_of_id(sun)
+        .child_of(sun)
         .set_pair::<Position, WorldX>(Position::default())
         .set_pair::<Position, Local>(Position { x: 2.0, y: 2.0 });
 
     let earth = world
         .entity_named("Earth")
-        .child_of_id(sun)
+        .child_of(sun)
         .set_pair::<Position, WorldX>(Position::default())
         .set_pair::<Position, Local>(Position { x: 3.0, y: 3.0 });
 
     world
         .entity_named("Moon")
-        .child_of_id(earth)
+        .child_of(earth)
         .set_pair::<Position, WorldX>(Position::default())
         .set_pair::<Position, Local>(Position { x: 0.1, y: 0.1 });
 

--- a/flecs_ecs/examples/flecs/queries/query_run.rs
+++ b/flecs_ecs/examples/flecs/queries/query_run.rs
@@ -66,7 +66,11 @@ fn main() {
             for i in it.iter() {
                 position[i].x += velocity[i].x;
                 position[i].y += velocity[i].y;
-                println!(" - entity {}: has {:?}", it.entity(i).name(), position[i]);
+                println!(
+                    " - entity {}: has {:?}",
+                    it.entity(i).unwrap().name(),
+                    position[i]
+                );
             }
 
             println!();

--- a/flecs_ecs/examples/flecs/queries/query_setting_variables.rs
+++ b/flecs_ecs/examples/flecs/queries/query_setting_variables.rs
@@ -44,13 +44,13 @@ fn main() {
 
     // Make the ECS aware of the inheritance relationships. Note that IsA
     // relationship used here is the same as in the prefab example.
-    world.component::<CombatUnit>().is_a::<Unit>();
-    world.component::<MeleeUnit>().is_a::<CombatUnit>();
-    world.component::<RangedUnit>().is_a::<CombatUnit>();
+    world.component::<CombatUnit>().is_a(id::<Unit>());
+    world.component::<MeleeUnit>().is_a(id::<CombatUnit>());
+    world.component::<RangedUnit>().is_a(id::<CombatUnit>());
 
-    world.component::<Warrior>().is_a::<MeleeUnit>();
-    world.component::<Wizard>().is_a::<RangedUnit>();
-    world.component::<Marksman>().is_a::<RangedUnit>();
+    world.component::<Warrior>().is_a(id::<MeleeUnit>());
+    world.component::<Wizard>().is_a(id::<RangedUnit>());
+    world.component::<Marksman>().is_a(id::<RangedUnit>());
 
     // Populate store with players and platoons
     for p in 0..PLAYER_COUNT {
@@ -62,25 +62,28 @@ fn main() {
         };
 
         // Add player tag so we can query for all players if we want to
-        player.add::<Player>();
+        player.add(id::<Player>());
 
         for _ in 0..PLATOONS_PER_PLAYER {
             let platoon = world
                 .entity()
-                .add_first::<Player>(player)
+                .add((id::<Player>(), player))
                 // Add platoon tag so we can query for all platoons if we want to
-                .add::<Platoon>();
+                .add(id::<Platoon>());
 
             // Add warriors, wizards and marksmen to the platoon
             world
                 .entity()
-                .add::<Warrior>()
-                .add_first::<Platoon>(platoon);
+                .add(id::<Warrior>())
+                .add((id::<Platoon>(), platoon));
             world
                 .entity()
-                .add::<Marksman>()
-                .add_first::<Platoon>(platoon);
-            world.entity().add::<Wizard>().add_first::<Platoon>(platoon);
+                .add(id::<Marksman>())
+                .add((id::<Platoon>(), platoon));
+            world
+                .entity()
+                .add(id::<Wizard>())
+                .add((id::<Platoon>(), platoon));
         }
     }
 
@@ -93,10 +96,10 @@ fn main() {
     // - check if _Platoon has (Player, *), store * in _Player
     let mut query = world
         .query::<()>()
-        .with::<RangedUnit>()
-        .with::<&Platoon>()
+        .with(id::<RangedUnit>())
+        .with(id::<&Platoon>())
         .set_second_name("$platoon")
-        .with_first_name::<&Player>("$player")
+        .with_name_second(id::<Player>(), "$player")
         .set_src_name("$platoon")
         .build();
 
@@ -112,7 +115,7 @@ fn main() {
     query
         .set_var(player_var, world.lookup_recursive("MyPlayer"))
         .each_iter(|it, index, _| {
-            let unit = it.entity(index);
+            let unit = it.entity(index).unwrap();
             println!(
                 "Unit id: {} of class {} in platoon id: {} for player {}",
                 unit,

--- a/flecs_ecs/examples/flecs/queries/query_setting_variables.rs
+++ b/flecs_ecs/examples/flecs/queries/query_setting_variables.rs
@@ -99,7 +99,7 @@ fn main() {
         .with(id::<RangedUnit>())
         .with(id::<&Platoon>())
         .set_second_name("$platoon")
-        .with_name_second(id::<Player>(), "$player")
+        .with((id::<Player>(), "$player"))
         .set_src_name("$platoon")
         .build();
 

--- a/flecs_ecs/examples/flecs/queries/query_setting_variables.rs
+++ b/flecs_ecs/examples/flecs/queries/query_setting_variables.rs
@@ -98,9 +98,9 @@ fn main() {
         .query::<()>()
         .with(id::<RangedUnit>())
         .with(id::<&Platoon>())
-        .set_second_name("$platoon")
+        .set_second("$platoon")
         .with((id::<Player>(), "$player"))
-        .set_src_name("$platoon")
+        .set_src("$platoon")
         .build();
 
     // If we would iterate this query it would return all ranged units for all

--- a/flecs_ecs/examples/flecs/queries/query_transitive_queries.rs
+++ b/flecs_ecs/examples/flecs/queries/query_transitive_queries.rs
@@ -127,7 +127,7 @@ fn main() {
     let query = world
         .query::<()>()
         .with(id::<&Person>())
-        .with_name_second(id::<LocatedIn>(), "$Location")
+        .with((id::<LocatedIn>(), "$Location"))
         .with(id::<&Country>())
         .set_src_name("$Location")
         .build();

--- a/flecs_ecs/examples/flecs/queries/query_transitive_queries.rs
+++ b/flecs_ecs/examples/flecs/queries/query_transitive_queries.rs
@@ -129,7 +129,7 @@ fn main() {
         .with(id::<&Person>())
         .with((id::<LocatedIn>(), "$Location"))
         .with(id::<&Country>())
-        .set_src_name("$Location")
+        .set_src("$Location")
         .build();
 
     // Lookup the index of the variable. This will let us quickly lookup its

--- a/flecs_ecs/examples/flecs/queries/query_transitive_queries.rs
+++ b/flecs_ecs/examples/flecs/queries/query_transitive_queries.rs
@@ -39,80 +39,82 @@ fn main() {
     let world = World::new();
 
     // Register the LocatedIn relationship as transitive
-    world.component::<LocatedIn>().add::<flecs::Transitive>();
+    world
+        .component::<LocatedIn>()
+        .add(id::<flecs::Transitive>());
 
     // Populate the store with locations
-    let earth = world.entity_named("Earth").add::<Planet>();
+    let earth = world.entity_named("Earth").add(id::<Planet>());
 
     // Continents
     let north_america = world
         .entity_named("NorthAmerica")
-        .add::<Continent>()
-        .add_first::<LocatedIn>(earth);
+        .add(id::<Continent>())
+        .add((id::<LocatedIn>(), earth));
 
     let europe = world
         .entity_named("Europe")
-        .add::<Continent>()
-        .add_first::<LocatedIn>(earth);
+        .add(id::<Continent>())
+        .add((id::<LocatedIn>(), earth));
 
     // Countries
     let united_states = world
         .entity_named("UnitedStates")
-        .add::<Country>()
-        .add_first::<LocatedIn>(north_america);
+        .add(id::<Country>())
+        .add((id::<LocatedIn>(), north_america));
 
     let netherlands = world
         .entity_named("Netherlands")
-        .add::<Country>()
-        .add_first::<LocatedIn>(europe);
+        .add(id::<Country>())
+        .add((id::<LocatedIn>(), europe));
 
     // States
     let california = world
         .entity_named("California")
-        .add::<State>()
-        .add_first::<LocatedIn>(united_states);
+        .add(id::<State>())
+        .add((id::<LocatedIn>(), united_states));
 
     let washington = world
         .entity_named("Washington")
-        .add::<State>()
-        .add_first::<LocatedIn>(united_states);
+        .add(id::<State>())
+        .add((id::<LocatedIn>(), united_states));
 
     let noord_holland = world
         .entity_named("NoordHolland")
-        .add::<State>()
-        .add_first::<LocatedIn>(netherlands);
+        .add(id::<State>())
+        .add((id::<LocatedIn>(), netherlands));
 
     // Cities
     let san_francisco = world
         .entity_named("SanFrancisco")
-        .add::<City>()
-        .add_first::<LocatedIn>(california);
+        .add(id::<City>())
+        .add((id::<LocatedIn>(), california));
 
     let seattle = world
         .entity_named("Seattle")
-        .add::<City>()
-        .add_first::<LocatedIn>(washington);
+        .add(id::<City>())
+        .add((id::<LocatedIn>(), washington));
 
     let amsterdam = world
         .entity_named("Amsterdam")
-        .add::<City>()
-        .add_first::<LocatedIn>(noord_holland);
+        .add(id::<City>())
+        .add((id::<LocatedIn>(), noord_holland));
 
     // Inhabitants
     world
         .entity_named("Bob")
-        .add::<Person>()
-        .add_first::<LocatedIn>(san_francisco);
+        .add(id::<Person>())
+        .add((id::<LocatedIn>(), san_francisco));
 
     world
         .entity_named("Alice")
-        .add::<Person>()
-        .add_first::<LocatedIn>(seattle);
+        .add(id::<Person>())
+        .add((id::<LocatedIn>(), seattle));
 
     world
         .entity_named("Job")
-        .add::<Person>()
-        .add_first::<LocatedIn>(amsterdam);
+        .add(id::<Person>())
+        .add((id::<LocatedIn>(), amsterdam));
 
     // Create a query that finds the countries persons live in. Note that these
     // have not been explicitly added to the Person entities, but because the
@@ -124,9 +126,9 @@ fn main() {
 
     let query = world
         .query::<()>()
-        .with::<&Person>()
-        .with_first_name::<&LocatedIn>("$Location")
-        .with::<&Country>()
+        .with(id::<&Person>())
+        .with_name_second(id::<LocatedIn>(), "$Location")
+        .with(id::<&Country>())
         .set_src_name("$Location")
         .build();
 
@@ -136,7 +138,11 @@ fn main() {
 
     // Iterate the query
     query.each_iter(|it, index, _| {
-        println!("{} lives in {}", it.entity(index), it.get_var(location_var));
+        println!(
+            "{} lives in {}",
+            it.entity(index).unwrap(),
+            it.get_var(location_var)
+        );
     });
 
     // Output:

--- a/flecs_ecs/examples/flecs/queries/query_variables.rs
+++ b/flecs_ecs/examples/flecs/queries/query_variables.rs
@@ -48,7 +48,7 @@ fn main() {
         // same entity.
         .with((id::<Eats>(), "$food"))
         .with(id::<&Healthy>())
-        .set_src_name("$food")
+        .set_src("$food")
         .build();
 
     // Lookup the index of the variable. This will let us quickly lookup its

--- a/flecs_ecs/examples/flecs/queries/query_variables.rs
+++ b/flecs_ecs/examples/flecs/queries/query_variables.rs
@@ -11,23 +11,23 @@ struct Healthy;
 fn main() {
     let world = World::new();
 
-    let apples = world.entity_named("Apples").add::<Healthy>();
-    let salad = world.entity_named("Salad").add::<Healthy>();
+    let apples = world.entity_named("Apples").add(id::<Healthy>());
+    let salad = world.entity_named("Salad").add(id::<Healthy>());
     let burgers = world.entity_named("Burgers");
     let pizza = world.entity_named("Pizza");
     let chocolate = world.entity_named("Chocolate");
 
     world
         .entity_named("Bob")
-        .add_first::<Eats>(apples)
-        .add_first::<Eats>(burgers)
-        .add_first::<Eats>(pizza);
+        .add((id::<Eats>(), apples))
+        .add((id::<Eats>(), burgers))
+        .add((id::<Eats>(), pizza));
 
     world
         .entity_named("Alice")
-        .add_first::<Eats>(salad)
-        .add_first::<Eats>(chocolate)
-        .add_first::<Eats>(apples);
+        .add((id::<Eats>(), salad))
+        .add((id::<Eats>(), chocolate))
+        .add((id::<Eats>(), apples));
 
     // Here we're creating a rule that in the query DSL would look like this:
     //   Eats($This, $Food), Healthy($Food)
@@ -46,8 +46,8 @@ fn main() {
         //
         // By replacing * with _Food, both terms are constrained to use the
         // same entity.
-        .with_first_name::<&Eats>("$food")
-        .with::<&Healthy>()
+        .with_name_second(id::<Eats>(), "$food")
+        .with(id::<&Healthy>())
         .set_src_name("$food")
         .build();
 
@@ -59,7 +59,7 @@ fn main() {
     rule.each_iter(|it, index, ()| {
         println!(
             "{} eats {}",
-            it.entity(index).name(),
+            it.entity(index).unwrap().name(),
             it.get_var(food_var.unwrap()).name()
         );
     });

--- a/flecs_ecs/examples/flecs/queries/query_variables.rs
+++ b/flecs_ecs/examples/flecs/queries/query_variables.rs
@@ -46,7 +46,7 @@ fn main() {
         //
         // By replacing * with _Food, both terms are constrained to use the
         // same entity.
-        .with_name_second(id::<Eats>(), "$food")
+        .with((id::<Eats>(), "$food"))
         .with(id::<&Healthy>())
         .set_src_name("$food")
         .build();

--- a/flecs_ecs/examples/flecs/queries/query_wildcard.rs
+++ b/flecs_ecs/examples/flecs/queries/query_wildcard.rs
@@ -33,7 +33,7 @@ fn main() {
     // Iterate the query with a flecs::iter. This makes it possible to inspect
     // the pair that we are currently matched with.
     query.each_iter(|it, index, eats| {
-        let entity = it.entity(index);
+        let entity = it.entity(index).unwrap();
         let pair = it.pair(0).unwrap();
         let food = pair.second_id();
 

--- a/flecs_ecs/examples/flecs/queries/query_with.rs
+++ b/flecs_ecs/examples/flecs/queries/query_with.rs
@@ -19,18 +19,18 @@ fn main() {
     // result does not become part of the function signatures of each and iter.
     // This is useful for things like tags, which because they don't have a
     // value are less useful to pass to the each/iter functions as argument.
-    let query = world.query::<&Position>().with::<&Npc>().build();
+    let query = world.query::<&Position>().with(id::<&Npc>()).build();
 
     // Create a few test entities for the Position, Npc query
     world
         .entity_named("e1")
         .set(Position { x: 10.0, y: 20.0 })
-        .add::<Npc>();
+        .add(id::<Npc>());
 
     world
         .entity_named("e2")
         .set(Position { x: 10.0, y: 20.0 })
-        .add::<Npc>();
+        .add(id::<Npc>());
 
     // This entity will not match as it does not have Position, Npc
     world.entity_named("e3").set(Position { x: 10.0, y: 20.0 });

--- a/flecs_ecs/examples/flecs/queries/query_without.rs
+++ b/flecs_ecs/examples/flecs/queries/query_without.rs
@@ -22,7 +22,7 @@ fn main() {
     //
     // The without method is short for:
     //   .term<Npc>().not_()
-    let query = world.query::<&Position>().without::<&Npc>().build();
+    let query = world.query::<&Position>().without(id::<Npc>()).build();
 
     // Create a few test entities for the Position query
     world.entity_named("e1").set(Position { x: 10.0, y: 20.0 });
@@ -33,7 +33,7 @@ fn main() {
     world
         .entity_named("e3")
         .set(Position { x: 10.0, y: 20.0 })
-        .add::<Npc>();
+        .add(id::<Npc>());
 
     // Note how the Npc tag is not part of the each signature
     query.each_entity(|entity, pos| {

--- a/flecs_ecs/examples/flecs/reflection/entity_type.rs
+++ b/flecs_ecs/examples/flecs/reflection/entity_type.rs
@@ -16,7 +16,7 @@ fn main() {
     world.component::<TypeWithEntity>().meta();
 
     /* Alternatively, you can do it manually like so (without the derive macro)
-    .member::<Entity>("e", 1, core::mem::offset_of!(TypeWithEntity, e));
+    .member(id::<Entity>(),"e", 1, core::mem::offset_of!(TypeWithEntity, e));
     */
 
     let bar = world.entity_named("bar");

--- a/flecs_ecs/examples/flecs/reflection/reflection_basics.rs
+++ b/flecs_ecs/examples/flecs/reflection/reflection_basics.rs
@@ -16,8 +16,8 @@ fn main() {
     world.component::<Position>().meta();
 
     /* Alternatively, you can do it manually like so (without the derive macro)
-        .member::<f32>("x", 1 /* count */, core::mem::offset_of!(Position, x))
-        .member::<f32>("y", 1, core::mem::offset_of!(Position, y));
+        .member(id::<f32>(),"x", 1 /* count */, core::mem::offset_of!(Position, x))
+        .member(id::<f32>(),"y", 1, core::mem::offset_of!(Position, y));
     */
 
     // Create a new entity

--- a/flecs_ecs/examples/flecs/reflection/reflection_basics_bitmask.rs
+++ b/flecs_ecs/examples/flecs/reflection/reflection_basics_bitmask.rs
@@ -63,7 +63,9 @@ fn main() {
         .bit("lettuce", Toppings::LETTUCE)
         .bit("tomato", Toppings::TOMATO);
 
-    world.component::<Sandwich>().member::<Toppings>("toppings");
+    world
+        .component::<Sandwich>()
+        .member(id::<Toppings>(), "toppings");
 
     // Create entity with Sandwich
     let e = world.entity().set(Sandwich {

--- a/flecs_ecs/examples/flecs/reflection/reflection_basics_deserialize.rs
+++ b/flecs_ecs/examples/flecs/reflection/reflection_basics_deserialize.rs
@@ -16,12 +16,12 @@ fn main() {
     world.component::<Position>().meta();
 
     /* Alternatively, you can do it manually like so (without the derive macro)
-    .member::<f32>("x", 1 /* count */, core::mem::offset_of!(Position, x))
-    .member::<f32>("y", 1, core::mem::offset_of!(Position, y));
+    .member(id::<f32>(),"x", 1 /* count */, core::mem::offset_of!(Position, x))
+    .member(id::<f32>(),"y", 1, core::mem::offset_of!(Position, y));
     */
 
     // Create a new entity, set value of position using reflection API
-    let e = world.entity().add::<Position>();
+    let e = world.entity().add(id::<Position>());
 
     e.get::<&mut Position>(|pos| {
         let mut cur = world.cursor::<Position>(pos);

--- a/flecs_ecs/examples/flecs/reflection/reflection_basics_json.rs
+++ b/flecs_ecs/examples/flecs/reflection/reflection_basics_json.rs
@@ -16,8 +16,8 @@ fn main() {
     world.component::<Position>().meta();
 
     /* Alternatively, you can do it manually like so (without the derive macro)
-    .member::<f32>("x", 1 /* count */, core::mem::offset_of!(Position, x))
-    .member::<f32>("y", 1, core::mem::offset_of!(Position, y));
+    .member(id::<f32>(),"x", 1 /* count */, core::mem::offset_of!(Position, x))
+    .member(id::<f32>(),"y", 1, core::mem::offset_of!(Position, y));
     */
 
     // Create a new entity with the Position component

--- a/flecs_ecs/examples/flecs/reflection/reflection_basics_simple_enum.rs
+++ b/flecs_ecs/examples/flecs/reflection/reflection_basics_simple_enum.rs
@@ -32,7 +32,7 @@ fn main() {
     world.component::<TypeWithEnum>().meta();
 
     /* Alternatively, you can do it manually like so (without the derive macro)
-    .member::<Color>("color", 1, core::mem::offset_of!(TypeWithEnum, color));
+    .member(id::<Color>(),"color", 1, core::mem::offset_of!(TypeWithEnum, color));
      */
 
     // Create a new entity

--- a/flecs_ecs/examples/flecs/reflection/reflection_nested_set_member.rs
+++ b/flecs_ecs/examples/flecs/reflection/reflection_nested_set_member.rs
@@ -24,7 +24,7 @@ fn main() {
     world.component::<Line>().meta();
 
     // Create entity, set value of Line using reflection API
-    let e = world.entity().add::<Line>();
+    let e = world.entity().add(id::<Line>());
 
     e.get::<&mut Line>(|line| {
         let mut cur = world.cursor(line);

--- a/flecs_ecs/examples/flecs/reflection/reflection_runtime_component.rs
+++ b/flecs_ecs/examples/flecs/reflection/reflection_runtime_component.rs
@@ -7,8 +7,8 @@ fn main() {
 
     let position = world
         .component_untyped_named("Position")
-        .member::<f32>("x")
-        .member::<f32>("y");
+        .member(id::<f32>(), "x")
+        .member(id::<f32>(), "y");
 
     // Create entity
     let e = world.entity();

--- a/flecs_ecs/examples/flecs/reflection/reflection_runtime_nested_component.rs
+++ b/flecs_ecs/examples/flecs/reflection/reflection_runtime_nested_component.rs
@@ -7,16 +7,16 @@ fn main() {
 
     let point = world
         .component_untyped_named("Point")
-        .member::<f32>("x")
-        .member::<f32>("y");
+        .member(id::<f32>(), "x")
+        .member(id::<f32>(), "y");
 
     let line = world
         .component_untyped_named("Line")
-        .member_id(point, "start")
-        .member_id(point, "stop");
+        .member(point, "start")
+        .member(point, "stop");
 
     // Create entity, set value of line using reflection API
-    let e = world.entity().add_id(line);
+    let e = world.entity().add(line);
 
     let ptr = e.get_untyped_mut(line);
 

--- a/flecs_ecs/examples/flecs/reflection/reflection_ser_opaque_type.rs
+++ b/flecs_ecs/examples/flecs/reflection/reflection_ser_opaque_type.rs
@@ -21,9 +21,9 @@ fn main() {
         .opaque_id(
             world
                 .component_untyped()
-                .member::<i32>("a")
-                .member::<i32>("b")
-                .member::<i32>("result"),
+                .member(id::<i32>(), "a")
+                .member(id::<i32>(), "b")
+                .member(id::<i32>(), "result"),
         )
         // Forward struct members to serializer
         .serialize(|s: &Serializer, data: &Sum| {

--- a/flecs_ecs/examples/flecs/relationships/relationships_basics.rs
+++ b/flecs_ecs/examples/flecs/relationships/relationships_basics.rs
@@ -20,20 +20,20 @@ fn main() {
     let bob = world
         .entity_named("Bob")
         // Pairs can be constructed from a type and entity
-        .add_first::<Eats>(apples)
-        .add_first::<Eats>(pears)
+        .add((id::<Eats>(), apples))
+        .add((id::<Eats>(), pears))
         // Pairs can also be constructed from two entity ids
-        .add_id((grows, pears));
+        .add((grows, pears));
 
     // Has can be used with relationships as well
-    println!("Bob eats apples? {}", bob.has_first::<Eats>(apples));
+    println!("Bob eats apples? {}", bob.has((id::<Eats>(), apples)));
 
     // Wildcards can be used to match relationships
     println!(
         "Bob grows food? {}, {}",
-        bob.has_id((grows, flecs::Wildcard::ID)),
+        bob.has((grows, flecs::Wildcard::ID)),
         //or you can do
-        bob.has_second::<flecs::Wildcard>(grows)
+        bob.has((grows, id::<flecs::Wildcard>()))
     );
 
     println!();
@@ -45,7 +45,7 @@ fn main() {
     println!();
 
     // Relationships can be iterated for an entity. This iterates (Eats, *):
-    bob.each_target::<Eats>(|second| {
+    bob.each_target(id::<Eats>(), |second| {
         println!("Bob eats {}", second.name());
     });
 
@@ -59,10 +59,13 @@ fn main() {
     println!();
 
     // Get first target of relationship
-    println!("Bob eats {}", bob.target::<Eats>(0).unwrap().name());
+    println!("Bob eats {}", bob.target(id::<Eats>(), 0).unwrap().name());
 
     // Get second target of relationship
-    println!("Bob also eats {}", bob.target::<Eats>(1).unwrap().name());
+    println!(
+        "Bob also eats {}",
+        bob.target(id::<Eats>(), 1).unwrap().name()
+    );
 
     // Output:
     //  Bob eats apples? true

--- a/flecs_ecs/examples/flecs/relationships/relationships_component_data.rs
+++ b/flecs_ecs/examples/flecs/relationships/relationships_component_data.rs
@@ -78,7 +78,7 @@ fn main() {
     println!(
         "{}",
         world
-            .id_from::<(Requires, Gigawatts)>()
+            .id_view_from((id::<Requires>(), id::<Gigawatts>()))
             .type_id()
             .path()
             .unwrap()
@@ -86,7 +86,7 @@ fn main() {
     println!(
         "{}",
         world
-            .id_from::<(Gigawatts, Requires)>()
+            .id_view_from((id::<Gigawatts>(), id::<Requires>()))
             .type_id()
             .path()
             .unwrap()
@@ -94,7 +94,7 @@ fn main() {
     println!(
         "{}",
         world
-            .id_from::<(Expires, Position)>()
+            .id_view_from((id::<Expires>(), id::<Position>()))
             .type_id()
             .path()
             .unwrap()

--- a/flecs_ecs/examples/flecs/relationships/relationships_enum.rs
+++ b/flecs_ecs/examples/flecs/relationships/relationships_enum.rs
@@ -55,11 +55,8 @@ fn main() {
     println!();
 
     // Check if the entity has the Tile relationship and the Tile::Stone pair
-    println!("has tile enum: {}", tile.has::<Tile>()); // true
-    println!(
-        "is the enum from tile stone?: {}",
-        tile.has_enum(Tile::Stone)
-    ); // true
+    println!("has tile enum: {}", tile.has(id::<Tile>())); // true
+    println!("is the enum from tile stone?: {}", tile.has(Tile::Stone)); // true
 
     // Get the current value of the enum
     tile.try_get::<&Tile>(|tile| {
@@ -116,7 +113,7 @@ fn main() {
     println!();
 
     // Remove any instance of the TileStatus relationship
-    tile.remove::<TileStatus>();
+    tile.remove(id::<TileStatus>());
 
     // (Tile, Tile.Stone)
     println!("{:?}", tile.archetype());

--- a/flecs_ecs/examples/flecs/relationships/relationships_exclusive.rs
+++ b/flecs_ecs/examples/flecs/relationships/relationships_exclusive.rs
@@ -10,7 +10,7 @@ fn main() {
 
     // Register Platoon as exclusive relationship. This ensures that an entity
     // can only belong to a single Platoon.
-    world.component::<Platoon>().add::<flecs::Exclusive>();
+    world.component::<Platoon>().add(id::<flecs::Exclusive>());
 
     // Create two platoons
     let platoon_1 = world.entity();
@@ -20,16 +20,16 @@ fn main() {
     let unit = world.entity();
 
     // Add unit to platoon 1
-    unit.add_first::<Platoon>(platoon_1);
+    unit.add((id::<Platoon>(), platoon_1));
 
     // Log platoon of unit
     println!(
         "Unit in platoon 1: {}",
-        unit.has_first::<Platoon>(platoon_1)
+        unit.has((id::<Platoon>(), platoon_1))
     ); // true
     println!(
         "Unit in platoon 2: {}",
-        unit.has_first::<Platoon>(platoon_2)
+        unit.has((id::<Platoon>(), platoon_2))
     ); // false
 
     println!();
@@ -37,16 +37,16 @@ fn main() {
     // Add unit to platoon 2. Because Platoon is an exclusive relationship, this
     // both removes (Platoon, platoon_1) and adds (Platoon, platoon_2) in a
     // single operation.
-    unit.add_first::<Platoon>(platoon_2);
+    unit.add((id::<Platoon>(), platoon_2));
 
     // Log platoon of unit
     println!(
         "Unit in platoon 1: {}",
-        unit.has_first::<Platoon>(platoon_1)
+        unit.has((id::<Platoon>(), platoon_1))
     ); // false
     println!(
         "Unit in platoon 2: {}",
-        unit.has_first::<Platoon>(platoon_2)
+        unit.has((id::<Platoon>(), platoon_2))
     ); // true
 
     // Output:

--- a/flecs_ecs/examples/flecs/relationships/relationships_symmetric.rs
+++ b/flecs_ecs/examples/flecs/relationships/relationships_symmetric.rs
@@ -9,7 +9,9 @@ fn main() {
 
     // Register TradesWith as symmetric relationship. Symmetric relationships
     // go both ways, adding (R, B) to A will also add (R, A) to B.
-    world.component::<TradesWith>().add::<flecs::Symmetric>();
+    world
+        .component::<TradesWith>()
+        .add(id::<flecs::Symmetric>());
 
     // Create two players
     let player_1 = world.entity();
@@ -17,16 +19,16 @@ fn main() {
 
     // Add (TradesWith, player_2) to player_1. This also adds
     // (TradesWith, player_1) to player_2.
-    player_1.add_first::<TradesWith>(player_2);
+    player_1.add((id::<TradesWith>(), player_2));
 
     // Log platoon of unit
     println!(
         "Player 1 trades with Player 2: {}",
-        player_1.has_first::<TradesWith>(player_2)
+        player_1.has((id::<TradesWith>(), player_2))
     ); // true
     println!(
         "Player 2 trades with Player 1: {}",
-        player_2.has_first::<TradesWith>(player_1)
+        player_2.has((id::<TradesWith>(), player_1))
     ); // true
 
     // Output:

--- a/flecs_ecs/examples/flecs/relationships/relationships_union.rs
+++ b/flecs_ecs/examples/flecs/relationships/relationships_union.rs
@@ -37,8 +37,8 @@ fn main() {
 
     // Register Movement and Direction as union relationships. This ensures that
     // an entity can only have one Movement and one Direction.
-    world.component::<Movement>().add::<flecs::Union>();
-    world.component::<Direction>().add::<flecs::Union>();
+    world.component::<Movement>().add(id::<flecs::Union>());
+    world.component::<Direction>().add(id::<flecs::Union>());
 
     // Create a query that subscribes for all entities that have a Direction
     // and that are walking.
@@ -69,7 +69,7 @@ fn main() {
 
     // Iterate the query
     q.each_iter(|it, index, ()| {
-        let entity = it.entity(index);
+        let entity = it.entity(index).unwrap();
 
         // Movement will always be Walking, Direction can be any state
         println!(

--- a/flecs_ecs/examples/flecs/systems/system_ctx.rs
+++ b/flecs_ecs/examples/flecs/systems/system_ctx.rs
@@ -52,7 +52,7 @@ fn main() {
         .set_context(&mut query_collide as *mut Query<(&Position, &Radius)> as *mut c_void)
         .each_iter(|mut it, index, (p1, r1)| {
             let query = unsafe { it.context::<Query<(&Position, &Radius)>>() };
-            let e1 = it.entity(index);
+            let e1 = it.entity(index).unwrap();
 
             query.each_entity(|e2, (p2, r2)| {
                 if e1 == *e2 {

--- a/flecs_ecs/examples/flecs/systems/system_custom_phases.rs
+++ b/flecs_ecs/examples/flecs/systems/system_custom_phases.rs
@@ -20,28 +20,28 @@ fn main() {
     // to discover which systems it should run.
     let physics = world
         .entity()
-        .add::<flecs::pipeline::Phase>()
-        .depends_on::<flecs::pipeline::OnUpdate>();
+        .add(id::<flecs::pipeline::Phase>())
+        .depends_on(id::<flecs::pipeline::OnUpdate>());
 
     let collisions = world
         .entity()
-        .add::<flecs::pipeline::Phase>()
-        .depends_on_id(physics);
+        .add(id::<flecs::pipeline::Phase>())
+        .depends_on(physics);
 
     // Create 3 dummy systems.
     world
         .system_named::<()>("CollisionSystem")
-        .kind_id(collisions)
+        .kind(collisions)
         .run(sys);
 
     world
         .system_named::<()>("PhysicsSystem")
-        .kind_id(physics)
+        .kind(physics)
         .run(sys);
 
     world
         .system_named::<()>("GameSystem")
-        .kind::<flecs::pipeline::OnUpdate>()
+        .kind(id::<flecs::pipeline::OnUpdate>())
         .run(sys);
 
     // Run pipeline

--- a/flecs_ecs/examples/flecs/systems/system_custom_phases_no_builtin.rs
+++ b/flecs_ecs/examples/flecs/systems/system_custom_phases_no_builtin.rs
@@ -19,33 +19,30 @@ fn main() {
     // which is necessary for the builtin pipeline to discover which systems it
     // should run.
 
-    let update = world.entity().add::<flecs::pipeline::Phase>();
+    let update = world.entity().add(id::<flecs::pipeline::Phase>());
 
     let physics = world
         .entity()
-        .add::<flecs::pipeline::Phase>()
-        .depends_on_id(update);
+        .add(id::<flecs::pipeline::Phase>())
+        .depends_on(update);
 
     let collisions = world
         .entity()
-        .add::<flecs::pipeline::Phase>()
-        .depends_on_id(physics);
+        .add(id::<flecs::pipeline::Phase>())
+        .depends_on(physics);
 
     // Create 3 dummy systems.
     world
         .system_named::<()>("CollisionSystem")
-        .kind_id(collisions)
+        .kind(collisions)
         .run(sys);
 
     world
         .system_named::<()>("PhysicsSystem")
-        .kind_id(physics)
+        .kind(physics)
         .run(sys);
 
-    world
-        .system_named::<()>("GameSystem")
-        .kind_id(update)
-        .run(sys);
+    world.system_named::<()>("GameSystem").kind(update).run(sys);
 
     // Run pipeline
     world.progress();

--- a/flecs_ecs/examples/flecs/systems/system_custom_pipeline.rs
+++ b/flecs_ecs/examples/flecs/systems/system_custom_pipeline.rs
@@ -20,15 +20,15 @@ fn main() {
     // DependsOn relationship.
     let pipeline = world
         .pipeline()
-        .with_id(flecs::system::System::ID)
-        .with::<&Physics>()
+        .with(flecs::system::System::ID)
+        .with(id::<&Physics>())
         .build();
 
     // Configure the world to use the custom pipeline
-    world.set_pipeline_id(pipeline.entity());
+    world.set_pipeline(pipeline.entity());
 
     // Create system with Physics tag
-    world.system::<()>().kind::<Physics>().run(|mut it| {
+    world.system::<()>().kind(id::<Physics>()).run(|mut it| {
         while it.next() {
             println!("System with Physics ran!");
         }

--- a/flecs_ecs/examples/flecs/systems/system_mutate_entity.rs
+++ b/flecs_ecs/examples/flecs/systems/system_mutate_entity.rs
@@ -26,7 +26,7 @@ fn main() {
                 // When the entity to be mutated is not the same as the entity
                 // provided by the system, an additional mut() call is required.
                 // See the mutate_entity_handle example.
-                let e = it.entity(index);
+                let e = it.entity(index).unwrap();
                 e.destruct();
                 println!("Expire: {} deleted!", e.name());
             }

--- a/flecs_ecs/examples/flecs/systems/system_mutate_entity_handle.rs
+++ b/flecs_ecs/examples/flecs/systems/system_mutate_entity_handle.rs
@@ -41,7 +41,7 @@ fn main() {
                 //
                 // The current entity can also be used to provide context. This
                 // is useful for functions that accept a flecs::entity:
-                //   t.to_delete.mut(it.entity(index)).destruct();
+                //   t.to_delete.mut(it.entity(index).unwrap()).destruct();
                 //
                 // A shortcut is to use the iterator directly:
                 let world = it.world();
@@ -65,12 +65,12 @@ fn main() {
     // Observer that triggers when entity is actually deleted
     world
         .observer::<flecs::OnRemove, ()>()
-        .with::<Tag>()
+        .with(id::<Tag>())
         .each_entity(|e, _tag| {
             println!("Expired: {} actually deleted", e.name());
         });
 
-    let to_delete = world.entity_named("ToDelete").add::<Tag>();
+    let to_delete = world.entity_named("ToDelete").add(id::<Tag>());
 
     world.entity_named("MyEntity").set(Timeout {
         to_delete: to_delete.id(),

--- a/flecs_ecs/examples/flecs/systems/system_pipeline.rs
+++ b/flecs_ecs/examples/flecs/systems/system_pipeline.rs
@@ -20,7 +20,7 @@ fn main() {
     // Create a system for moving an entity
     world
         .system::<(&mut Position, &Velocity)>()
-        .kind::<flecs::pipeline::OnUpdate>()
+        .kind(id::<flecs::pipeline::OnUpdate>())
         .each(|(p, v)| {
             p.x += v.x;
             p.y += v.y;
@@ -29,7 +29,7 @@ fn main() {
     // Create a system for printing the entity position
     world
         .system::<&Position>()
-        .kind::<flecs::pipeline::PostUpdate>()
+        .kind(id::<flecs::pipeline::PostUpdate>())
         .each_entity(|e, p| {
             println!("{}: {{ {}, {} }}", e.name(), p.x, p.y);
         });

--- a/flecs_ecs/examples/flecs/systems/system_startup_system.rs
+++ b/flecs_ecs/examples/flecs/systems/system_startup_system.rs
@@ -16,7 +16,7 @@ fn main() {
     // Startup system
     world
         .system_named::<()>("Startup")
-        .kind::<flecs::pipeline::OnStart>()
+        .kind(id::<flecs::pipeline::OnStart>())
         .run(|mut it| {
             while it.next() {
                 println!("{}", it.system().name());

--- a/flecs_ecs/examples/flecs/systems/system_sync_point.rs
+++ b/flecs_ecs/examples/flecs/systems/system_sync_point.rs
@@ -32,9 +32,9 @@ fn main() {
 
     world
         .system_named::<()>("SetVelocitySP")
-        .with::<&PositionSP>()
+        .with(id::<&PositionSP>())
         .set_inout_none()
-        .write::<VelocitySP>() // VelocitySP is written, but shouldn't be matched
+        .with(id::<&mut VelocitySP>()) // VelocitySP is written, but shouldn't be matched
         .each_entity(|e, ()| {
             e.set(VelocitySP { x: 1.0, y: 2.0 });
         });
@@ -86,7 +86,7 @@ fn main() {
 
     // The "merge" lines indicate sync points.
     //
-    // Removing `.write::<VelocitySP>()` from the system will remove the first
+    // Removing `.with(id::<&mut VelocitySP>())` from the system will remove the first
     // sync point from the schedule.
 }
 

--- a/flecs_ecs/examples/flecs/systems/system_sync_point_delete.rs
+++ b/flecs_ecs/examples/flecs/systems/system_sync_point_delete.rs
@@ -43,7 +43,7 @@ fn main() {
     // const, since inside the system we're only reading it.
     world
         .system_named::<&Position>("DeleteEntity")
-        .write::<flecs::Wildcard>()
+        .with(id::<&mut flecs::Wildcard>())
         .each_entity(|e, p| {
             if p.x >= 3.0 {
                 println!("Delete entity {}", e.name());
@@ -77,7 +77,7 @@ fn main() {
     set_log_level(1);
 
     while world.progress() {
-        if world.count::<Position>() == 0 {
+        if world.count(id::<Position>()) == 0 {
             break; // No more entities left with Position
         }
     }

--- a/flecs_ecs/src/addons/alerts/alert_builder.rs
+++ b/flecs_ecs/src/addons/alerts/alert_builder.rs
@@ -414,9 +414,6 @@ where
     type BuiltType = Alert<'a>;
 
     /// Build the `AlertBuilder` into an Alert
-    ///
-    /// See also
-    ///
     fn build(&mut self) -> Self::BuiltType {
         let alert = Alert::new(self.world(), self.desc);
         for s in self.term_builder.str_ptrs_to_free.iter_mut() {

--- a/flecs_ecs/src/addons/alerts/alert_builder.rs
+++ b/flecs_ecs/src/addons/alerts/alert_builder.rs
@@ -5,7 +5,6 @@ use crate::core::*;
 use crate::sys;
 
 use super::Alert;
-use super::SeverityAlert;
 
 use core::mem::ManuallyDrop;
 
@@ -173,25 +172,9 @@ where
     /// # See also
     ///
     /// * `ecs_alert_desc_t::severity`
-    pub fn severity_id(&mut self, severity: impl Into<Entity>) -> &mut Self {
-        self.desc.severity = *severity.into();
+    pub fn severity(&mut self, severity: impl IntoEntity) -> &mut Self {
+        self.desc.severity = *severity.into_entity(self.world);
         self
-    }
-
-    /// Set severity of alert (default is Error).
-    ///
-    /// # Type Parameters
-    ///
-    /// * `Severity` - The severity component.
-    ///
-    /// # See also
-    ///
-    /// * `ecs_alert_desc_t::severity`
-    pub fn severity<Severity>(&mut self) -> &mut Self
-    where
-        Severity: ComponentId + SeverityAlert,
-    {
-        self.severity_id(Severity::id(self.world()))
     }
 
     /// Set retain period of alert.
@@ -219,10 +202,10 @@ where
     /// # See also
     ///
     /// * `ecs_alert_desc_t::severity_filters`
-    pub fn severity_filter_id(
+    pub fn severity_filter(
         &mut self,
-        severity: impl Into<Entity>,
-        with: impl Into<Id>,
+        severity: impl IntoEntity,
+        with: impl IntoId,
         var: Option<&str>,
     ) -> &mut Self {
         ecs_assert!(
@@ -232,36 +215,14 @@ where
 
         let filter = &mut self.desc.severity_filters[self.severity_filter_count as usize];
         self.severity_filter_count += 1;
-        filter.severity = *severity.into();
-        filter.with = *with.into();
+        filter.severity = *severity.into_entity(self.world);
+        filter.with = *with.into_id(self.world);
         if let Some(var) = var {
             let var = ManuallyDrop::new(format!("{}\0", var));
             filter.var = var.as_ptr() as *const _;
             self.str_ptrs_to_free.push(var);
         }
         self
-    }
-
-    /// Add severity filter.
-    ///
-    /// # Type Parameters
-    ///
-    /// * `Severity` - Severity component.
-    ///
-    /// # Arguments
-    ///
-    /// * `with` - Filter with this id.
-    /// * `var` - Variable name (optional).
-    ///
-    /// # See also
-    ///
-    /// * `ecs_alert_desc_t::severity_filters`
-    pub fn severity_filter<Severity>(&mut self, with: impl Into<Id>, var: Option<&str>) -> &mut Self
-    where
-        Severity: ComponentId,
-    {
-        let severity_id = Severity::id(self.world());
-        self.severity_filter_id(severity_id, with, var)
     }
 
     /// Add severity filter for non-enum components.
@@ -285,7 +246,7 @@ where
     {
         let severity_id = Severity::id(self.world());
         let with_id = With::id(self.world());
-        self.severity_filter_id(severity_id, with_id, var)
+        self.severity_filter(severity_id, with_id, var)
     }
 
     /// Add severity filter for enum components.
@@ -317,7 +278,7 @@ where
         let with_id = With::id(world);
         let constant_id = with.id_variant(world);
         let pair_id = ecs_pair(with_id, *constant_id.id());
-        self.severity_filter_id(severity_id, pair_id, var)
+        self.severity_filter(severity_id, pair_id, var)
     }
 
     /// Set member to create an alert for out of range values.
@@ -329,8 +290,8 @@ where
     /// # See also
     ///
     /// * `ecs_alert_desc_t::member`
-    pub fn member_id(&mut self, member: impl Into<Entity>) -> &mut Self {
-        self.desc.member = *member.into();
+    pub fn member(&mut self, member: impl IntoEntity) -> &mut Self {
+        self.desc.member = *member.into_entity(self.world);
         self
     }
 
@@ -344,8 +305,8 @@ where
     /// # See also
     ///
     /// * `ecs_alert_desc_t::id`
-    pub fn id(&mut self, id: impl Into<Id>) -> &mut Self {
-        self.desc.id = *id.into();
+    pub fn id(&mut self, id: impl IntoId) -> &mut Self {
+        self.desc.id = *id.into_id(self.world);
         self
     }
 
@@ -395,7 +356,7 @@ where
             self.str_ptrs_to_free.push(var);
         }
 
-        self.member_id(member_id)
+        self.member(member_id)
     }
 
     /// Set source variable for member (optional, defaults to `$this`).

--- a/flecs_ecs/src/addons/doc.rs
+++ b/flecs_ecs/src/addons/doc.rs
@@ -44,7 +44,7 @@ pub trait Doc<'a>: WorldProvider<'a> + Into<Entity> + Clone {
     ///
     /// * [`World::doc_name()`]
     fn doc_name(&self) -> Option<String> {
-        self.world().doc_name_id(self.clone())
+        self.world().doc_name(self.clone())
     }
 
     /// Get brief description for an entity.
@@ -57,7 +57,7 @@ pub trait Doc<'a>: WorldProvider<'a> + Into<Entity> + Clone {
     ///
     /// * [`World::doc_brief()`]
     fn doc_brief(&self) -> Option<String> {
-        self.world().doc_brief_id(self.clone())
+        self.world().doc_brief(self.clone())
     }
 
     /// Get detailed description for an entity.
@@ -70,7 +70,7 @@ pub trait Doc<'a>: WorldProvider<'a> + Into<Entity> + Clone {
     ///
     /// * [`World::doc_detail()`]
     fn doc_detail(&self) -> Option<String> {
-        self.world().doc_detail_id(self.clone())
+        self.world().doc_detail(self.clone())
     }
 
     /// Get link to external documentation for an entity.
@@ -83,7 +83,7 @@ pub trait Doc<'a>: WorldProvider<'a> + Into<Entity> + Clone {
     ///
     /// * [`World::doc_link()`]
     fn doc_link(&self) -> Option<String> {
-        self.world().doc_link_id(self.clone())
+        self.world().doc_link(self.clone())
     }
 
     /// Get color for an entity.
@@ -96,7 +96,7 @@ pub trait Doc<'a>: WorldProvider<'a> + Into<Entity> + Clone {
     ///
     /// * [`World::doc_color()`]
     fn doc_color(&self) -> Option<String> {
-        self.world().doc_color_id(self.clone())
+        self.world().doc_color(self.clone())
     }
 
     /// Get UUID for entity
@@ -107,13 +107,11 @@ pub trait Doc<'a>: WorldProvider<'a> + Into<Entity> + Clone {
     ///
     /// # See also
     ///
-    /// * [`World::doc_uuid_id()`]
     /// * [`World::doc_uuid()`]
     /// * [`Doc::set_doc_uuid()`]
-    /// * [`World::set_doc_uuid_id()`]
     /// * [`World::set_doc_uuid()`]
     fn doc_uuid(&self) -> Option<String> {
-        self.world().doc_uuid_id(self.clone())
+        self.world().doc_uuid(self.clone())
     }
 
     //MARK: _setters
@@ -130,9 +128,8 @@ pub trait Doc<'a>: WorldProvider<'a> + Into<Entity> + Clone {
     /// # See also
     ///
     /// * [`World::set_doc_name()`]
-    /// * [`World::set_doc_name_id()`]
     fn set_doc_name(&self, name: &str) -> &Self {
-        self.world().set_doc_name_id(self.clone(), name);
+        self.world().set_doc_name(self.clone(), name);
         self
     }
 
@@ -145,9 +142,8 @@ pub trait Doc<'a>: WorldProvider<'a> + Into<Entity> + Clone {
     /// # See also
     ///
     /// * [`World::set_doc_brief()`]
-    /// * [`World::set_doc_brief_id()`]
     fn set_doc_brief(&self, brief: &str) -> &Self {
-        self.world().set_doc_brief_id(self.clone(), brief);
+        self.world().set_doc_brief(self.clone(), brief);
         self
     }
 
@@ -160,9 +156,8 @@ pub trait Doc<'a>: WorldProvider<'a> + Into<Entity> + Clone {
     /// # See also
     ///
     /// * [`World::set_doc_detail()`]
-    /// * [`World::set_doc_detail_id()`]
     fn set_doc_detail(&self, detail: &str) -> &Self {
-        self.world().set_doc_detail_id(self.clone(), detail);
+        self.world().set_doc_detail(self.clone(), detail);
         self
     }
 
@@ -175,9 +170,8 @@ pub trait Doc<'a>: WorldProvider<'a> + Into<Entity> + Clone {
     /// # See also
     ///
     /// * [`World::set_doc_link()`]
-    /// * [`World::set_doc_link_id()`]
     fn set_doc_link(&self, link: &str) -> &Self {
-        self.world().set_doc_link_id(self.clone(), link);
+        self.world().set_doc_link(self.clone(), link);
         self
     }
 
@@ -193,9 +187,8 @@ pub trait Doc<'a>: WorldProvider<'a> + Into<Entity> + Clone {
     /// # See also
     ///
     /// * [`World::set_doc_color()`]
-    /// * [`World::set_doc_color_id()`]
     fn set_doc_color(&self, color: &str) -> &Self {
-        self.world().set_doc_color_id(self.clone(), color);
+        self.world().set_doc_color(self.clone(), color);
         self
     }
 
@@ -207,13 +200,11 @@ pub trait Doc<'a>: WorldProvider<'a> + Into<Entity> + Clone {
     /// * `uuid` - The UUID to add.
     ///
     /// # See also
-    /// * [`World::set_doc_uuid_id()`]
     /// * [`World::set_doc_uuid()`]
     /// * [`World::doc_uuid()`]
-    /// * [`World::doc_uuid_id()`]
     /// * [`Doc::doc_uuid()`]
     fn set_doc_uuid(&self, uuid: &str) -> &Self {
-        self.world().set_doc_uuid_id(self.clone(), uuid);
+        self.world().set_doc_uuid(self.clone(), uuid);
         self
     }
 }
@@ -222,36 +213,17 @@ impl<'a, T> Doc<'a> for T where T: Into<Entity> + WorldProvider<'a> + Clone {}
 
 //MARK: impl World
 /// ```
-/// use flecs_ecs::{addons::doc::Doc, core::World, macros::Component};
+/// use flecs_ecs::prelude::*;
 ///
 /// #[derive(Component)]
 /// struct Tag;
 ///
 /// let world = World::default();
 /// world.component::<Tag>();
-/// world.set_doc_name::<Tag>("A tag");
+/// world.set_doc_name(id::<Tag>(),"A tag");
 /// ```
 impl World {
     //MARK: _World::getters
-
-    /// Get human readable name for an entity.
-    ///
-    /// # Type Parameters
-    ///
-    /// * `T` - The type that implements `ComponentId`.
-    ///
-    /// # Returns
-    ///
-    /// The human readable name of the entity.
-    ///
-    /// # See also
-    ///
-    /// * [`Doc::doc_name()`]
-    /// * [`World::doc_name_id()`]
-    #[inline(always)]
-    pub fn doc_name<T: ComponentId>(&self) -> Option<String> {
-        self.doc_name_id(T::get_id(self))
-    }
 
     /// Get human readable name for an entity.
     ///
@@ -268,31 +240,12 @@ impl World {
     /// * [`Doc::doc_name()`]
     /// * [`World::doc_name()`]
     #[inline(always)]
-    pub fn doc_name_id(&self, entity: impl Into<Entity>) -> Option<String> {
-        let cstr = NonNull::new(
-            unsafe { sys::ecs_doc_get_name(self.world_ptr(), *entity.into()) } as *mut _,
-        )
+    pub fn doc_name(&self, entity: impl IntoEntity) -> Option<String> {
+        let cstr = NonNull::new(unsafe {
+            sys::ecs_doc_get_name(self.world_ptr(), *entity.into_entity(self))
+        } as *mut _)
         .map(|s| unsafe { CStr::from_ptr(s.as_ptr()) });
         cstr.and_then(|s| s.to_str().ok().map(ToString::to_string))
-    }
-
-    /// Get brief description for an entity.
-    ///
-    /// # Type Parameters
-    ///
-    /// * `T` - The type that implements `ComponentId`.
-    ///
-    /// # Returns
-    ///
-    /// The brief description of the entity.
-    ///
-    /// # See also
-    ///
-    /// * [`Doc::doc_brief()`]
-    /// * [`World::doc_brief_id()`]
-    #[inline(always)]
-    pub fn doc_brief<T: ComponentId>(&self) -> Option<String> {
-        self.doc_brief_id(T::get_id(self))
     }
 
     /// Get brief description for an entity.
@@ -310,30 +263,12 @@ impl World {
     /// * [`Doc::doc_brief()`]
     /// * [`World::doc_brief()`]
     #[inline(always)]
-    pub fn doc_brief_id(&self, entity: impl Into<Entity>) -> Option<String> {
-        let cstr = NonNull::new(
-            unsafe { sys::ecs_doc_get_brief(self.world_ptr(), *entity.into()) } as *mut _,
-        )
+    pub fn doc_brief(&self, entity: impl IntoEntity) -> Option<String> {
+        let cstr = NonNull::new(unsafe {
+            sys::ecs_doc_get_brief(self.world_ptr(), *entity.into_entity(self))
+        } as *mut _)
         .map(|s| unsafe { CStr::from_ptr(s.as_ptr()) });
         cstr.and_then(|s| s.to_str().ok().map(ToString::to_string))
-    }
-
-    /// Get detailed description for an entity.
-    /// # Type Parameters
-    ///
-    /// * `T` - The type that implements `ComponentId`.
-    ///
-    /// # Returns
-    ///
-    /// The detailed description of the entity.
-    ///
-    /// # See also
-    ///
-    /// * [`Doc::doc_detail()`]
-    /// * [`World::doc_detail_id()`]
-    #[inline(always)]
-    pub fn doc_detail<T: ComponentId>(&self) -> Option<String> {
-        self.doc_detail_id(T::get_id(self))
     }
 
     /// Get detailed description for an entity.
@@ -351,31 +286,12 @@ impl World {
     /// * [`Doc::doc_detail()`]
     /// * [`World::doc_detail()`]
     #[inline(always)]
-    pub fn doc_detail_id(&self, entity: impl Into<Entity>) -> Option<String> {
-        let cstr = NonNull::new(
-            unsafe { sys::ecs_doc_get_detail(self.world_ptr(), *entity.into()) } as *mut _,
-        )
+    pub fn doc_detail(&self, entity: impl IntoEntity) -> Option<String> {
+        let cstr = NonNull::new(unsafe {
+            sys::ecs_doc_get_detail(self.world_ptr(), *entity.into_entity(self))
+        } as *mut _)
         .map(|s| unsafe { CStr::from_ptr(s.as_ptr()) });
         cstr.and_then(|s| s.to_str().ok().map(ToString::to_string))
-    }
-
-    /// Get link to external documentation for an entity.
-    ///
-    /// # Type Parameters
-    ///
-    /// * `T` - The type that implements `ComponentId`.
-    ///
-    /// # Returns
-    ///
-    /// The link to external documentation of the entity.
-    ///
-    /// # See also
-    ///
-    /// * [`Doc::doc_link()`]
-    /// * [`World::doc_link_id()`]
-    #[inline(always)]
-    pub fn doc_link<T: ComponentId>(&self) -> Option<String> {
-        self.doc_link_id(T::get_id(self))
     }
 
     /// Get link to external documentation for an entity.
@@ -392,30 +308,12 @@ impl World {
     /// * [`Doc::doc_link()`]
     /// * [`World::doc_link()`]
     #[inline(always)]
-    pub fn doc_link_id(&self, entity: impl Into<Entity>) -> Option<String> {
-        let cstr = NonNull::new(
-            unsafe { sys::ecs_doc_get_link(self.world_ptr(), *entity.into()) } as *mut _,
-        )
+    pub fn doc_link(&self, entity: impl IntoEntity) -> Option<String> {
+        let cstr = NonNull::new(unsafe {
+            sys::ecs_doc_get_link(self.world_ptr(), *entity.into_entity(self))
+        } as *mut _)
         .map(|s| unsafe { CStr::from_ptr(s.as_ptr()) });
         cstr.and_then(|s| s.to_str().ok().map(ToString::to_string))
-    }
-
-    /// Get color for an entity.
-    /// # Type Parameters
-    ///
-    /// * `T` - The type that implements `ComponentId`.
-    ///
-    /// # Returns
-    ///
-    /// The color of the entity.
-    ///
-    /// # See also
-    ///
-    /// * [`Doc::doc_color()`]
-    /// * [`World::doc_color_id()`]
-    #[inline(always)]
-    pub fn doc_color<T: ComponentId>(&self) -> Option<String> {
-        self.doc_color_id(T::get_id(self))
     }
 
     /// Get color for an entity.
@@ -432,10 +330,10 @@ impl World {
     /// * [`Doc::doc_color()`]
     /// * [`World::doc_color()`]
     #[inline(always)]
-    pub fn doc_color_id(&self, entity: impl Into<Entity>) -> Option<String> {
-        let cstr = NonNull::new(
-            unsafe { sys::ecs_doc_get_color(self.world_ptr(), *entity.into()) } as *mut _,
-        )
+    pub fn doc_color(&self, entity: impl IntoEntity) -> Option<String> {
+        let cstr = NonNull::new(unsafe {
+            sys::ecs_doc_get_color(self.world_ptr(), *entity.into_entity(self))
+        } as *mut _)
         .map(|s| unsafe { CStr::from_ptr(s.as_ptr()) });
         cstr.and_then(|s| s.to_str().ok().map(ToString::to_string))
     }
@@ -446,55 +344,16 @@ impl World {
     ///
     /// * [`World::doc_uuid()`]
     /// * [`Doc::doc_uuid()`]
-    /// * [`World::set_doc_uuid_id()`]
     /// * [`Doc::set_doc_uuid()`]
-    pub fn doc_uuid_id(&self, entity: impl Into<Entity>) -> Option<String> {
-        let cstr = NonNull::new(
-            unsafe { sys::ecs_doc_get_uuid(self.world_ptr(), *entity.into()) } as *mut _,
-        )
+    pub fn doc_uuid(&self, entity: impl IntoEntity) -> Option<String> {
+        let cstr = NonNull::new(unsafe {
+            sys::ecs_doc_get_uuid(self.world_ptr(), *entity.into_entity(self))
+        } as *mut _)
         .map(|s| unsafe { CStr::from_ptr(s.as_ptr()) });
         cstr.and_then(|s| s.to_str().ok().map(ToString::to_string))
     }
 
-    /// Get UUID for component
-    ///
-    /// # Type Parameters
-    ///
-    /// * `T` - The component.
-    ///
-    /// # See Also
-    ///
-    /// * [`World::doc_uuid_id()`]
-    /// * [`Doc::doc_uuid()`]
-    /// * [`World::set_doc_uuid_id()`]
-    /// * [`Doc::set_doc_uuid()`]
-    pub fn doc_uuid<T: ComponentId>(&self) -> Option<String> {
-        self.doc_uuid_id(T::get_id(self))
-    }
-
     //MARK: _World::setters
-
-    /// Add human-readable name to entity.
-    ///
-    /// Contrary to entity names, human readable names do not have to be unique and
-    /// can contain special characters used in the query language like '*'.
-    ///
-    /// # Type Parameters
-    ///
-    /// * `T` - The type that implements `ComponentId`.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - The name to add.
-    ///
-    /// # See also
-    ///
-    /// * [`Doc::set_doc_name()`]
-    /// * [`World::set_doc_name_id()`]
-    #[inline(always)]
-    pub fn set_doc_name<T: ComponentId>(&self, name: &str) {
-        self.set_doc_name_id(T::get_id(self), name);
-    }
 
     /// Add human-readable name to entity.
     ///
@@ -511,28 +370,15 @@ impl World {
     /// * [`Doc::set_doc_name()`]
     /// * [`World::set_doc_name()`]
     #[inline(always)]
-    pub fn set_doc_name_id(&self, entity: impl Into<Entity>, name: &str) {
+    pub fn set_doc_name(&self, entity: impl IntoEntity, name: &str) {
         let name = compact_str::format_compact!("{}\0", name);
-        unsafe { sys::ecs_doc_set_name(self.ptr_mut(), *entity.into(), name.as_ptr() as *const _) };
-    }
-
-    /// Add brief description to entity.
-    ///
-    /// # Type Parameters
-    ///
-    /// * `T` - The type that implements `ComponentId`.
-    ///
-    /// # Arguments
-    ///
-    /// * `brief` - The brief description to add.
-    ///
-    /// # See also
-    ///
-    /// * [`Doc::set_doc_brief()`]
-    /// * [`World::set_doc_brief_id()`]
-    #[inline(always)]
-    pub fn set_doc_brief<T: ComponentId>(&self, brief: &str) {
-        self.set_doc_brief_id(T::get_id(self), brief);
+        unsafe {
+            sys::ecs_doc_set_name(
+                self.ptr_mut(),
+                *entity.into_entity(self),
+                name.as_ptr() as *const _,
+            );
+        };
     }
 
     /// Add brief description to entity.
@@ -547,30 +393,15 @@ impl World {
     /// * [`Doc::set_doc_brief()`]
     /// * [`World::set_doc_brief()`]
     #[inline(always)]
-    pub fn set_doc_brief_id(&self, entity: impl Into<Entity>, brief: &str) {
+    pub fn set_doc_brief(&self, entity: impl IntoEntity, brief: &str) {
         let brief = compact_str::format_compact!("{}\0", brief);
         unsafe {
-            sys::ecs_doc_set_brief(self.ptr_mut(), *entity.into(), brief.as_ptr() as *const _);
+            sys::ecs_doc_set_brief(
+                self.ptr_mut(),
+                *entity.into_entity(self),
+                brief.as_ptr() as *const _,
+            );
         };
-    }
-
-    /// Add detailed description to entity.
-    ///
-    /// # Type Parameters
-    ///
-    /// * `T` - The type that implements `ComponentId`.
-    ///
-    /// # Arguments
-    ///
-    /// * `detail` - The detailed description to add.
-    ///
-    /// # See also
-    ///
-    /// * [`Doc::set_doc_detail()`]
-    /// * [`World::set_doc_detail_id()`]
-    #[inline(always)]
-    pub fn set_doc_detail<T: ComponentId>(&self, detail: &str) {
-        self.set_doc_detail_id(T::get_id(self), detail);
     }
 
     /// Add detailed description to entity.
@@ -585,30 +416,15 @@ impl World {
     /// * [`Doc::set_doc_detail()`]
     /// * [`World::set_doc_detail()`]
     #[inline(always)]
-    pub fn set_doc_detail_id(&self, entity: impl Into<Entity>, detail: &str) {
+    pub fn set_doc_detail(&self, entity: impl IntoEntity, detail: &str) {
         let detail = compact_str::format_compact!("{}\0", detail);
         unsafe {
-            sys::ecs_doc_set_detail(self.ptr_mut(), *entity.into(), detail.as_ptr() as *const _);
+            sys::ecs_doc_set_detail(
+                self.ptr_mut(),
+                *entity.into_entity(self),
+                detail.as_ptr() as *const _,
+            );
         };
-    }
-
-    /// Add link to external documentation to entity.
-    ///
-    /// # Type Parameters
-    ///
-    /// * `T` - The type that implements `ComponentId`.
-    ///
-    /// # Arguments
-    ///
-    /// * `link` - The link to add.
-    ///
-    /// # See also
-    ///
-    /// * [`Doc::set_doc_link()`]
-    /// * [`World::set_doc_link_id()`]
-    #[inline(always)]
-    pub fn set_doc_link<T: ComponentId>(&self, link: &str) {
-        self.set_doc_link_id(T::get_id(self), link);
     }
 
     /// Add link to external documentation to entity.
@@ -623,30 +439,15 @@ impl World {
     /// * [`Doc::set_doc_link()`]
     /// * [`World::set_doc_link()`]
     #[inline(always)]
-    pub fn set_doc_link_id(&self, entity: impl Into<Entity>, link: &str) {
+    pub fn set_doc_link(&self, entity: impl IntoEntity, link: &str) {
         let link = compact_str::format_compact!("{}\0", link);
-        unsafe { sys::ecs_doc_set_link(self.ptr_mut(), *entity.into(), link.as_ptr() as *const _) };
-    }
-
-    /// Add color to component.
-    ///
-    /// UIs can use color as hint to improve visualizing entities.
-    ///
-    /// # Type Parameters
-    ///
-    /// * `T` - The type that implements `ComponentId`.
-    ///
-    /// # Arguments
-    ///
-    /// * `color` - The color to add.
-    ///
-    /// # See also
-    ///
-    /// * [`Doc::set_doc_color()`]
-    /// * [`World::set_doc_color_id()`]
-    #[inline(always)]
-    pub fn set_doc_color<T: ComponentId>(&self, color: &str) {
-        self.set_doc_color_id(T::get_id(self), color);
+        unsafe {
+            sys::ecs_doc_set_link(
+                self.ptr_mut(),
+                *entity.into_entity(self),
+                link.as_ptr() as *const _,
+            );
+        };
     }
 
     /// Add color to entity.
@@ -663,10 +464,14 @@ impl World {
     /// * [`Doc::set_doc_color()`]
     /// * [`World::set_doc_color()`]
     #[inline(always)]
-    pub fn set_doc_color_id(&self, entity: impl Into<Entity>, color: &str) {
+    pub fn set_doc_color(&self, entity: impl IntoEntity, color: &str) {
         let color = compact_str::format_compact!("{}\0", color);
         unsafe {
-            sys::ecs_doc_set_color(self.ptr_mut(), *entity.into(), color.as_ptr() as *const _);
+            sys::ecs_doc_set_color(
+                self.ptr_mut(),
+                *entity.into_entity(self),
+                color.as_ptr() as *const _,
+            );
         };
     }
 
@@ -683,35 +488,16 @@ impl World {
     /// * [`Doc::set_doc_uuid()`]
     /// * [`World::set_doc_uuid()`]
     /// * [`World::doc_uuid()`]
-    /// * [`World::doc_uuid_id()`]
     /// * [`Doc::doc_uuid()`]
-    pub fn set_doc_uuid_id(&self, entity: impl Into<Entity>, uuid: &str) {
+    pub fn set_doc_uuid(&self, entity: impl IntoEntity, uuid: &str) {
         let uuid = compact_str::format_compact!("{}\0", uuid);
         unsafe {
-            sys::ecs_doc_set_uuid(self.ptr_mut(), *entity.into(), uuid.as_ptr() as *const _);
+            sys::ecs_doc_set_uuid(
+                self.ptr_mut(),
+                *entity.into_entity(self),
+                uuid.as_ptr() as *const _,
+            );
         };
-    }
-
-    /// Add UUID to component
-    /// This adds `(flecs.doc.Description, flecs.doc.Uuid)` to the component
-    ///
-    /// # Type Parameters
-    ///
-    /// * `T` - The component.
-    ///
-    /// # Arguments
-    ///
-    /// * `uuid` - The UUID to add.
-    ///
-    /// # See also
-    ///
-    /// * [`World::set_doc_uuid_id()`]
-    /// * [`Doc::set_doc_uuid()`]
-    /// * [`World::doc_uuid()`]
-    /// * [`World::doc_uuid_id()`]
-    /// * [`Doc::doc_uuid()`]
-    pub fn set_doc_uuid<T: ComponentId>(&self, uuid: &str) {
-        self.set_doc_uuid_id(T::get_id(self), uuid);
     }
 }
 
@@ -733,7 +519,7 @@ fn test_compile_doc() {
 
     let observer = world
         .observer::<flecs::OnAdd, ()>()
-        .with::<Tag>()
+        .with(id::<Tag>())
         .run(|_| {});
     observer.set_doc_name("name");
 

--- a/flecs_ecs/src/addons/doc.rs
+++ b/flecs_ecs/src/addons/doc.rs
@@ -220,7 +220,7 @@ impl<'a, T> Doc<'a> for T where T: Into<Entity> + WorldProvider<'a> + Clone {}
 ///
 /// let world = World::default();
 /// world.component::<Tag>();
-/// world.set_doc_name(id::<Tag>(),"A tag");
+/// world.set_doc_name(id::<Tag>(), "A tag");
 /// ```
 impl World {
     //MARK: _World::getters

--- a/flecs_ecs/src/addons/json/mod.rs
+++ b/flecs_ecs/src/addons/json/mod.rs
@@ -25,7 +25,7 @@ pub type IterToJsonDesc = sys::ecs_iter_to_json_desc_t;
 impl EntityView<'_> {
     /// Set component or pair id from JSON.
     pub fn set_json_id(self, comp: impl IntoId, json: &str, desc: Option<&FromJsonDesc>) -> Self {
-        let comp: u64 = *comp.into();
+        let comp: u64 = *comp.into_id(self.world);
         let world = self.world_ptr_mut();
         let id = *self.id;
         unsafe {
@@ -120,7 +120,7 @@ impl World {
     /// Serialize untyped value to JSON.
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub fn to_json_id(&self, tid: impl IntoId, value: *const core::ffi::c_void) -> String {
-        let tid: u64 = *tid.into();
+        let tid: u64 = *tid.into_id(self);
         let world = self.world_ptr();
         unsafe {
             let json_ptr = sys::ecs_ptr_to_json(world, tid, value);
@@ -172,7 +172,7 @@ impl World {
         json: &str,
         desc: Option<&FromJsonDesc>,
     ) {
-        let tid: u64 = *tid.into();
+        let tid: u64 = *tid.into_id(self);
         let world = self.ptr_mut();
         let desc_ptr = desc
             .map(|d| d as *const FromJsonDesc)

--- a/flecs_ecs/src/addons/json/mod.rs
+++ b/flecs_ecs/src/addons/json/mod.rs
@@ -24,7 +24,7 @@ pub type IterToJsonDesc = sys::ecs_iter_to_json_desc_t;
 
 impl EntityView<'_> {
     /// Set component or pair id from JSON.
-    pub fn set_json_id(self, comp: impl IntoId, json: &str, desc: Option<&FromJsonDesc>) -> Self {
+    pub fn set_json(self, comp: impl IntoId, json: &str, desc: Option<&FromJsonDesc>) -> Self {
         let comp: u64 = *comp.into_id(self.world);
         let world = self.world_ptr_mut();
         let id = *self.id;
@@ -57,31 +57,6 @@ impl EntityView<'_> {
             sys::ecs_modified_id(world, id, comp);
         }
         self
-    }
-
-    /// Set component or pair from JSON.
-    pub fn set_json<T: ComponentOrPairId>(self, json: &str, desc: Option<&FromJsonDesc>) -> Self {
-        self.set_json_id(T::get_id(self.world), json, desc)
-    }
-
-    /// Set pair from JSON where First is a type and Second is an entity id.
-    pub fn set_json_first<Rel: ComponentId>(
-        self,
-        target: impl Into<Entity> + Copy,
-        json: &str,
-        desc: Option<&FromJsonDesc>,
-    ) -> Self {
-        self.set_json_id((Rel::get_id(self.world), target), json, desc)
-    }
-
-    /// Set pair from JSON where First is an entity id and Second is a type.
-    pub fn set_json_second<Second: ComponentId>(
-        self,
-        rel: impl Into<Entity> + Copy,
-        json: &str,
-        desc: Option<&FromJsonDesc>,
-    ) -> Self {
-        self.set_json_id((rel, Second::get_id(self.world)), json, desc)
     }
 
     /// Serialize entity to JSON.

--- a/flecs_ecs/src/addons/meta/cursor.rs
+++ b/flecs_ecs/src/addons/meta/cursor.rs
@@ -12,12 +12,13 @@ impl<'a> Cursor<'a> {
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub(crate) fn new(
         world: impl WorldProvider<'a>,
-        type_id: impl Into<Entity>,
+        type_id: impl IntoEntity,
         ptr: *mut core::ffi::c_void,
     ) -> Self {
-        let world = world.world_ptr();
-        let type_id = *type_id.into();
-        let cursor = unsafe { sys::ecs_meta_cursor(world, type_id, ptr) };
+        let world = world.world();
+        let world_ptr = world.world_ptr();
+        let type_id = *type_id.into_entity(world);
+        let cursor = unsafe { sys::ecs_meta_cursor(world_ptr, type_id, ptr) };
         Self {
             cursor,
             phantom: core::marker::PhantomData,

--- a/flecs_ecs/src/addons/meta/cursor.rs
+++ b/flecs_ecs/src/addons/meta/cursor.rs
@@ -134,7 +134,14 @@ impl<'a> Cursor<'a> {
 
     /// Set (component) id value
     pub fn set_id(&mut self, value: impl IntoId) -> i32 {
-        unsafe { sys::ecs_meta_set_id(&mut self.cursor, *value.into()) }
+        unsafe {
+            sys::ecs_meta_set_id(
+                &mut self.cursor,
+                *value.into_id(WorldRef::from_ptr(
+                    self.cursor.world as *mut sys::ecs_world_t,
+                )),
+            )
+        }
     }
 
     /// Set null value

--- a/flecs_ecs/src/addons/meta/macros/macro_component.rs
+++ b/flecs_ecs/src/addons/meta/macros/macro_component.rs
@@ -113,11 +113,11 @@ macro_rules! member {
 macro_rules! member_ext {
     ($world:expr, $compvar:ident: $component:ty, $name:tt : [$type:ty; $n:literal]) => {
         $crate::assert_is_type!($component, $name: [$type; $n]);
-        $compvar.member_id(::flecs_ecs::prelude::id!($world, $type), (::core::stringify!($name), flecs_ecs::addons::meta::Count($n), ::core::mem::offset_of!($component, $name).try_into().unwrap()))
+        $compvar.member(::flecs_ecs::prelude::id!($world, $type), (::core::stringify!($name), flecs_ecs::addons::meta::Count($n), ::core::mem::offset_of!($component, $name).try_into().unwrap()))
     };
     ($world:expr, $compvar:ident: $component:ty, $name:tt : $type:ty) => {
         $crate::assert_is_type!($component, $name: $type);
-        $compvar.member_id(::flecs_ecs::prelude::id!($world, $type), (::core::stringify!($name), flecs_ecs::addons::meta::Count(1), ::core::mem::offset_of!($component, $name).try_into().unwrap()))
+        $compvar.member(::flecs_ecs::prelude::id!($world, $type), (::core::stringify!($name), flecs_ecs::addons::meta::Count(1), ::core::mem::offset_of!($component, $name).try_into().unwrap()))
     };
     ($world:expr, $component:ty, $name:tt : $($tail:tt)*) => {{
         let world = $world;
@@ -332,12 +332,12 @@ pub fn opaque_option_struct<T: Default>(world: WorldRef) -> Opaque<Option<T>, T>
         Some: T,
     }
     let dummy = world.component_ext(id!(&world, Dummy<T>));
-    if !dummy.has::<flecs::meta::Type>() {
-        dummy.member_id(
+    if !dummy.has(crate::core::utility::id::<flecs::meta::Type>()) {
+        dummy.member(
             id!(&world, bool),
             ("None", Count(1), core::mem::offset_of!(Dummy<T>, None)),
         );
-        dummy.member_id(
+        dummy.member(
             id!(&world, T),
             ("Some", Count(1), core::mem::offset_of!(Dummy<T>, Some)),
         );

--- a/flecs_ecs/src/addons/meta/macros/macro_meta_register_vector.rs
+++ b/flecs_ecs/src/addons/meta/macros/macro_meta_register_vector.rs
@@ -2,7 +2,7 @@
 ///
 /// This macro expands to a function that registers a vector component type with metadata.
 /// It performs the following actions:
-/// - Generates a unique ID for the vector component type using the [`id!`](crate::addons::meta::id) macro.
+/// - Generates a unique ID for the vector component type using the [`id!`](crate::addons::meta::id!) macro.
 /// - Registers the vector component type with the [`World`](crate::core::World) using the [`component_ext`](crate::core::World::component_ext) function.
 /// - Associates the generated function with the vector component type using the [`meta_register_vector_func`] macro.
 ///

--- a/flecs_ecs/src/addons/meta/mod.rs
+++ b/flecs_ecs/src/addons/meta/mod.rs
@@ -60,18 +60,18 @@ impl World {
     }
 
     /// Return meta cursor to value
-    pub fn cursor_id(&self, type_id: impl Into<Entity>, ptr: *mut c_void) -> Cursor {
+    pub fn cursor<T: ComponentId>(&self, data: &mut T) -> Cursor {
+        let type_id = T::get_id(self.world());
+        Cursor::new(self, type_id, data as *mut T as *mut c_void)
+    }
+
+    /// Return meta cursor to value
+    pub fn cursor_id(&self, type_id: impl IntoEntity, ptr: *mut c_void) -> Cursor {
         if ptr.is_null() {
             panic!("ptr is null");
         }
 
         Cursor::new(self, type_id, ptr)
-    }
-
-    /// Return meta cursor to value
-    pub fn cursor<T: ComponentId>(&self, data: &mut T) -> Cursor {
-        let type_id = T::get_id(self.world());
-        Cursor::new(self, type_id, data as *mut T as *mut c_void)
     }
 
     /// Create primitive type
@@ -91,9 +91,9 @@ impl World {
     }
 
     /// Create array type
-    pub fn array_id(&self, elem_id: impl Into<Entity>, array_count: i32) -> EntityView {
+    pub fn array(&self, elem_id: impl IntoEntity, array_count: i32) -> EntityView {
         let desc = sys::ecs_array_desc_t {
-            type_: *elem_id.into(),
+            type_: *elem_id.into_entity(self),
             count: array_count,
             entity: 0u64,
         };
@@ -105,11 +105,6 @@ impl World {
             "failed to create array type"
         );
         EntityView::new_from(self, eid)
-    }
-
-    /// Create array type
-    pub fn array<T: ComponentId>(&self, array_count: i32) -> EntityView {
-        self.array_id(T::get_id(self.world()), array_count)
     }
 
     /// Create vector type
@@ -165,9 +160,15 @@ pub trait EcsSerializer {
 
 impl EcsSerializer for sys::ecs_serializer_t {
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    fn value_id(&self, type_id: impl Into<Entity>, value: *const c_void) -> i32 {
+    fn value_id(&self, type_id: impl IntoEntity, value: *const c_void) -> i32 {
         if let Some(value_func) = self.value {
-            unsafe { value_func(self, *type_id.into(), value) }
+            unsafe {
+                value_func(
+                    self,
+                    *type_id.into_entity(WorldRef::from_ptr(self.world as *mut _)),
+                    value,
+                )
+            }
         } else {
             0
         }
@@ -227,8 +228,8 @@ impl<'a, T: 'static> Component<'a, T> {
 
     /// # See also
     ///
-    pub fn opaque_id(&self, id: impl Into<Entity>) -> Opaque<'a, T> {
-        let id = id.into();
+    pub fn opaque_id(&self, id: impl IntoEntity) -> Opaque<'a, T> {
+        let id = id.into_entity(self.world());
         let mut opaque = Opaque::<T>::new(self.world());
         opaque.as_type(id);
         opaque
@@ -367,17 +368,17 @@ impl UntypedComponent<'_> {
     /// (name : &'static str,),
     /// (name: &'static str, count: i32),
     /// (name: &'static str, count: i32, offset: i32)
-    pub fn member_id_unit<Meta: MetaMember>(
+    pub fn member_unit<Meta: MetaMember>(
         self,
-        type_id: impl Into<Entity>,
-        unit: impl Into<Entity>,
+        type_id: impl IntoEntity,
+        unit: impl IntoEntity,
         data: Meta,
     ) -> Self {
         let name = compact_str::format_compact!("{}\0", data.name());
         let world = self.world_ptr_mut();
         let id = *self.id;
-        let type_id = *type_id.into();
-        let unit = *unit.into();
+        let type_id = *type_id.into_entity(world);
+        let unit = *unit.into_entity(world);
 
         let desc = sys::ecs_entity_desc_t {
             name: name.as_ptr() as *const _,
@@ -411,32 +412,8 @@ impl UntypedComponent<'_> {
     /// (name : &'static str,),
     /// (name: &'static str, count: i32),
     /// (name: &'static str, count: i32, offset: i32)
-    pub fn member_id(self, type_id: impl Into<Entity>, data: impl MetaMember) -> Self {
-        self.member_id_unit(type_id, 0, data)
-    }
-
-    /// Add member.
-    ///
-    /// [`MetaMember`] is a trait that accepts the following options:
-    /// (name : &'static str,),
-    /// (name: &'static str, count: i32),
-    /// (name: &'static str, count: i32, offset: i32)
-    pub fn member<T: ComponentId>(self, data: impl MetaMember) -> Self {
-        self.member_id(T::get_id(self.world()), data)
-    }
-
-    /// Add member with unit.
-    ///
-    /// [`MetaMember`] is a trait that accepts the following options:
-    /// (name : &'static str,),
-    /// (name: &'static str, count: i32),
-    /// (name: &'static str, count: i32, offset: i32)
-    pub fn member_unit<T: ComponentId>(
-        self,
-        unit: impl Into<Entity>,
-        data: impl MetaMember,
-    ) -> Self {
-        self.member_id_unit(T::get_id(self.world()), unit, data)
+    pub fn member(self, type_id: impl IntoEntity, data: impl MetaMember) -> Self {
+        self.member_unit(type_id, 0, data)
     }
 
     /// Add member with unit typed.
@@ -446,7 +423,7 @@ impl UntypedComponent<'_> {
     /// (name: &'static str, count: i32),
     /// (name: &'static str, count: i32, offset: i32)
     pub fn member_unit_type<T: ComponentId, U: ComponentId>(self, data: impl MetaMember) -> Self {
-        self.member_id_unit(T::get_id(self.world()), U::get_id(self.world()), data)
+        self.member_unit(T::get_id(self.world()), U::get_id(self.world()), data)
     }
 
     //TODO
@@ -541,7 +518,7 @@ impl UntypedComponent<'_> {
 
         mr.value.min = min;
         mr.value.max = max;
-        me.modified::<flecs::meta::MemberRanges>();
+        me.modified(flecs::meta::MemberRanges::ID);
         self
     }
 
@@ -563,7 +540,7 @@ impl UntypedComponent<'_> {
 
         mr.warning.min = min;
         mr.warning.max = max;
-        me.modified::<flecs::meta::MemberRanges>();
+        me.modified(flecs::meta::MemberRanges::ID);
         self
     }
 
@@ -585,7 +562,7 @@ impl UntypedComponent<'_> {
 
         mr.error.min = min;
         mr.error.max = max;
-        me.modified::<flecs::meta::MemberRanges>();
+        me.modified(flecs::meta::MemberRanges::ID);
         self
     }
 }

--- a/flecs_ecs/src/addons/meta/mod.rs
+++ b/flecs_ecs/src/addons/meta/mod.rs
@@ -193,8 +193,6 @@ impl EcsSerializer for sys::ecs_serializer_t {
 
 /// Register opaque type interface
 impl<'a, T: 'static> Component<'a, T> {
-    /// # See also
-    ///
     pub fn opaque_func<Func>(&self, func: Func) -> &Self
     where
         Func: FnOnce(WorldRef<'a>) -> Opaque<'a, T>,
@@ -205,8 +203,6 @@ impl<'a, T: 'static> Component<'a, T> {
         self
     }
 
-    /// # See also
-    ///
     pub fn opaque_func_id<Func, Elem>(&self, id: impl Into<Entity>, func: Func) -> &Self
     where
         Func: FnOnce(WorldRef<'a>) -> Opaque<'a, T, Elem>,
@@ -217,8 +213,6 @@ impl<'a, T: 'static> Component<'a, T> {
         self
     }
 
-    /// # See also
-    ///
     pub fn opaque<Type: 'static>(&self) -> Opaque<'a, T> {
         let id = self.world().component_id_map::<Type>();
         let mut opaque = Opaque::<T>::new(self.world());
@@ -226,8 +220,6 @@ impl<'a, T: 'static> Component<'a, T> {
         opaque
     }
 
-    /// # See also
-    ///
     pub fn opaque_id(&self, id: impl IntoEntity) -> Opaque<'a, T> {
         let id = id.into_entity(self.world());
         let mut opaque = Opaque::<T>::new(self.world());
@@ -235,8 +227,6 @@ impl<'a, T: 'static> Component<'a, T> {
         opaque
     }
 
-    /// # See also
-    ///
     pub fn opaque_dyn_id<E>(&self, id_type: E, id_field: E) -> Opaque<'a, T>
     where
         E: Into<Entity> + Copy,

--- a/flecs_ecs/src/addons/metrics/metric_builder.rs
+++ b/flecs_ecs/src/addons/metrics/metric_builder.rs
@@ -56,8 +56,8 @@ impl<'a> MetricBuilder<'a> {
     /// # Arguments
     ///
     /// * `e` - The entity representing the member.
-    pub fn member_id(&mut self, e: impl Into<Entity>) -> &mut Self {
-        self.desc.member = *e.into();
+    pub fn member(&mut self, e: impl IntoEntity) -> &mut Self {
+        self.desc.member = *e.into_entity(self.world);
         self
     }
 
@@ -97,7 +97,7 @@ impl<'a> MetricBuilder<'a> {
             //eprintln!("member '{}' not found", name);
         }
 
-        self.member_id(member_id)
+        self.member(member_id)
     }
 
     /// Set the member for the metric using a component type and member name.
@@ -109,7 +109,7 @@ impl<'a> MetricBuilder<'a> {
     /// # Arguments
     ///
     /// * `name` - The name of the member within the component.
-    pub fn member<T>(&mut self, name: &str) -> &mut Self
+    pub fn member_named_type<T>(&mut self, name: &str) -> &mut Self
     where
         T: ComponentId,
     {
@@ -135,7 +135,7 @@ impl<'a> MetricBuilder<'a> {
             return self;
         }
 
-        self.member_id(m.unwrap())
+        self.member(m.unwrap())
     }
 
     /// Set the `dotmember` expression for the metric.
@@ -176,64 +176,9 @@ impl<'a> MetricBuilder<'a> {
     /// # Arguments
     ///
     /// * `the_id` - The ID to set.
-    pub fn id(&mut self, the_id: impl Into<Id>) -> &mut Self {
-        self.desc.id = *the_id.into();
+    pub fn id(&mut self, the_id: impl IntoId) -> &mut Self {
+        self.desc.id = *the_id.into_id(self.world);
         self
-    }
-
-    /// Set the ID for the metric using a pair of entities.
-    ///
-    /// # Arguments
-    ///
-    /// * `first` - The first entity in the pair.
-    /// * `second` - The second entity in the pair.
-    pub fn id_pair(&mut self, first: impl Into<Entity>, second: impl Into<Entity>) -> &mut Self {
-        self.desc.id = ecs_pair(*first.into(), *second.into());
-        self
-    }
-
-    /// Set the ID for the metric using a component type.
-    ///
-    /// # Type Parameters
-    ///
-    /// * `T` - The component type.
-    pub fn id_type<T>(&mut self) -> &mut Self
-    where
-        T: ComponentOrPairId,
-    {
-        self.id(T::get_id(self.world()))
-    }
-
-    /// Set the ID for the metric using a component type as the first element and an entity as the second.
-    ///
-    /// # Type Parameters
-    ///
-    /// * `First` - The component type for the first element.
-    ///
-    /// # Arguments
-    ///
-    /// * `second` - The second entity in the pair.
-    pub fn id_first<First>(&mut self, second: impl Into<Entity>) -> &mut Self
-    where
-        First: ComponentId,
-    {
-        self.id_pair(First::id(self.world()), second)
-    }
-
-    /// Set the ID for the metric using an entity as the first element and a component type as the second.
-    ///
-    /// # Type Parameters
-    ///
-    /// * `Second` - The component type for the second element.
-    ///
-    /// # Arguments
-    ///
-    /// * `first` - The first entity in the pair.
-    pub fn id_second<Second>(&mut self, first: impl Into<Entity>) -> &mut Self
-    where
-        Second: ComponentId,
-    {
-        self.id_pair(first, Second::id(self.world()))
     }
 
     /// Specify whether the metric should include targets.
@@ -251,21 +196,9 @@ impl<'a> MetricBuilder<'a> {
     /// # Arguments
     ///
     /// * `the_kind` - The entity representing the kind.
-    pub fn kind_id(&mut self, the_kind: impl Into<Entity>) -> &mut Self {
-        self.desc.kind = *the_kind.into();
+    pub fn kind(&mut self, the_kind: impl IntoEntity) -> &mut Self {
+        self.desc.kind = *the_kind.into_entity(self.world);
         self
-    }
-
-    /// Set the kind of the metric using a component type.
-    ///
-    /// # Type Parameters
-    ///
-    /// * `Kind` - The component type representing the kind.
-    pub fn kind<Kind>(&mut self) -> &mut Self
-    where
-        Kind: ComponentId,
-    {
-        self.kind_id(Kind::id(self.world()))
     }
 
     /// Set a brief description for the metric.

--- a/flecs_ecs/src/addons/metrics/mod.rs
+++ b/flecs_ecs/src/addons/metrics/mod.rs
@@ -55,14 +55,14 @@ impl<'a> UntypedComponent<'a> {
         if let Some(parent) = parent {
             let component_name = unsafe { e.get_name_cstr() };
             if let Some(metric_name) = metric_name {
-                world.run_in_scope_with_id(parent, || {
+                world.run_in_scope_with(parent, || {
                     metric_entity = world.entity_named(metric_name);
                 });
             } else {
                 let member_name = unsafe { core::ffi::CStr::from_ptr((*member).name) };
                 let member_name_str = member_name.to_str().expect("non valid Utf8 conversion");
                 if member_name_str == "value" || component_name.is_none() {
-                    world.run_in_scope_with_id(parent, || {
+                    world.run_in_scope_with(parent, || {
                         metric_entity = world.entity_named(member_name_str);
                     });
                 } else {
@@ -75,7 +75,7 @@ impl<'a> UntypedComponent<'a> {
                                 .to_str()
                                 .expect("non valid Utf8 conversion")
                         };
-                        world.run_in_scope_with_id(parent, || {
+                        world.run_in_scope_with(parent, || {
                             metric_entity = world.entity_named(snake_name_str);
                         });
                         unsafe {
@@ -89,7 +89,7 @@ impl<'a> UntypedComponent<'a> {
         }
 
         let mut metric = world.metric(metric_entity);
-        metric.member_id(me).kind::<Kind>();
+        metric.member(me).kind(id::<Kind>());
         if let Some(brief) = brief {
             metric.brief(brief);
         }

--- a/flecs_ecs/src/addons/script/mod.rs
+++ b/flecs_ecs/src/addons/script/mod.rs
@@ -86,10 +86,10 @@ impl World {
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub fn to_expr_id(
         &self,
-        id_of_value: impl Into<Entity>,
+        id_of_value: impl IntoEntity,
         value: *const core::ffi::c_void,
     ) -> String {
-        Script::to_expr_id(self, id_of_value, value)
+        Script::to_expr(self, id_of_value, value)
     }
 
     /// Serialize value into a String.
@@ -99,7 +99,11 @@ impl World {
     ///
     /// * C API: `ecs_ptr_to_expr`
     pub fn to_expr<T: ComponentId>(&self, value: &T) -> String {
-        Script::to_expr(self, value)
+        Script::to_expr(
+            self,
+            id::<T>(),
+            value as *const T as *const core::ffi::c_void,
+        )
     }
 
     /// Wraps the provided entity id in a [`ScriptEntityView`].
@@ -107,16 +111,7 @@ impl World {
     /// # Panics
     ///
     /// The entity must have a [`flecs::Script`] component.
-    pub fn script_entity_from_id(&self, id: impl Into<Entity>) -> ScriptEntityView {
+    pub fn script_entity_from(&self, id: impl IntoEntity) -> ScriptEntityView {
         ScriptEntityView::new_from(self, id)
-    }
-
-    /// Wraps the provided entity in a [`ScriptEntityView`].
-    ///
-    /// # Panics
-    ///
-    /// The entity must have a [`flecs::Script`] component.
-    pub fn script_entity_from<T: ComponentId>(&self) -> ScriptEntityView {
-        ScriptEntityView::new_from(self, T::id(self))
     }
 }

--- a/flecs_ecs/src/addons/script/mod.rs
+++ b/flecs_ecs/src/addons/script/mod.rs
@@ -71,8 +71,6 @@ impl World {
     /// # Returns
     ///
     /// True if success, false if failed.
-    ///
-    /// # See also
     pub fn run_file(&self, filename: &str) -> bool {
         Script::run_file(self, filename)
     }

--- a/flecs_ecs/src/addons/script/script_entity_view.rs
+++ b/flecs_ecs/src/addons/script/script_entity_view.rs
@@ -34,10 +34,10 @@ impl DerefMut for ScriptEntityView<'_> {
 
 impl<'a> ScriptEntityView<'a> {
     /// Create a new script entity view.
-    pub fn new_from(world: impl WorldProvider<'a>, entity: impl Into<Entity>) -> Self {
+    pub fn new_from(world: impl WorldProvider<'a>, entity: impl IntoEntity) -> Self {
         let entity = EntityView::new_from(world, entity);
         ecs_assert!(
-            entity.has::<flecs::Script>(),
+            entity.has(id::<flecs::Script>()),
             FlecsErrorCode::InvalidParameter,
             "Entity does not have a script component"
         );

--- a/flecs_ecs/src/addons/script/unmanaged_script.rs
+++ b/flecs_ecs/src/addons/script/unmanaged_script.rs
@@ -151,8 +151,6 @@ impl<'a> Script<'a> {
     /// # Returns
     ///
     /// True if success, false if failed.
-    ///
-    /// # See also
     pub fn run_file(world: impl WorldProvider<'a>, filename: &str) -> bool {
         let filename = compact_str::format_compact!("{}\0", filename);
         let world_ptr = world.world_ptr_mut();

--- a/flecs_ecs/src/addons/script/unmanaged_script.rs
+++ b/flecs_ecs/src/addons/script/unmanaged_script.rs
@@ -207,12 +207,13 @@ impl<'a> Script<'a> {
     ///
     /// * C API: `ecs_ptr_to_expr`
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub fn to_expr_id(
+    pub fn to_expr(
         world: impl WorldProvider<'a>,
-        id_of_value: impl Into<Entity>,
+        id_of_value: impl IntoEntity,
         value: *const core::ffi::c_void,
     ) -> String {
-        let id = *id_of_value.into();
+        let world = world.world();
+        let id = *id_of_value.into_entity(world);
         let world = world.world_ptr_mut();
         let expr = unsafe { sys::ecs_ptr_to_expr(world, id, value) };
         let c_str = unsafe { CStr::from_ptr(expr) };
@@ -221,17 +222,5 @@ impl<'a> Script<'a> {
             sys::ecs_os_api.free_.expect("os api is missing")(expr as *mut core::ffi::c_void);
         };
         str
-    }
-
-    /// Convert value to string
-    ///
-    /// # See also
-    ///
-    /// * C API: `ecs_ptr_to_expr`
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub fn to_expr<T: ComponentId>(world: impl WorldProvider<'a>, value: &T) -> String {
-        let world = world.world();
-        let id = T::get_id(world);
-        Self::to_expr_id(world, id, value as *const T as *const core::ffi::c_void)
     }
 }

--- a/flecs_ecs/src/addons/system/system_builder.rs
+++ b/flecs_ecs/src/addons/system/system_builder.rs
@@ -211,9 +211,6 @@ where
     type BuiltType = System<'a>;
 
     /// Build the `system_builder` into an system
-    ///
-    /// See also
-    ///
     fn build(&mut self) -> Self::BuiltType {
         let system = System::new(self.world(), self.desc);
         for s in self.term_builder.str_ptrs_to_free.iter_mut() {

--- a/flecs_ecs/src/addons/system/system_builder.rs
+++ b/flecs_ecs/src/addons/system/system_builder.rs
@@ -112,8 +112,8 @@ where
     /// # Arguments
     ///
     /// * `phase` - the phase
-    pub fn kind_id(&mut self, phase: impl Into<Entity>) -> &mut Self {
-        let phase = *phase.into();
+    pub fn kind(&mut self, phase: impl IntoEntity) -> &mut Self {
+        let phase = *phase.into_entity(self.world);
         let current_phase: sys::ecs_entity_t = unsafe {
             sys::ecs_get_target(self.world_ptr_mut(), self.desc.entity, ECS_DEPENDS_ON, 0)
         };
@@ -134,18 +134,6 @@ where
         self
     }
 
-    /// Specify in which phase the system should run
-    ///
-    /// # Type Parameters
-    ///
-    /// * `Phase` - the phase
-    pub fn kind<Phase>(&mut self) -> &mut Self
-    where
-        Phase: ComponentId + ComponentType<Struct>,
-    {
-        self.kind_id(Phase::id(self.world()))
-    }
-
     /// Specify in which enum phase the system should run
     ///
     /// # Arguments
@@ -156,7 +144,7 @@ where
         Phase: ComponentId + ComponentType<Enum> + EnumComponentInfo,
     {
         let enum_id = phase.id_variant(self.world());
-        self.kind_id(enum_id)
+        self.kind(enum_id)
     }
 
     /// Specify whether system can run on multiple threads.

--- a/flecs_ecs/src/addons/timer.rs
+++ b/flecs_ecs/src/addons/timer.rs
@@ -4,7 +4,7 @@ use core::ops::{Deref, DerefMut};
 
 use flecs_ecs_sys::{self as sys};
 
-use crate::core::{ComponentId, Entity, EntityView, QueryTuple, World, WorldProvider};
+use crate::core::{ComponentId, Entity, EntityView, IntoEntity, QueryTuple, World, WorldProvider};
 
 use super::system::{System, SystemBuilder};
 
@@ -235,25 +235,6 @@ impl TimerAPI for System<'_> {
 }
 
 impl System<'_> {
-    /// Assign tick source to system based on a type.
-    /// Systems can be their own tick source, which can be any of the tick sources (one shot timers, interval times and rate filters).
-    /// However, in some cases it is must be guaranteed that different systems tick on the exact same frame.
-    ///
-    /// This cannot be guaranteed by giving two systems the same interval/rate filter as it is possible
-    /// that one system is (for example) disabled, which would cause the systems to go out of sync.
-    /// To provide these guarantees, systems must use the same tick source, which is what this operation enables.
-    ///
-    /// When two systems share the same tick source, it is guaranteed that they tick in the same frame.
-    /// The provided tick source can be any entity that is a tick source, including another system.
-    /// If the provided entity is not a tick source the system will not be ran.
-    ///
-    /// To disassociate a tick source from a system, use [`System::reset_tick_source()`](crate::addons::system::System::reset_tick_source).
-    pub fn set_tick_source<T: ComponentId>(&self) {
-        unsafe {
-            sys::ecs_set_tick_source(self.entity.world_ptr_mut(), *self.id, T::id(self.world()));
-        }
-    }
-
     /// Assign tick source to system based on an id.
     /// Systems can be their own tick source, which can be any of the tick sources (one shot timers, interval times and rate filters).
     /// However, in some cases it is must be guaranteed that different systems tick on the exact same frame.
@@ -267,8 +248,14 @@ impl System<'_> {
     /// If the provided entity is not a tick source the system will not be ran.
     ///
     /// To disassociate a tick source from a system, use [`System::reset_tick_source()`](crate::addons::system::System::reset_tick_source).
-    pub fn set_tick_source_id(&self, id: impl Into<Entity>) {
-        unsafe { sys::ecs_set_tick_source(self.entity.world_ptr_mut(), *self.id, *id.into()) }
+    pub fn set_tick_source(&self, id: impl IntoEntity) {
+        unsafe {
+            sys::ecs_set_tick_source(
+                self.entity.world_ptr_mut(),
+                *self.id,
+                *id.into_entity(self.world),
+            );
+        }
     }
 
     /// Reset, disassociate a tick source from a system
@@ -307,18 +294,10 @@ impl<T: QueryTuple> SystemBuilder<'_, T> {
         self
     }
 
-    /// Set tick source with the type associated with the singleton
-    /// tick source to use for the system.
-    /// This operation sets a shared tick source for the system.
-    pub fn set_tick_source<C: ComponentId>(&mut self) -> &mut Self {
-        self.desc.tick_source = C::id(self.world());
-        self
-    }
-
     /// Set tick source.
     /// This operation sets a shared tick source for the system.
-    pub fn set_tick_source_id(&mut self, tick_source: impl Into<Entity>) -> &mut Self {
-        self.desc.tick_source = *tick_source.into();
+    pub fn set_tick_source(&mut self, tick_source: impl IntoEntity) -> &mut Self {
+        self.desc.tick_source = *tick_source.into_entity(self.world());
         self
     }
 }

--- a/flecs_ecs/src/core/archetype.rs
+++ b/flecs_ecs/src/core/archetype.rs
@@ -33,7 +33,7 @@ pub struct Archetype<'a> {
 impl Display for Archetype<'_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         if let Some(s) = self.to_string() {
-            write!(f, "{}", s)
+            write!(f, "{s}")
         } else {
             write!(f, "empty archetype")
         }

--- a/flecs_ecs/src/core/components/component.rs
+++ b/flecs_ecs/src/core/components/component.rs
@@ -161,9 +161,6 @@ impl<'a, T> Component<'a, T> {
     }
 
     /// Function to free the binding context.
-    ///
-    /// # See also
-    ///
     unsafe extern "C-unwind" fn binding_ctx_drop(ptr: *mut c_void) {
         let ptr_struct: *mut ComponentBindingCtx = ptr as *mut ComponentBindingCtx;
         unsafe {

--- a/flecs_ecs/src/core/components/component_untyped.rs
+++ b/flecs_ecs/src/core/components/component_untyped.rs
@@ -62,7 +62,7 @@ impl<'a> UntypedComponent<'a> {
     ///
     /// * `world`: the world.
     /// * `id`: the id of the component to reference.
-    pub(crate) fn new_from(world: impl WorldProvider<'a>, id: impl Into<Entity>) -> Self {
+    pub(crate) fn new_from(world: impl WorldProvider<'a>, id: impl IntoEntity) -> Self {
         UntypedComponent {
             entity: EntityView::new_from(world, id),
         }

--- a/flecs_ecs/src/core/components/lifecycle_traits.rs
+++ b/flecs_ecs/src/core/components/lifecycle_traits.rs
@@ -104,9 +104,6 @@ pub fn register_copy_panic_lifecycle_action<T>(type_hooks: &mut sys::ecs_type_ho
 /// * `ptr` - pointer to the memory to be initialized
 /// * `count` - number of elements to be initialized
 /// * `_type_info` - type info for the type to be initialized
-///
-/// # See also
-///
 extern "C-unwind" fn ctor<T: Default>(
     ptr: *mut c_void,
     count: i32,
@@ -133,9 +130,6 @@ extern "C-unwind" fn ctor<T: Default>(
 /// * `ptr` - pointer to the memory to be destructed
 /// * `count` - number of elements to be destructed
 /// * `_type_info` - type info for the type to be destructed
-///
-/// # See also
-///
 extern "C-unwind" fn dtor<T>(
     ptr: *mut c_void,
     count: i32,
@@ -156,9 +150,6 @@ extern "C-unwind" fn dtor<T>(
 
 /// This is the generic copy for trivial types
 /// It will copy the memory
-///
-/// # See also
-///
 extern "C-unwind" fn copy<T: Clone>(
     dst_ptr: *mut c_void,
     src_ptr: *const c_void,
@@ -184,9 +175,6 @@ extern "C-unwind" fn copy<T: Clone>(
 
 /// This is the generic copy for trivial types
 /// It will copy the memory
-///
-/// # See also
-///
 extern "C-unwind" fn copy_ctor<T: Clone>(
     dst_ptr: *mut c_void,
     src_ptr: *const c_void,
@@ -234,9 +222,6 @@ extern "C-unwind" fn panic_copy<T>(
 
 /// This is the generic move for non-trivial types
 /// It will move the memory
-///
-/// # See also
-///
 extern "C-unwind" fn move_dtor<T>(
     dst_ptr: *mut c_void,
     src_ptr: *mut c_void,
@@ -265,9 +250,6 @@ extern "C-unwind" fn move_dtor<T>(
 }
 
 /// a move to from src to dest where src will not be used anymore and dest is in control of the drop.
-///
-/// # See also
-///
 extern "C-unwind" fn move_ctor<T>(
     dst_ptr: *mut c_void,
     src_ptr: *mut c_void,

--- a/flecs_ecs/src/core/ecs_os_api.rs
+++ b/flecs_ecs/src/core/ecs_os_api.rs
@@ -4,7 +4,6 @@
 //! This module provides a basic structure for hooking into the initialization
 //! of that API, which allows, for example, customizing how Flecs sends log
 //! messages.
-//!
 #[cfg(feature = "std")]
 extern crate std;
 

--- a/flecs_ecs/src/core/entity_view/bulk_entity_builder.rs
+++ b/flecs_ecs/src/core/entity_view/bulk_entity_builder.rs
@@ -290,8 +290,8 @@ impl<'a> BulkEntityBuilder<'a> {
     /// let ent = world
     ///     .entity()
     ///     .set(Position { x: 0, y: 0 })
-    ///     .add::<Velocity>()
-    ///     .add_id(ent_id);
+    ///     .add(id::<Velocity>())
+    ///     .add(ent_id);
     ///
     /// let mut table = ent.table().unwrap();
     ///

--- a/flecs_ecs/src/core/entity_view/bulk_entity_builder.rs
+++ b/flecs_ecs/src/core/entity_view/bulk_entity_builder.rs
@@ -159,7 +159,7 @@ impl<'a> BulkEntityBuilder<'a> {
     /// let entities_created = world.entity_bulk(10).add_id(entity).build();
     /// ```
     pub fn add_id(&mut self, id: impl IntoId) -> &mut Self {
-        let id = *id.into();
+        let id = *id.into_id(self.world);
         let world = self.world.world_ptr_mut();
 
         check_add_id_validity(world, id);

--- a/flecs_ecs/src/core/entity_view/entity_view_const.rs
+++ b/flecs_ecs/src/core/entity_view/entity_view_const.rs
@@ -951,7 +951,7 @@ impl<'a> EntityView<'a> {
     /// let apple = world.entity_named("Apple");
     /// let banana = world.entity_named("Banana");
     ///
-    /// entity.add((likes,apple)).add((likes,banana));
+    /// entity.add((likes, apple)).add((likes, banana));
     ///
     /// assert_eq!(entity.target_id_count(likes), Some(2));
     /// ```
@@ -992,7 +992,9 @@ impl<'a> EntityView<'a> {
     /// let apple = world.entity_named("Apple");
     /// let banana = world.entity_named("Banana");
     ///
-    /// entity.add((id::<Likes>(), apple)).add((id::<Likes>(), banana));
+    /// entity
+    ///     .add((id::<Likes>(), apple))
+    ///     .add((id::<Likes>(), banana));
     ///
     /// assert_eq!(entity.target_count::<Likes>(), Some(2));
     /// ```
@@ -1737,7 +1739,6 @@ impl<'a> EntityView<'a> {
     /// * The entity for which the target has been found.
     ///
     /// # See also
-    ///
     // TODO needs to be made safe
     pub(crate) fn target_for_first<First: ComponentId + DataComponent>(
         &self,

--- a/flecs_ecs/src/core/entity_view/entity_view_const.rs
+++ b/flecs_ecs/src/core/entity_view/entity_view_const.rs
@@ -446,10 +446,6 @@ impl<'a> EntityView<'a> {
     // /// Returns the entity name as a `CStr`.
     // ///
     // /// if the entity has no name, this will return an empty string
-    // ///
-    // /// # See also
-    // ///
-    // /// * C++ API: `entity_view::name`
     // pub fn name_cstr(self) -> &'a CStr {
     //     self.get_name_cstr().unwrap_or(c"")
     // }
@@ -1654,7 +1650,13 @@ impl<'a> EntityView<'a> {
     /// Ensure the pointer is valid before use. The caller must know the actual type to cast the pointer correctly.
     /// The pointer might get invalided if the table alters.
     pub fn get_untyped(self, component_id: impl IntoId) -> *const c_void {
-        unsafe { sys::ecs_get_id(self.world.world_ptr(), *self.id, *component_id.into()) }
+        unsafe {
+            sys::ecs_get_id(
+                self.world.world_ptr(),
+                *self.id,
+                *component_id.into_id(self),
+            )
+        }
     }
 
     /// Get the pair value as untyped pointer.
@@ -1736,7 +1738,7 @@ impl<'a> EntityView<'a> {
     /// Ensure the pointer is valid before use. The caller must know the actual type to cast the pointer correctly.
     /// The pointer might get invalided if the table alters.
     pub fn get_untyped_mut(self, id: impl IntoId) -> *mut c_void {
-        unsafe { sys::ecs_get_mut_id(self.world.world_ptr(), *self.id(), *id.into()) }
+        unsafe { sys::ecs_get_mut_id(self.world.world_ptr(), *self.id(), *id.into_id(self)) }
     }
 
     /// Get mutable pair value as untyped pointer.
@@ -1880,7 +1882,7 @@ impl<'a> EntityView<'a> {
                 self.world.world_ptr(),
                 *self.id,
                 *relationship.into(),
-                *component_id.into(),
+                *component_id.into_id(self.world),
             )
         };
         if id == 0 {
@@ -2155,7 +2157,7 @@ impl<'a> EntityView<'a> {
     /// * [`EntityView::has()`]
     #[inline(always)]
     pub fn has_id(self, id: impl IntoId) -> bool {
-        unsafe { sys::ecs_has_id(self.world.world_ptr(), *self.id, *id.into()) }
+        unsafe { sys::ecs_has_id(self.world.world_ptr(), *self.id, *id.into_id(self.world)) }
     }
 
     /// Check if entity has the provided component.
@@ -2286,7 +2288,13 @@ impl<'a> EntityView<'a> {
     /// # Returns
     /// - `true` if the entity owns the provided entity, `false` otherwise.
     pub fn owns_id(self, entity_id: impl IntoId) -> bool {
-        unsafe { sys::ecs_owns_id(self.world.world_ptr(), *self.id, *entity_id.into()) }
+        unsafe {
+            sys::ecs_owns_id(
+                self.world.world_ptr(),
+                *self.id,
+                *entity_id.into_id(self.world),
+            )
+        }
     }
 
     /// Check if the entity owns the provided component.
@@ -2357,7 +2365,7 @@ impl<'a> EntityView<'a> {
     /// # Returns
     /// - `true` if enabled, `false` if not.
     pub fn is_enabled_id(self, id: impl IntoId) -> bool {
-        unsafe { sys::ecs_is_enabled_id(self.world.world_ptr(), *self.id, *id.into()) }
+        unsafe { sys::ecs_is_enabled_id(self.world.world_ptr(), *self.id, *id.into_id(self.world)) }
     }
 
     /// Test if component is enabled.

--- a/flecs_ecs/src/core/entity_view/entity_view_impl.rs
+++ b/flecs_ecs/src/core/entity_view/entity_view_impl.rs
@@ -22,7 +22,7 @@ impl<'a> IdOperations<'a> for EntityView<'a> {
     fn new_from_id(world: impl WorldProvider<'a>, id: impl IntoId) -> Self {
         Self {
             world: world.world(),
-            id: Entity::from(*id.into()),
+            id: Entity::from(*id.into_id(world)),
         }
     }
 

--- a/flecs_ecs/src/core/entity_view/entity_view_mut.rs
+++ b/flecs_ecs/src/core/entity_view/entity_view_mut.rs
@@ -492,8 +492,6 @@ impl<'a> EntityView<'a> {
     ///     // ...
     /// });
     /// ```
-    /// # See also
-    ///
     pub fn set_pair<First, Second>(
         self,
         data: <(First, Second) as ComponentOrPairId>::CastType,
@@ -772,8 +770,6 @@ impl<'a> EntityView<'a> {
     ///
     /// - `first`: The first element of the pair.
     /// - `func`: The function to call.///
-    /// # See also
-    ///
     pub fn with_first(self, first: impl IntoEntity, func: impl FnOnce()) -> Self {
         unsafe {
             let prev = sys::ecs_set_with(

--- a/flecs_ecs/src/core/event.rs
+++ b/flecs_ecs/src/core/event.rs
@@ -88,7 +88,7 @@ impl<'a, T: ComponentId> EventBuilder<'a, T> {
     ///
     /// * `id` - The id of the component to add to the event
     pub fn add_id(&mut self, id: impl IntoId) -> &mut Self {
-        let id = *id.into();
+        let id = *id.into_id(self.world);
         let ids = &mut self.ids;
         let ids_array = &mut self.ids_array;
         ids.array = ids_array.as_mut_ptr();

--- a/flecs_ecs/src/core/event.rs
+++ b/flecs_ecs/src/core/event.rs
@@ -87,7 +87,7 @@ impl<'a, T: ComponentId> EventBuilder<'a, T> {
     /// # Arguments
     ///
     /// * `id` - The id of the component to add to the event
-    pub fn add_id(&mut self, id: impl IntoId) -> &mut Self {
+    pub fn add(&mut self, id: impl IntoId) -> &mut Self {
         let id = *id.into_id(self.world);
         let ids = &mut self.ids;
         let ids_array = &mut self.ids_array;
@@ -97,19 +97,6 @@ impl<'a, T: ComponentId> EventBuilder<'a, T> {
         }
         ids.count += 1;
         self
-    }
-
-    /// Add component to emit for the event.
-    ///
-    /// # Type parameters
-    ///
-    /// * `C` - The component to add to the event
-    pub fn add<C>(&mut self) -> &mut Self
-    where
-        C: ComponentOrPairId,
-    {
-        let world = self.world;
-        self.add_id(C::get_id(world))
     }
 
     pub fn add_enum<C: ComponentId + ComponentType<Enum> + EnumComponentInfo>(
@@ -125,32 +112,7 @@ impl<'a, T: ComponentId> EventBuilder<'a, T> {
             FlecsErrorCode::InvalidParameter,
             "Component was not found in reflection data."
         );
-        self.add_id((rel, target))
-    }
-
-    /// Add a pair of components to emit for the event.
-    ///
-    /// # Type parameters
-    ///
-    /// * `First` - The first component to add to the event
-    ///
-    /// # Arguments
-    ///
-    /// * `second` - The id of the second component to add to the event
-    fn add_first<First>(&mut self, second: impl Into<Entity>) -> &mut Self
-    where
-        First: ComponentId,
-    {
-        let world = self.world;
-        self.add_id(ecs_pair(First::id(world), *second.into()))
-    }
-
-    fn add_second<Second>(&mut self, first: impl Into<Entity>) -> &mut Self
-    where
-        Second: ComponentId,
-    {
-        let world = self.world;
-        self.add_id(ecs_pair(*first.into(), Second::id(world)))
+        self.add((rel, target))
     }
 
     /// Set the target entity to emit for the event.

--- a/flecs_ecs/src/core/flecs.rs
+++ b/flecs_ecs/src/core/flecs.rs
@@ -13,7 +13,7 @@ macro_rules! create_pre_registered_component {
         create_pre_registered_component!($struct_name, $const_name, "");
     };
     ($struct_name:ident, $const_name:ident, $doc:tt) => {
-        #[derive(Debug, Default)]
+        #[derive(Debug, Default, Clone)]
         #[allow(clippy::empty_docs)]
         #[doc = $doc]
         pub struct $struct_name;
@@ -57,8 +57,8 @@ macro_rules! create_pre_registered_component {
             const IS_GENERIC: bool = false;
             const IS_ENUM: bool = false;
             const IS_TAG: bool = true;
-            const IMPLS_CLONE: bool = false;
-            const IMPLS_DEFAULT: bool = false;
+            const IMPLS_CLONE: bool = true;
+            const IMPLS_DEFAULT: bool = true;
             const IS_REF: bool = false;
             const IS_MUT: bool = false;
             type TagType =

--- a/flecs_ecs/src/core/id_view.rs
+++ b/flecs_ecs/src/core/id_view.rs
@@ -170,7 +170,7 @@ impl<'a> IdView<'a> {
             return false;
         }
 
-        ecs_first(self.id) == first.into()
+        ecs_first(self.id, self.world) == first.into()
     }
 
     /// Get first element from a pair.
@@ -181,7 +181,7 @@ impl<'a> IdView<'a> {
     pub fn first_id(&self) -> EntityView {
         ecs_assert!(self.is_pair(), FlecsErrorCode::InvalidOperation);
 
-        let entity = ecs_first(self.id);
+        let entity = ecs_first(self.id, self.world);
         self.world.get_alive(entity)
     }
 
@@ -194,7 +194,7 @@ impl<'a> IdView<'a> {
         if !self.is_pair() {
             None
         } else {
-            let entity = ecs_first(self.id);
+            let entity = ecs_first(self.id, self.world);
             self.world.try_get_alive(entity)
         }
     }
@@ -206,7 +206,7 @@ impl<'a> IdView<'a> {
     pub fn second_id(&self) -> EntityView {
         ecs_assert!(self.is_pair(), FlecsErrorCode::InvalidOperation);
 
-        let entity = ecs_second(self.id);
+        let entity = ecs_second(self.id, self.world);
         self.world.get_alive(entity)
     }
 
@@ -218,7 +218,7 @@ impl<'a> IdView<'a> {
         if !self.is_pair() {
             None
         } else {
-            let entity = ecs_second(self.id);
+            let entity = ecs_second(self.id, self.world);
             self.world.try_get_alive(entity)
         }
     }
@@ -323,7 +323,7 @@ impl<'a> IdOperations<'a> for IdView<'a> {
     fn new_from_id(world: impl WorldProvider<'a>, id: impl IntoId) -> Self {
         Self {
             world: world.world(),
-            id: id.into(),
+            id: id.into_id(world),
         }
     }
 

--- a/flecs_ecs/src/core/mod.rs
+++ b/flecs_ecs/src/core/mod.rs
@@ -10,7 +10,7 @@ mod entity_view;
 mod event;
 pub mod flecs;
 pub(crate) mod get_tuple;
-mod id;
+pub mod id;
 mod id_view;
 mod observer;
 mod observer_builder;

--- a/flecs_ecs/src/core/observer.rs
+++ b/flecs_ecs/src/core/observer.rs
@@ -70,15 +70,15 @@ impl<'a> Observer<'a> {
                             should be written as:
                             ```
                             .observer::<flecs::OnAdd, ()>()
-                            .with::<Position>() // Note: no `&` or `&mut` here! 
+                            .with(id::<Position>()) // Note: no `&` or `&mut` here! 
                             ```
                         
                             Invalid signatures include:
                             ```
                             .observer::<flecs::OnAdd, &T>()
                             .observer::<flecs::OnAdd, &mut T>()
-                            .observer::<flecs::OnAdd, ()>().with::<&T>()
-                            .observer::<flecs::OnAdd, ()>().with::<&mut T>()
+                            .observer::<flecs::OnAdd, ()>().with(id::<&T>())
+                            .observer::<flecs::OnAdd, ()>().read_write(id::<T>())
                             ```
                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                             "#

--- a/flecs_ecs/src/core/observer_builder.rs
+++ b/flecs_ecs/src/core/observer_builder.rs
@@ -27,9 +27,6 @@ impl<'a, P: ComponentId, T: QueryTuple> ObserverBuilder<'a, P, T> {
     /// # Arguments
     ///
     /// * `world` - The world to create the observer in
-    ///
-    /// See also
-    ///
     pub(crate) fn new(world: impl WorldProvider<'a>) -> Self {
         let desc = Default::default();
         let mut obj = Self {
@@ -54,9 +51,6 @@ impl<'a, P: ComponentId, T: QueryTuple> ObserverBuilder<'a, P, T> {
     ///
     /// * `world` - The world to create the observer in
     /// * `name` - The name of the observer
-    ///
-    /// See also
-    ///
     pub fn new_named(world: impl WorldProvider<'a>, name: &str) -> Self {
         let name = compact_str::format_compact!("{}\0", name);
 
@@ -107,9 +101,6 @@ impl<'a, P, T: QueryTuple> ObserverBuilder<'a, P, T> {
     ///
     /// * `world` - The world to create the observer in
     /// * `desc` - The descriptor to create the observer from
-    ///
-    /// See also
-    ///
     pub(crate) fn new_from_desc(
         world: impl WorldProvider<'a>,
         desc: sys::ecs_observer_desc_t,
@@ -205,9 +196,6 @@ where
     type BuiltType = Observer<'a>;
 
     /// Build the `observer_builder` into an `observer`
-    ///
-    /// See also
-    ///
     fn build(&mut self) -> Self::BuiltType {
         let observer = Observer::new(self.world(), self.desc);
         for s in self.term_builder.str_ptrs_to_free.iter_mut() {

--- a/flecs_ecs/src/core/observer_builder.rs
+++ b/flecs_ecs/src/core/observer_builder.rs
@@ -148,25 +148,9 @@ impl<P, T: QueryTuple> ObserverBuilder<'_, P, T> {
     /// # Arguments
     ///
     /// * `event` - The event to add
-    pub fn add_event_id(&mut self, event: impl Into<Entity>) -> &mut ObserverBuilder<(), T> {
-        let event = *event.into();
+    pub fn add_event(&mut self, event: impl IntoEntity) -> &mut ObserverBuilder<(), T> {
+        let event = *event.into_entity(self.world);
         self.desc.events[self.event_count] = event;
-        self.event_count += 1;
-        // SAFETY: Same layout
-        unsafe { core::mem::transmute(self) }
-    }
-
-    /// Specify the event(s) for when the observer should run.
-    ///
-    /// # Type parameters
-    ///
-    /// * `T` - The type of the event
-    pub fn add_event<E>(&mut self) -> &mut ObserverBuilder<(), T>
-    where
-        E: ComponentId,
-    {
-        let id = E::id(self.world());
-        self.desc.events[self.event_count] = id;
         self.event_count += 1;
         // SAFETY: Same layout
         unsafe { core::mem::transmute(self) }

--- a/flecs_ecs/src/core/query.rs
+++ b/flecs_ecs/src/core/query.rs
@@ -311,9 +311,6 @@ where
     /// # Arguments
     ///
     /// * `world` - The world to get the iterator for
-    ///
-    /// # See also
-    ///
     unsafe fn get_iter_raw(&mut self) -> sys::ecs_iter_t {
         unsafe { sys::ecs_query_iter(self.world_ptr(), self.query.as_ptr()) }
     }

--- a/flecs_ecs/src/core/query_builder.rs
+++ b/flecs_ecs/src/core/query_builder.rs
@@ -80,9 +80,6 @@ where
     /// # Arguments
     ///
     /// * `world` - The world to create the observer in
-    ///
-    /// See also
-    ///
     pub fn new(world: &'a World) -> Self {
         let mut obj = Self {
             desc: Default::default(),
@@ -102,9 +99,6 @@ where
     ///
     /// * `world` - The world to create the observer in
     /// * `name` - The name of the observer
-    ///
-    /// See also
-    ///
     pub fn new_named(world: &'a World, name: &str) -> Self {
         let name = compact_str::format_compact!("{}\0", name);
 
@@ -136,9 +130,6 @@ where
     ///
     /// * `world` - The world to create the observer in
     /// * `desc` - The descriptor to create the observer from
-    ///
-    /// See also
-    ///
     pub(crate) fn new_from_desc(
         world: impl WorldProvider<'a>,
         desc: &mut sys::ecs_query_desc_t,
@@ -158,9 +149,6 @@ where
     /// * `world` - The world to create the observer in
     /// * `desc` - The descriptor to create the observer from
     /// * `term_index` - The index of the term to create the observer from
-    ///
-    /// See also
-    ///
     pub(crate) fn new_from_desc_term_index(
         world: &'a World,
         desc: &mut sys::ecs_query_desc_t,
@@ -567,8 +555,6 @@ pub trait QueryBuilderImpl<'a>: TermBuilderImpl<'a> {
     ///
     /// * `component`: The component used to sort.
     /// * `compare`: The compare function used to sort the components.
-    /// # See also
-    ///
     fn order_by_id(
         &mut self,
         component: impl Into<Entity>,

--- a/flecs_ecs/src/core/query_builder.rs
+++ b/flecs_ecs/src/core/query_builder.rs
@@ -337,18 +337,19 @@ pub trait QueryBuilderImpl<'a>: TermBuilderImpl<'a> {
                 self.init_current_term(ecs_pair(*rel, *target));
             }
             AccessTarget::Name(name) => {
-                self.set_first(name);
+                self.set_first::<&'static str>(name);
             }
             AccessTarget::PairName(rel, target) => {
-                self.set_first(rel).set_second(target);
+                self.set_first::<&'static str>(rel)
+                    .set_second::<&'static str>(target);
             }
             AccessTarget::PairEntityName(rel, target) => {
                 self.init_current_term(rel);
-                self.set_second(target);
+                self.set_second::<&'static str>(target);
             }
             AccessTarget::PairNameEntity(rel, target) => {
-                self.set_first(rel);
-                self.set_second(target);
+                self.set_first::<&'static str>(rel);
+                self.set_second::<Entity>(target);
             }
         }
 

--- a/flecs_ecs/src/core/query_iter.rs
+++ b/flecs_ecs/src/core/query_iter.rs
@@ -33,19 +33,8 @@ where
     /// # Arguments
     ///
     /// * `group_id`: the group id to set
-    pub fn set_group_id(&mut self, group_id: impl Into<Entity>) -> &mut Self {
-        unsafe { sys::ecs_iter_set_group(&mut self.iter, *group_id.into()) }
-        self
-    }
-
-    /// Limit results to tables with specified group id (grouped queries only)
-    ///
-    /// # Type parameters
-    ///
-    /// * `Group`: the group to set
-    pub fn set_group<Group: ComponentId>(&mut self) -> &mut Self {
-        let world = unsafe { WorldRef::from_ptr(self.iter.real_world) };
-        unsafe { sys::ecs_iter_set_group(&mut self.iter, Group::id(world)) }
+    pub fn set_group(&mut self, group_id: impl IntoEntity) -> &mut Self {
+        unsafe { sys::ecs_iter_set_group(&mut self.iter, *group_id.into_entity(self.world())) }
         self
     }
 

--- a/flecs_ecs/src/core/table/field.rs
+++ b/flecs_ecs/src/core/table/field.rs
@@ -70,9 +70,6 @@ pub struct FieldUntyped {
 /// * `size`: size of the component type.
 /// * `count`: number of elements in the array.
 /// * `is_shared`: whether the component is shared.
-///
-/// # See also
-///
 impl FieldUntyped {
     pub(crate) fn new(array: *mut c_void, size: usize, count: usize, is_shared: bool) -> Self {
         Self {

--- a/flecs_ecs/src/core/table/iter.rs
+++ b/flecs_ecs/src/core/table/iter.rs
@@ -649,7 +649,7 @@ where
         );
 
         let id = unsafe { self.iter.ids.add(index as usize).read() };
-        Id::new(id)
+        crate::core::Id::new(id)
     }
 
     /// Get readonly access to entity ids.
@@ -894,7 +894,10 @@ where
                 FlecsErrorCode::InvalidParameter,
                 "field does not match a pair"
             );
-            let target = EntityView::new_from(self.world(), ecs_second(id));
+            let target = EntityView::new_from(
+                self.world(),
+                ecs_second(id, unsafe { WorldRef::from_ptr(self.iter.world) }),
+            );
             func(target);
             i += 1;
         }

--- a/flecs_ecs/src/core/table/iter.rs
+++ b/flecs_ecs/src/core/table/iter.rs
@@ -375,9 +375,6 @@ where
     /// # Returns
     ///
     /// Returns a column object that can be used to access the field data.
-    ///
-    /// # See also
-    ///
     // TODO? in C++ API there is a mutable and immutable version of this function
     // Maybe we should create a ColumnView struct that is immutable and use the Column struct for mutable access?
     pub unsafe fn field_unchecked<T>(&self, index: i8) -> Field<T> {
@@ -847,7 +844,10 @@ where
     /// let salad = world.entity();
     /// let alice = world.entity().add((likes, pizza)).add((likes, salad));
     ///
-    /// let q = world.query::<()>().with((likes,id::<flecs::Any>())).build();
+    /// let q = world
+    ///     .query::<()>()
+    ///     .with((likes, id::<flecs::Any>()))
+    ///     .build();
     ///
     /// let mut count = 0;
     /// let mut tgt_count = 0;

--- a/flecs_ecs/src/core/table/mod.rs
+++ b/flecs_ecs/src/core/table/mod.rs
@@ -354,8 +354,6 @@ impl<'a> TableOperations<'a> for TableRange<'a> {
     }
 
     /// Returns the table range count
-    ///
-    /// # See also
     fn count(&self) -> i32 {
         self.count
     }

--- a/flecs_ecs/src/core/table/mod.rs
+++ b/flecs_ecs/src/core/table/mod.rs
@@ -155,91 +155,15 @@ pub trait TableOperations<'a>: IntoTable {
     /// # Returns
     ///
     /// The index of the id in the table type, or `None` if the id is not found
-    fn find_type_index_id(&self, id: sys::ecs_id_t) -> Option<i32> {
+    fn find_type_index(&self, id: impl IntoId) -> Option<i32> {
         let index = unsafe {
-            sys::ecs_table_get_type_index(self.world().world_ptr(), self.table_ptr_mut(), id)
+            sys::ecs_table_get_type_index(
+                self.world().world_ptr(),
+                self.table_ptr_mut(),
+                *id.into_id(self.world()),
+            )
         };
         if index == -1 { None } else { Some(index) }
-    }
-
-    /// Find type index for component type
-    ///
-    /// # Type parameters
-    ///
-    /// * `T` - The type of the component
-    ///
-    /// # Returns
-    ///
-    /// The index of the component in the table type, or `None` if the component is not in the table
-    fn find_type_index<T: ComponentId>(&self) -> Option<i32> {
-        self.find_type_index_id(T::id(self.world()))
-    }
-
-    /// Find type index for pair of component types
-    ///
-    /// # Arguments
-    ///
-    /// * `first` - First element of the pair
-    /// * `second` - Second element of the pair
-    ///
-    /// # Returns
-    ///
-    /// The index of the pair in the table type, or `None` if the pair is not in the table
-    fn find_type_index_pair_ids(
-        &self,
-        first: impl Into<Entity>,
-        second: impl Into<Entity>,
-    ) -> Option<i32> {
-        self.find_type_index_id(ecs_pair(*first.into(), *second.into()))
-    }
-
-    /// Find type index for pair of component types
-    ///
-    /// # Type parameters
-    ///
-    /// * `First` - The type of the first component
-    /// * `Second` - The type of the second component
-    ///
-    /// # Returns
-    ///
-    /// The index of the pair in the table type, or `None` if the pair is not in the table
-    fn find_type_index_pair<First: ComponentId, Second: ComponentId>(&self) -> Option<i32> {
-        let world = self.world();
-        self.find_type_index_pair_ids(First::id(world), Second::id(world))
-    }
-
-    /// Find type index for pair of component types
-    ///
-    /// # Type parameters
-    ///
-    /// * `First` - The type of the first component
-    ///
-    /// # Arguments
-    ///
-    /// * `second` - The id of the second component
-    ///
-    /// # Returns
-    ///
-    /// The index of  the pair in the table type, or `None` if the pair is not in the table
-    fn find_type_index_first<First: ComponentId>(&self, second: impl Into<Entity>) -> Option<i32> {
-        self.find_type_index_pair_ids(First::id(self.world()), second)
-    }
-
-    /// Find type index for pair of component types
-    ///
-    /// # Type parameters
-    ///
-    /// * `Second` - The type of the second component
-    ///
-    /// # Arguments
-    ///
-    /// * `first` - The id of the first component
-    ///
-    /// # Returns
-    ///
-    /// The index of  the pair in the table type, or `None` if the pair is not in the table
-    fn find_type_index_second<Second: ComponentId>(&self, first: impl Into<Entity>) -> Option<i32> {
-        self.find_type_index_pair_ids(first, Second::id(self.world()))
     }
 
     /// Find index for (component) id in table type
@@ -256,124 +180,15 @@ pub trait TableOperations<'a>: IntoTable {
     /// # Returns
     ///
     /// The index of the id in the table, or `None` if the id is not in the table
-    fn find_column_index_id(&self, id: sys::ecs_id_t) -> Option<i32> {
+    fn find_column_index(&self, id: impl IntoId) -> Option<i32> {
         let index = unsafe {
-            sys::ecs_table_get_column_index(self.world().world_ptr(), self.table_ptr_mut(), id)
+            sys::ecs_table_get_column_index(
+                self.world().world_ptr(),
+                self.table_ptr_mut(),
+                *id.into_id(self.world()),
+            )
         };
         if index == -1 { None } else { Some(index) }
-    }
-
-    /// Find column index for component type in table
-    ///
-    /// This operation returns the index of first occurrence of the type in the table type.
-    ///
-    /// This is a constant time operation.
-    ///
-    /// # Type parameters
-    ///
-    /// * `T` - The type of the component
-    ///
-    /// # Returns
-    ///
-    /// The index of the component in the table, or `None` if the component is not in the table
-    fn find_column_index<T: ComponentId>(&self) -> Option<i32> {
-        self.find_column_index_id(T::id(self.world()))
-    }
-
-    /// Find index for pair of component types in table
-    ///
-    /// This operation returns the index of first occurrence of the pair in the table type.
-    ///
-    /// This is a constant time operation.
-    ///
-    /// # Type parameters
-    ///
-    /// * `First` - The type of the first component
-    /// * `Second` - The type of the second component
-    ///
-    /// # Returns
-    ///
-    /// The index of the pair in the table, or `None` if the pair is not in the table
-    fn find_column_index_pair<First: ComponentId, Second: ComponentId>(&self) -> Option<i32> {
-        let world = self.world();
-        self.find_column_index_id(ecs_pair(First::id(world), Second::id(world)))
-    }
-
-    /// Find index for pair of component ids in table type
-    ///
-    /// This operation returns the index of first occurrence of the pair in the table type.
-    ///
-    /// This is a constant time operation.
-    ///
-    /// # Arguments
-    ///
-    /// * `first` - The id of the first component
-    /// * `second` - The id of the second component
-    ///
-    /// # Returns
-    ///
-    /// The index of the pair in the table, or `None` if the pair is not in the table
-    fn find_column_index_pair_ids(
-        &self,
-        first: impl Into<Entity>,
-        second: impl Into<Entity>,
-    ) -> Option<i32> {
-        self.find_column_index_id(ecs_pair(*first.into(), *second.into()))
-    }
-
-    /// Find index for pair of component types in table type
-    ///
-    /// # Type parameters
-    ///
-    /// * `First` - The type of the first component
-    ///
-    /// # Arguments
-    ///
-    /// * `second` - The id of the second component
-    ///
-    /// # Returns
-    ///
-    /// The index of the pair in the table, or `None` if the pair is not in the table
-    fn find_column_index_first<First: ComponentId>(
-        &self,
-        second: impl Into<Entity>,
-    ) -> Option<i32> {
-        self.find_column_index_pair_ids(First::id(self.world()), second)
-    }
-
-    /// Find index for pair of component types in table type
-    ///
-    /// # Type parameters
-    ///
-    /// * `Second` - The type of the second component
-    ///
-    /// # Arguments
-    ///
-    /// * `first` - The id of the first component
-    ///
-    /// # Returns
-    ///
-    /// The index of the pair in the table, or `None` if the pair is not in the table
-    fn find_column_index_second<Second: ComponentId>(
-        &self,
-        first: impl Into<Entity>,
-    ) -> Option<i32> {
-        self.find_column_index_pair_ids(first, Second::id(self.world()))
-    }
-
-    /// Test if table has component type
-    ///
-    /// This is a constant time operation.
-    ///
-    /// # Type parameters
-    ///
-    /// * `T` - The type of the component
-    ///
-    /// # Returns
-    ///
-    /// True if the table has the component type, false otherwise
-    fn has_type<T: ComponentId>(&self) -> bool {
-        self.find_type_index::<T>().is_some()
     }
 
     /// Test if table has (component) id
@@ -387,40 +202,8 @@ pub trait TableOperations<'a>: IntoTable {
     /// # Returns
     ///
     /// True if the table has the component id, false otherwise
-    fn has_type_id(&self, id: sys::ecs_id_t) -> bool {
-        self.find_type_index_id(id).is_some()
-    }
-
-    /// Test if table has pair of component types
-    ///
-    /// This is a constant time operation.
-    ///
-    /// # Type parameters
-    ///
-    /// * `First` - The type of the first component
-    /// * `Second` - The type of the second component
-    ///
-    /// # Returns
-    ///
-    /// True if the table has the pair of component types, false otherwise
-    fn has_pair<First: ComponentId, Second: ComponentId>(&self) -> bool {
-        self.find_type_index_pair::<First, Second>().is_some()
-    }
-
-    /// Test if table has pair of component ids
-    ///
-    /// This is a constant time operation.
-    ///
-    /// # Arguments
-    ///
-    /// * `first` - The id of the first component
-    /// * `second` - The id of the second component
-    ///
-    /// # Returns
-    ///
-    /// True if the table has the pair of component ids, false otherwise
-    fn has_pair_ids(&self, first: impl Into<Entity>, second: impl Into<Entity>) -> bool {
-        self.find_type_index_pair_ids(first, second).is_some()
+    fn has(&self, id: impl IntoId) -> bool {
+        self.find_type_index(id).is_some()
     }
 
     /// Get column, components array ptr from table by column index.
@@ -446,7 +229,7 @@ pub trait TableOperations<'a>: IntoTable {
     /// # Returns
     ///
     /// Some(Pointer) to the column, or `None` if not found
-    fn get_mut<T: ComponentId>(&self) -> Option<&mut [T]> {
+    fn get_mut<T: ComponentId>(&mut self) -> Option<&mut [T]> {
         self.get_mut_untyped(T::id(self.world())).map(|ptr| unsafe {
             core::slice::from_raw_parts_mut(ptr as *mut T, (self.count()) as usize)
         })
@@ -462,7 +245,7 @@ pub trait TableOperations<'a>: IntoTable {
     ///
     /// Some(Pointer) to the column, or `None` if not found
     fn get_mut_untyped(&self, id: sys::ecs_id_t) -> Option<*mut c_void> {
-        if let Some(index) = self.find_column_index_id(id) {
+        if let Some(index) = self.find_column_index(id) {
             self.column_untyped(index)
         } else {
             None
@@ -519,21 +302,6 @@ pub trait TableOperations<'a>: IntoTable {
     /// Depth is determined by counting the number of targets encountered while traversing up the
     /// relationship tree for rel. Only acyclic relationships are supported.
     ///
-    /// # Type parameters
-    ///
-    /// * `Rel` - The type of the relationship
-    ///
-    /// # Returns
-    ///
-    /// The depth of the relationship
-    fn depth<Rel: ComponentId>(&self) -> i32 {
-        self.depth_id(Rel::id(self.world()))
-    }
-
-    /// Return depth for table in tree for relationship type.
-    /// Depth is determined by counting the number of targets encountered while traversing up the
-    /// relationship tree for rel. Only acyclic relationships are supported.
-    ///
     /// # Arguments
     ///
     /// * `rel` - The id of the relationship
@@ -541,12 +309,13 @@ pub trait TableOperations<'a>: IntoTable {
     /// # Returns
     ///
     /// The depth of the relationship
-    fn depth_id(&self, rel: impl Into<Entity>) -> i32 {
+    fn depth(&self, rel: impl IntoEntity) -> i32 {
+        let world = self.world();
         unsafe {
             sys::ecs_table_get_depth(
-                self.world().world_ptr_mut(),
+                world.world_ptr_mut(),
                 self.table_ptr_mut(),
-                *rel.into(),
+                *rel.into_entity(world),
             )
         }
     }

--- a/flecs_ecs/src/core/term.rs
+++ b/flecs_ecs/src/core/term.rs
@@ -382,107 +382,107 @@ pub trait TermBuilderImpl<'a>: Sized + WorldProvider<'a> + internals::QueryConfi
         self
     }
 
-    /// Select src identifier, initialize it with entity id
+    /// Select src identifier
     ///
-    /// # Arguments
     ///
-    /// * `id` - The id to set.
-    fn set_src(&mut self, id: impl IntoEntity) -> &mut Self {
-        self.src().set_id(id)
-    }
-
-    /// Select src identifier, initialize it with name. If name starts with a $
+    /// * initialize it with entity id or
+    /// * initialize it with name. If name starts with a $
     /// the name is interpreted as a variable.
     ///
     /// # Arguments
     ///
-    /// * `name` - The name to set.
-    fn set_src_name(&mut self, name: &'a str) -> &mut Self {
-        ecs_assert!(
-            !name.is_empty(),
-            FlecsErrorCode::InvalidParameter,
-            "name is empty"
-        );
+    /// * `id` - The id to set.
+    fn set_src<T: SingleAccessArg>(&mut self, id: T) -> &mut Self
+    where
+        Access: FromAccessArg<T>,
+    {
+        let access = Access::from_access_arg(id, self.world());
 
-        self.src();
-        if let Some(stripped_name) = strip_prefix_str_raw(name, "$") {
-            self.set_var(stripped_name)
-        } else {
-            self.name(name)
+        match access.target {
+            AccessTarget::Entity(entity) => self.src().set_id(entity),
+            AccessTarget::Name(name) => {
+                ecs_assert!(
+                    !name.is_empty(),
+                    FlecsErrorCode::InvalidParameter,
+                    "name is empty"
+                );
+                self.src();
+                if let Some(stripped_name) = strip_prefix_str_raw(name, "$") {
+                    self.set_var(stripped_name)
+                } else {
+                    self.name(name)
+                }
+            }
+            _ => panic!("Invalid access target, only single targets allowed"),
         }
     }
 
-    /// Select first identifier, initialize it with entity id
+    /// Select first identifier
     ///
-    /// # Arguments
-    ///
-    /// * `id` - The id to set.
-    fn set_first(&mut self, id: impl IntoEntity) -> &mut Self {
-        check_term_access_validity(self);
-        let id = id.into_entity(self.world());
-        self.first().set_id(id);
-        // reset term ref mode to src, otherwise it stays on second and makes other actions potentially invalid
-        self.set_term_ref_mode(TermRefMode::Src);
-        self
-    }
-
-    /// Select first identifier, initialize it with name. If name starts with a $
+    /// * initialize with id or
+    /// * initialize it with name. If name starts with a $
     /// the name is interpreted as a variable.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - The name to set.
-    fn set_first_name(&mut self, name: &'a str) -> &mut Self {
+    fn set_first<T: SingleAccessArg>(&mut self, id: T) -> &mut Self
+    where
+        Access: FromAccessArg<T>,
+    {
         check_term_access_validity(self);
-        ecs_assert!(
-            !name.is_empty(),
-            FlecsErrorCode::InvalidParameter,
-            "name is empty"
-        );
+        let access = Access::from_access_arg(id, self.world());
+        match access.target {
+            AccessTarget::Entity(entity) => {
+                self.first().set_id(entity);
+            }
+            AccessTarget::Name(name) => {
+                ecs_assert!(
+                    !name.is_empty(),
+                    FlecsErrorCode::InvalidParameter,
+                    "name is empty"
+                );
 
-        self.first();
-        if let Some(stripped_name) = strip_prefix_str_raw(name, "$") {
-            self.set_var(stripped_name);
-        } else {
-            self.name(name);
+                self.first();
+                if let Some(stripped_name) = strip_prefix_str_raw(name, "$") {
+                    self.set_var(stripped_name);
+                } else {
+                    self.name(name);
+                }
+            }
+            _ => panic!("Invalid access target, only single targets allowed"),
         }
         // reset term ref mode to src, otherwise it stays on second and makes other actions potentially invalid
         self.set_term_ref_mode(TermRefMode::Src);
         self
     }
 
-    /// Select second identifier, initialize it with entity id
+    /// Select second identifier
     ///
-    /// # Arguments
-    ///
-    /// * `id` - The id to set.
-    fn set_second(&mut self, id: impl IntoEntity) -> &mut Self {
-        check_term_access_validity(self);
-        let id = id.into_entity(self.world());
-        self.second().set_id(id);
-        // reset term ref mode to src, otherwise it stays on second and makes other actions potentially invalid
-        self.set_term_ref_mode(TermRefMode::Src);
-        self
-    }
-
-    /// Select second identifier, initialize it with name. If name starts with a $
+    /// * initialize with id or
+    /// * initialize it with name. If name starts with a $
     /// the name is interpreted as a variable.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - The name to set.
-    fn set_second_name(&mut self, name: &'a str) -> &mut Self {
-        ecs_assert!(
-            !name.is_empty(),
-            FlecsErrorCode::InvalidParameter,
-            "name is empty"
-        );
+    fn set_second<T: SingleAccessArg>(&mut self, id: T) -> &mut Self
+    where
+        Access: FromAccessArg<T>,
+    {
+        check_term_access_validity(self);
+        let access = Access::from_access_arg(id, self.world());
+        match access.target {
+            AccessTarget::Entity(entity) => {
+                self.second().set_id(entity);
+            }
+            AccessTarget::Name(name) => {
+                ecs_assert!(
+                    !name.is_empty(),
+                    FlecsErrorCode::InvalidParameter,
+                    "name is empty"
+                );
 
-        self.second();
-        if let Some(stripped_name) = strip_prefix_str_raw(name, "$") {
-            self.set_var(stripped_name);
-        } else {
-            self.name(name);
+                self.second();
+                if let Some(stripped_name) = strip_prefix_str_raw(name, "$") {
+                    self.set_var(stripped_name);
+                } else {
+                    self.name(name);
+                }
+            }
+            _ => panic!("Invalid access target, only single targets allowed"),
         }
         // reset term ref mode to src, otherwise it stays on second and makes other actions potentially invalid
         self.set_term_ref_mode(TermRefMode::Src);

--- a/flecs_ecs/src/core/term.rs
+++ b/flecs_ecs/src/core/term.rs
@@ -387,7 +387,7 @@ pub trait TermBuilderImpl<'a>: Sized + WorldProvider<'a> + internals::QueryConfi
     ///
     /// * initialize it with entity id or
     /// * initialize it with name. If name starts with a $
-    /// the name is interpreted as a variable.
+    ///   the name is interpreted as a variable.
     ///
     /// # Arguments
     ///
@@ -421,10 +421,10 @@ pub trait TermBuilderImpl<'a>: Sized + WorldProvider<'a> + internals::QueryConfi
     ///
     /// * initialize with id or
     /// * initialize it with name. If name starts with a $
-    /// the name is interpreted as a variable.
-    fn set_first<T: SingleAccessArg>(&mut self, id: T) -> &mut Self
+    ///   the name is interpreted as a variable.
+    fn set_first<Q: SingleAccessArg>(&mut self, id: Q) -> &mut Self
     where
-        Access: FromAccessArg<T>,
+        Access: FromAccessArg<Q>,
     {
         check_term_access_validity(self);
         let access = Access::from_access_arg(id, self.world());
@@ -457,7 +457,7 @@ pub trait TermBuilderImpl<'a>: Sized + WorldProvider<'a> + internals::QueryConfi
     ///
     /// * initialize with id or
     /// * initialize it with name. If name starts with a $
-    /// the name is interpreted as a variable.
+    ///   the name is interpreted as a variable.
     fn set_second<T: SingleAccessArg>(&mut self, id: T) -> &mut Self
     where
         Access: FromAccessArg<T>,

--- a/flecs_ecs/src/core/term.rs
+++ b/flecs_ecs/src/core/term.rs
@@ -275,8 +275,6 @@ pub trait TermBuilderImpl<'a>: Sized + WorldProvider<'a> + internals::QueryConfi
     }
 
     /// The self flag indicates the term identifier itself is used
-    /// # See also
-    ///
     fn self_(&mut self) -> &mut Self {
         self.term_ref_mut().id |= ECS_SELF;
         self

--- a/flecs_ecs/src/core/term.rs
+++ b/flecs_ecs/src/core/term.rs
@@ -184,7 +184,7 @@ pub trait TermBuilderImpl<'a>: Sized + WorldProvider<'a> + internals::QueryConfi
     where
         T: IntoId,
     {
-        let id = id.into();
+        let id = id.into_id(self.world());
         let term = self.current_term_mut();
 
         #[allow(clippy::collapsible_else_if)]
@@ -632,7 +632,7 @@ pub trait TermBuilderImpl<'a>: Sized + WorldProvider<'a> + internals::QueryConfi
     ///
     /// * `flags` - The direction to traverse.
     fn id_flags(&mut self, flags: impl IntoId) -> &mut Self {
-        self.term_ref_mut().id |= *flags.into();
+        self.term_ref_mut().id |= *flags.into_id(self.world());
         self
     }
 
@@ -892,7 +892,7 @@ pub trait TermBuilderImpl<'a>: Sized + WorldProvider<'a> + internals::QueryConfi
                 self.current_term_mut().src.id = sid;
             } else {
                 self.current_term_mut().src.id =
-                    sys::ecs_get_alive(self.world_ptr_mut(), *ecs_first(sid));
+                    sys::ecs_get_alive(self.world_ptr_mut(), *ecs_first(sid, self.world()));
             }
         }
         self

--- a/flecs_ecs/src/core/term.rs
+++ b/flecs_ecs/src/core/term.rs
@@ -287,13 +287,14 @@ pub trait TermBuilderImpl<'a>: Sized + WorldProvider<'a> + internals::QueryConfi
     /// # Arguments
     ///
     /// * `id` - The id to set.
-    fn set_id(&mut self, id: impl Into<Entity>) -> &mut Self {
+    fn set_id(&mut self, id: impl IntoEntity) -> &mut Self {
+        let world = self.world();
         if self.current_term_ref_mode() != TermRefMode::Src {
             check_term_access_validity(self);
         }
 
         let term_ref = self.term_ref_mut();
-        term_ref.id = *id.into();
+        term_ref.id = *id.into_entity(world);
         self
     }
 
@@ -386,17 +387,8 @@ pub trait TermBuilderImpl<'a>: Sized + WorldProvider<'a> + internals::QueryConfi
     /// # Arguments
     ///
     /// * `id` - The id to set.
-    fn set_src_id(&mut self, id: impl Into<Entity>) -> &mut Self {
+    fn set_src(&mut self, id: impl IntoEntity) -> &mut Self {
         self.src().set_id(id)
-    }
-
-    /// Select src identifier, initialize it with id associated with type
-    ///
-    /// # Type Arguments
-    ///
-    /// * `T` - The type to use.
-    fn set_src<T: ComponentId>(&mut self) -> &mut Self {
-        self.set_src_id(T::id(self.world()))
     }
 
     /// Select src identifier, initialize it with name. If name starts with a $
@@ -425,22 +417,13 @@ pub trait TermBuilderImpl<'a>: Sized + WorldProvider<'a> + internals::QueryConfi
     /// # Arguments
     ///
     /// * `id` - The id to set.
-    fn set_first_id(&mut self, id: impl Into<Entity>) -> &mut Self {
+    fn set_first(&mut self, id: impl IntoEntity) -> &mut Self {
         check_term_access_validity(self);
+        let id = id.into_entity(self.world());
         self.first().set_id(id);
         // reset term ref mode to src, otherwise it stays on second and makes other actions potentially invalid
         self.set_term_ref_mode(TermRefMode::Src);
         self
-    }
-
-    /// Select first identifier, initialize it with id associated with type
-    ///
-    /// # Type Arguments
-    ///
-    /// * `T` - The type to use.
-    fn set_first<First: ComponentId>(&mut self) -> &mut Self {
-        check_term_access_validity(self);
-        self.set_first_id(First::id(self.world()))
     }
 
     /// Select first identifier, initialize it with name. If name starts with a $
@@ -473,22 +456,13 @@ pub trait TermBuilderImpl<'a>: Sized + WorldProvider<'a> + internals::QueryConfi
     /// # Arguments
     ///
     /// * `id` - The id to set.
-    fn set_second_id(&mut self, id: impl Into<Entity>) -> &mut Self {
+    fn set_second(&mut self, id: impl IntoEntity) -> &mut Self {
         check_term_access_validity(self);
+        let id = id.into_entity(self.world());
         self.second().set_id(id);
         // reset term ref mode to src, otherwise it stays on second and makes other actions potentially invalid
         self.set_term_ref_mode(TermRefMode::Src);
         self
-    }
-
-    /// Select second identifier, initialize it with id associated with type
-    ///
-    /// # Type Arguments
-    ///
-    /// * `T` - The type to use.
-    fn set_second<Second: ComponentId>(&mut self) -> &mut Self {
-        check_term_access_validity(self);
-        self.set_second_id(Second::id(self.world()))
     }
 
     /// Select second identifier, initialize it with name. If name starts with a $
@@ -543,7 +517,7 @@ pub trait TermBuilderImpl<'a>: Sized + WorldProvider<'a> + internals::QueryConfi
     /// # Arguments
     ///
     /// * `traverse_relationship` - The relationship to traverse.
-    fn up_id(&mut self, traverse_relationship: impl Into<Entity>) -> &mut Self {
+    fn up_id(&mut self, traverse_relationship: impl IntoEntity) -> &mut Self {
         ecs_assert!(
             self.current_term_ref_mode() == TermRefMode::Src,
             FlecsErrorCode::InvalidParameter,
@@ -551,25 +525,7 @@ pub trait TermBuilderImpl<'a>: Sized + WorldProvider<'a> + internals::QueryConfi
         );
         let term_ref = self.term_ref_mut();
         term_ref.id |= ECS_UP;
-        self.current_term_mut().trav = *traverse_relationship.into();
-        self
-    }
-
-    /// The up flag indicates that the term identifier may be substituted by
-    /// traversing a relationship upwards. For example: substitute the identifier
-    /// with its parent by traversing the `ChildOf` relationship.
-    ///
-    /// # Type Arguments
-    ///
-    /// * `TravRel` - The relationship to traverse.
-    fn up_type<TravRel: ComponentId>(&mut self) -> &mut Self {
-        ecs_assert!(
-            self.current_term_ref_mode() == TermRefMode::Src,
-            FlecsErrorCode::InvalidParameter,
-            "up traversal can only be applied to term source"
-        );
-        self.term_ref_mut().id |= ECS_UP;
-        self.current_term_mut().trav = TravRel::id(self.world());
+        self.current_term_mut().trav = *traverse_relationship.into_entity(self.world());
         self
     }
 
@@ -589,21 +545,8 @@ pub trait TermBuilderImpl<'a>: Sized + WorldProvider<'a> + internals::QueryConfi
     /// # Arguments
     ///
     /// * `traverse_relationship` - The optional relationship to traverse.
-    fn cascade_id(&mut self, traverse_relationship: impl Into<Entity>) -> &mut Self {
+    fn cascade_id(&mut self, traverse_relationship: impl IntoEntity) -> &mut Self {
         self.up_id(traverse_relationship);
-        self.term_ref_mut().id |= ECS_CASCADE;
-        self
-    }
-
-    /// Cascade iterates a hierarchy in top to bottom order (breadth first search)
-    /// The cascade flag is like up, but returns results in breadth-first order.
-    /// Only supported for `flecs::query`
-    ///
-    /// # Type Arguments
-    ///
-    /// * `TravRel` - The relationship to traverse.
-    fn cascade_type<TravRel: ComponentId>(&mut self) -> &mut Self {
-        self.up_type::<TravRel>();
         self.term_ref_mut().id |= ECS_CASCADE;
         self
     }
@@ -620,8 +563,8 @@ pub trait TermBuilderImpl<'a>: Sized + WorldProvider<'a> + internals::QueryConfi
     ///
     /// * `traverse_relationship` - The relationship to traverse.
     /// * `flags` - The direction to traverse.
-    fn trav(&mut self, traverse_relationship: impl Into<Entity>, flags: u64) -> &mut Self {
-        self.current_term_mut().trav = *traverse_relationship.into();
+    fn trav(&mut self, traverse_relationship: impl IntoEntity, flags: u64) -> &mut Self {
+        self.current_term_mut().trav = *traverse_relationship.into_entity(self.world());
         self.term_ref_mut().id |= flags;
         self
     }
@@ -704,7 +647,7 @@ pub trait TermBuilderImpl<'a>: Sized + WorldProvider<'a> + internals::QueryConfi
     /// * [`Self::inout_stage`]
     /// * [`InOutKind`]
     #[inline(always)]
-    fn read_write(&mut self) -> &mut Self {
+    fn read_write_curr(&mut self) -> &mut Self {
         check_term_access_validity(self);
         self.inout_stage(InOutKind::InOut)
     }

--- a/flecs_ecs/src/core/utility/functions.rs
+++ b/flecs_ecs/src/core/utility/functions.rs
@@ -409,7 +409,6 @@ pub(crate) unsafe fn ecs_field_at<T>(it: *const sys::ecs_iter_t, index: i8, row:
 /// * `T`: The type to get the `OperKind` for.
 ///
 /// # See also
-///
 pub(crate) fn type_to_oper<T: OperType>() -> OperKind {
     T::OPER
 }

--- a/flecs_ecs/src/core/utility/functions.rs
+++ b/flecs_ecs/src/core/utility/functions.rs
@@ -123,8 +123,10 @@ pub fn ecs_add_pair(
 ///
 /// The first entity from the pair.
 #[inline(always)]
-pub fn ecs_first(e: impl IntoId) -> Entity {
-    Entity(ecs_entity_id_high(e.into() & RUST_ECS_COMPONENT_MASK))
+pub fn ecs_first<'a>(e: impl IntoId, world: impl WorldProvider<'a>) -> Entity {
+    let world = world.world();
+    let id = e.into_id(world) & RUST_ECS_COMPONENT_MASK;
+    Entity(ecs_entity_id_high(id, world))
 }
 
 /// Get the second entity from a pair.
@@ -137,8 +139,9 @@ pub fn ecs_first(e: impl IntoId) -> Entity {
 ///
 /// The second entity from the pair.
 #[inline(always)]
-pub fn ecs_second(e: impl IntoId) -> Entity {
-    Entity(ecs_entity_id_low(e.into()))
+pub fn ecs_second<'a>(e: impl IntoId, world: impl WorldProvider<'a>) -> Entity {
+    let world = world.world();
+    Entity(ecs_entity_id_low(e.into_id(world), world))
 }
 
 /// Get the lower 32 bits of an entity id.
@@ -151,8 +154,8 @@ pub fn ecs_second(e: impl IntoId) -> Entity {
 ///
 /// The lower 32 bits of the entity id.
 #[inline(always)]
-pub fn ecs_entity_id_low(value: impl IntoId) -> u64 {
-    *value.into() as u32 as u64
+pub fn ecs_entity_id_low<'a>(value: impl IntoId, world: impl WorldProvider<'a>) -> u64 {
+    *value.into_id(world) as u32 as u64
 }
 
 /// Get the higher 32 bits of an entity id.
@@ -165,8 +168,8 @@ pub fn ecs_entity_id_low(value: impl IntoId) -> u64 {
 ///
 /// The higher 32 bits of the entity id.
 #[inline(always)]
-pub fn ecs_entity_id_high(value: impl IntoId) -> u64 {
-    (*value.into()) >> 32
+pub fn ecs_entity_id_high<'a>(value: impl IntoId, world: impl WorldProvider<'a>) -> u64 {
+    *value.into_id(world) >> 32
 }
 
 pub fn type_name_cstring<T>() -> CString {

--- a/flecs_ecs/src/core/utility/id.rs
+++ b/flecs_ecs/src/core/utility/id.rs
@@ -1,0 +1,26 @@
+use crate::core::ComponentId;
+
+impl<T: ComponentId> Clone for Id<T> {
+    fn clone(&self) -> Self {
+        Id::new()
+    }
+}
+
+impl<T: ComponentId> Copy for Id<T> {}
+
+#[derive(Debug)]
+pub struct Id<T: ComponentId> {
+    _marker: std::marker::PhantomData<T>,
+}
+
+pub fn id<T: ComponentId>() -> Id<T> {
+    Id::new()
+}
+
+impl<T: ComponentId> Id<T> {
+    pub(crate) fn new() -> Self {
+        Id {
+            _marker: std::marker::PhantomData,
+        }
+    }
+}

--- a/flecs_ecs/src/core/utility/id.rs
+++ b/flecs_ecs/src/core/utility/id.rs
@@ -2,7 +2,7 @@ use crate::core::ComponentId;
 
 impl<T: ComponentId> Clone for Id<T> {
     fn clone(&self) -> Self {
-        Id::new()
+        *self
     }
 }
 
@@ -10,17 +10,19 @@ impl<T: ComponentId> Copy for Id<T> {}
 
 #[derive(Debug)]
 pub struct Id<T: ComponentId> {
-    _marker: std::marker::PhantomData<T>,
+    _marker: core::marker::PhantomData<T>,
 }
 
-pub fn id<T: ComponentId>() -> Id<T> {
+#[inline(always)]
+pub const fn id<T: ComponentId>() -> Id<T> {
     Id::new()
 }
 
 impl<T: ComponentId> Id<T> {
-    pub(crate) fn new() -> Self {
+    #[inline(always)]
+    pub(crate) const fn new() -> Self {
         Id {
-            _marker: std::marker::PhantomData,
+            _marker: core::marker::PhantomData,
         }
     }
 }

--- a/flecs_ecs/src/core/utility/mod.rs
+++ b/flecs_ecs/src/core/utility/mod.rs
@@ -3,6 +3,7 @@
 
 mod errors;
 mod functions;
+pub mod id;
 pub(crate) mod id_map;
 mod log;
 pub mod traits;
@@ -10,6 +11,7 @@ pub mod types;
 
 pub use errors::*;
 pub use functions::*;
+pub use id::id;
 pub(crate) use id_map::*;
 pub use log::*;
 

--- a/flecs_ecs/src/core/utility/traits/into_entity.rs
+++ b/flecs_ecs/src/core/utility/traits/into_entity.rs
@@ -1,18 +1,136 @@
 use super::{super::id::Id, WorldProvider};
-use crate::core::{ComponentId, Entity};
+use crate::core::{ComponentId, ComponentInfo, Entity};
 
 pub trait IntoEntity {
+    const IS_TYPED_PAIR: bool;
+    const IS_TYPED: bool;
+    const IF_ID_IS_DEFAULT: bool;
+    const IS_TYPED_SECOND: bool;
+    const IF_ID_IS_DEFAULT_SECOND: bool;
+    const IS_ENUM: bool;
+    const IS_TYPE_TAG: bool;
+    const IS_TYPED_REF: bool;
+    const IS_TYPED_MUT_REF: bool;
     fn into_entity<'a>(self, world: impl WorldProvider<'a>) -> Entity;
 }
 
 impl<T: ComponentId> IntoEntity for Id<T> {
+    const IS_TYPED_PAIR: bool = false;
+    const IS_TYPED: bool = true;
+    const IF_ID_IS_DEFAULT: bool = T::IMPLS_DEFAULT;
+    const IS_TYPED_SECOND: bool = true;
+    const IF_ID_IS_DEFAULT_SECOND: bool = false;
+    const IS_ENUM: bool = T::IS_ENUM;
+    const IS_TYPE_TAG: bool = T::IS_TAG;
+    const IS_TYPED_REF: bool = <T as ComponentInfo>::IS_REF;
+    const IS_TYPED_MUT_REF: bool = <T as ComponentInfo>::IS_MUT;
     fn into_entity<'a>(self, world: impl WorldProvider<'a>) -> Entity {
         world.world().component_id::<T>()
     }
 }
 
 impl<T: Into<Entity>> IntoEntity for T {
+    const IS_TYPED_PAIR: bool = false;
+    const IS_TYPED: bool = false;
+    const IF_ID_IS_DEFAULT: bool = false; //we don't know if the id is default or not
+    const IS_TYPED_SECOND: bool = true;
+    const IF_ID_IS_DEFAULT_SECOND: bool = false;
+    const IS_ENUM: bool = false;
+    const IS_TYPE_TAG: bool = false;
+    const IS_TYPED_REF: bool = false;
+    const IS_TYPED_MUT_REF: bool = false;
     fn into_entity<'a>(self, _world: impl WorldProvider<'a>) -> Entity {
         self.into()
+    }
+}
+
+#[doc(hidden)]
+pub trait InternalIntoEntity {
+    const IS_TYPED_PAIR: bool;
+    const IS_TYPED: bool;
+    const IF_ID_IS_DEFAULT: bool;
+    const IS_TYPED_SECOND: bool;
+    const IF_ID_IS_DEFAULT_SECOND: bool;
+    const IS_ENUM: bool;
+    const IS_TYPE_TAG: bool;
+    const IS_TYPED_REF: bool;
+    const IS_TYPED_MUT_REF: bool;
+
+    fn into_entity<'a>(self, world: impl WorldProvider<'a>) -> Entity;
+}
+
+#[doc(hidden)]
+impl<T: IntoEntity> InternalIntoEntity for T {
+    const IS_TYPED_PAIR: bool = T::IS_TYPED_PAIR;
+    const IS_TYPED: bool = T::IS_TYPED;
+    const IF_ID_IS_DEFAULT: bool = T::IF_ID_IS_DEFAULT;
+    const IS_TYPED_SECOND: bool = T::IS_TYPED_SECOND;
+    const IF_ID_IS_DEFAULT_SECOND: bool = T::IF_ID_IS_DEFAULT_SECOND;
+    const IS_ENUM: bool = T::IS_ENUM;
+    const IS_TYPE_TAG: bool = <T as IntoEntity>::IS_TYPE_TAG;
+    const IS_TYPED_REF: bool = T::IS_TYPED_REF;
+    const IS_TYPED_MUT_REF: bool = T::IS_TYPED_MUT_REF;
+    fn into_entity<'a>(self, world: impl WorldProvider<'a>) -> Entity {
+        self.into_entity(world)
+    }
+}
+
+// we implement this to optimize the case where we add a component id<T> to add
+// normally we shouldn't implment IntoEntity for Id
+#[doc(hidden)]
+impl InternalIntoEntity for crate::core::Id {
+    const IS_TYPED_PAIR: bool = false;
+    const IS_TYPED: bool = false;
+    const IF_ID_IS_DEFAULT: bool = false; //we don't know if the id is default or not
+    const IS_TYPED_SECOND: bool = true;
+    const IF_ID_IS_DEFAULT_SECOND: bool = false;
+    const IS_ENUM: bool = false;
+    const IS_TYPE_TAG: bool = false;
+    const IS_TYPED_REF: bool = false;
+    const IS_TYPED_MUT_REF: bool = false;
+    fn into_entity<'a>(self, _world: impl WorldProvider<'a>) -> Entity {
+        Entity(self.0)
+    }
+}
+
+// we implement this to optimize the case where we add a component id<T> to add
+// normally we shouldn't implment IntoEntity for Id
+#[doc(hidden)]
+impl InternalIntoEntity for crate::core::IdView<'_> {
+    const IS_TYPED_PAIR: bool = false;
+    const IS_TYPED: bool = false;
+    const IF_ID_IS_DEFAULT: bool = false; //we don't know if the id is default or not
+    const IS_TYPED_SECOND: bool = true;
+    const IF_ID_IS_DEFAULT_SECOND: bool = false;
+    const IS_ENUM: bool = false;
+    const IS_TYPE_TAG: bool = false;
+    const IS_TYPED_REF: bool = false;
+    const IS_TYPED_MUT_REF: bool = false;
+    fn into_entity<'a>(self, _world: impl WorldProvider<'a>) -> Entity {
+        Entity(*self.id)
+    }
+}
+
+#[doc(hidden)]
+impl<T, U> InternalIntoEntity for (T, U)
+where
+    T: InternalIntoEntity + Copy,
+    U: InternalIntoEntity + Copy,
+{
+    const IS_TYPED_PAIR: bool = true;
+    const IS_TYPED: bool = T::IS_TYPED;
+    const IF_ID_IS_DEFAULT: bool = T::IF_ID_IS_DEFAULT; //we don't know if the id is default or not
+    const IS_TYPED_SECOND: bool = U::IS_TYPED;
+    const IF_ID_IS_DEFAULT_SECOND: bool = U::IF_ID_IS_DEFAULT; //we don't know if the id is default or not
+    const IS_ENUM: bool = false;
+    const IS_TYPE_TAG: bool = T::IS_TYPE_TAG & U::IS_TYPE_TAG;
+    const IS_TYPED_REF: bool = T::IS_TYPED_REF || U::IS_TYPED_REF;
+    const IS_TYPED_MUT_REF: bool = T::IS_TYPED_MUT_REF || U::IS_TYPED_MUT_REF;
+    fn into_entity<'a>(self, world: impl WorldProvider<'a>) -> Entity {
+        let world = world.world();
+        Entity(crate::core::ecs_pair(
+            *(self.0.into_entity(world)),
+            *(self.1.into_entity(world)),
+        ))
     }
 }

--- a/flecs_ecs/src/core/utility/traits/into_entity.rs
+++ b/flecs_ecs/src/core/utility/traits/into_entity.rs
@@ -76,7 +76,7 @@ impl<T: IntoEntity> InternalIntoEntity for T {
 }
 
 // we implement this to optimize the case where we add a component id<T> to add
-// normally we shouldn't implment IntoEntity for Id
+// normally we shouldn't implement IntoEntity for Id
 #[doc(hidden)]
 impl InternalIntoEntity for crate::core::Id {
     const IS_TYPED_PAIR: bool = false;
@@ -94,7 +94,7 @@ impl InternalIntoEntity for crate::core::Id {
 }
 
 // we implement this to optimize the case where we add a component id<T> to add
-// normally we shouldn't implment IntoEntity for Id
+// normally we shouldn't implement IntoEntity for Id
 #[doc(hidden)]
 impl InternalIntoEntity for crate::core::IdView<'_> {
     const IS_TYPED_PAIR: bool = false;

--- a/flecs_ecs/src/core/utility/traits/into_entity.rs
+++ b/flecs_ecs/src/core/utility/traits/into_entity.rs
@@ -124,8 +124,8 @@ where
     const IF_ID_IS_DEFAULT_SECOND: bool = U::IF_ID_IS_DEFAULT; //we don't know if the id is default or not
     const IS_ENUM: bool = false;
     const IS_TYPE_TAG: bool = T::IS_TYPE_TAG & U::IS_TYPE_TAG;
-    const IS_TYPED_REF: bool = T::IS_TYPED_REF || U::IS_TYPED_REF;
-    const IS_TYPED_MUT_REF: bool = T::IS_TYPED_MUT_REF || U::IS_TYPED_MUT_REF;
+    const IS_TYPED_REF: bool = false;
+    const IS_TYPED_MUT_REF: bool = false;
     fn into_entity<'a>(self, world: impl WorldProvider<'a>) -> Entity {
         let world = world.world();
         Entity(crate::core::ecs_pair(
@@ -134,3 +134,51 @@ where
         ))
     }
 }
+
+// #[doc(hidden)]
+// impl<T, U> InternalIntoEntity for &(T, U)
+// where
+//     T: InternalIntoEntity + Copy,
+//     U: InternalIntoEntity + Copy,
+// {
+//     const IS_TYPED_PAIR: bool = true;
+//     const IS_TYPED: bool = T::IS_TYPED;
+//     const IF_ID_IS_DEFAULT: bool = T::IF_ID_IS_DEFAULT; //we don't know if the id is default or not
+//     const IS_TYPED_SECOND: bool = U::IS_TYPED;
+//     const IF_ID_IS_DEFAULT_SECOND: bool = U::IF_ID_IS_DEFAULT; //we don't know if the id is default or not
+//     const IS_ENUM: bool = false;
+//     const IS_TYPE_TAG: bool = T::IS_TYPE_TAG & U::IS_TYPE_TAG;
+//     const IS_TYPED_REF: bool = true;
+//     const IS_TYPED_MUT_REF: bool = false;
+//     fn into_entity<'a>(self, world: impl WorldProvider<'a>) -> Entity {
+//         let world = world.world();
+//         Entity(crate::core::ecs_pair(
+//             *(self.0.into_entity(world)),
+//             *(self.1.into_entity(world)),
+//         ))
+//     }
+// }
+
+// #[doc(hidden)]
+// impl<T, U> InternalIntoEntity for &mut (T, U)
+// where
+//     T: InternalIntoEntity + Copy,
+//     U: InternalIntoEntity + Copy,
+// {
+//     const IS_TYPED_PAIR: bool = true;
+//     const IS_TYPED: bool = T::IS_TYPED;
+//     const IF_ID_IS_DEFAULT: bool = T::IF_ID_IS_DEFAULT; //we don't know if the id is default or not
+//     const IS_TYPED_SECOND: bool = U::IS_TYPED;
+//     const IF_ID_IS_DEFAULT_SECOND: bool = U::IF_ID_IS_DEFAULT; //we don't know if the id is default or not
+//     const IS_ENUM: bool = false;
+//     const IS_TYPE_TAG: bool = T::IS_TYPE_TAG & U::IS_TYPE_TAG;
+//     const IS_TYPED_REF: bool = false;
+//     const IS_TYPED_MUT_REF: bool = true;
+//     fn into_entity<'a>(self, world: impl WorldProvider<'a>) -> Entity {
+//         let world = world.world();
+//         Entity(crate::core::ecs_pair(
+//             *(self.0.into_entity(world)),
+//             *(self.1.into_entity(world)),
+//         ))
+//     }
+// }

--- a/flecs_ecs/src/core/utility/traits/into_entity.rs
+++ b/flecs_ecs/src/core/utility/traits/into_entity.rs
@@ -1,0 +1,18 @@
+use super::{super::id::Id, WorldProvider};
+use crate::core::{ComponentId, Entity};
+
+pub trait IntoEntity {
+    fn into_entity<'a>(self, world: impl WorldProvider<'a>) -> Entity;
+}
+
+impl<T: ComponentId> IntoEntity for Id<T> {
+    fn into_entity<'a>(self, world: impl WorldProvider<'a>) -> Entity {
+        world.world().component_id::<T>()
+    }
+}
+
+impl<T: Into<Entity>> IntoEntity for T {
+    fn into_entity<'a>(self, _world: impl WorldProvider<'a>) -> Entity {
+        self.into()
+    }
+}

--- a/flecs_ecs/src/core/utility/traits/into_id.rs
+++ b/flecs_ecs/src/core/utility/traits/into_id.rs
@@ -3,7 +3,7 @@ use crate::core::*;
 /// Extracts the Ecs ID from a type.
 /// Extension trait from [`Into<Entity>`] for tuples that implement `Into<Entity>`.
 /// These types can be [`Id`], [`IdView`], [`Entity`], [`EntityView`], [`Component`], [`UntypedComponent`].
-pub trait IntoId
+pub trait IntoId: InternalIntoEntity
 where
     Self: Sized,
 {
@@ -12,6 +12,10 @@ where
     /// not if the underlying id represents a pair.
     /// This should generally not be used by the user.
     const IS_PAIR: bool;
+    const IS_ENUM: bool;
+    const IS_TYPE_TAG: bool;
+    const IS_TYPED_REF: bool;
+    const IS_TYPED_MUT_REF: bool;
 
     #[doc(hidden)] // not meant to be used by the user
     #[inline]
@@ -46,38 +50,42 @@ where
 //     }
 // }
 
-impl<T, U> IntoId for (T, U)
-where
-    T: IntoEntity + Copy,
-    U: IntoEntity + Copy,
-{
-    const IS_PAIR: bool = true;
+// impl<T, U> IntoId for (T, U)
+// where
+//     T: IntoEntity + Copy,
+//     U: IntoEntity + Copy,
+// {
+//     const IS_PAIR: bool = true;
 
-    #[doc(hidden)] // not meant to be used by the use
-    #[inline]
-    fn into_id<'a>(self, world: impl WorldProvider<'a>) -> Id {
-        let world = world.world();
-        Id(ecs_pair(
-            *(self.0.into_entity(world)),
-            *(self.1.into_entity(world)),
-        ))
-    }
+//     #[doc(hidden)] // not meant to be used by the use
+//     #[inline]
+//     fn into_id<'a>(self, world: impl WorldProvider<'a>) -> Id {
+//         let world = world.world();
+//         Id(ecs_pair(
+//             *(self.0.into_entity(world)),
+//             *(self.1.into_entity(world)),
+//         ))
+//     }
 
-    #[doc(hidden)] // not meant to be used by the user
-    #[inline]
-    fn get_id_first<'a>(self, world: impl WorldProvider<'a>) -> Entity {
-        self.0.into_entity(world)
-    }
+//     #[doc(hidden)] // not meant to be used by the user
+//     #[inline]
+//     fn get_id_first<'a>(self, world: impl WorldProvider<'a>) -> Entity {
+//         self.0.into_entity(world)
+//     }
 
-    #[doc(hidden)] // not meant to be used by the user
-    #[inline]
-    fn get_id_second<'a>(self, world: impl WorldProvider<'a>) -> Entity {
-        self.1.into_entity(world)
-    }
-}
+//     #[doc(hidden)] // not meant to be used by the user
+//     #[inline]
+//     fn get_id_second<'a>(self, world: impl WorldProvider<'a>) -> Entity {
+//         self.1.into_entity(world)
+//     }
+// }
 
-impl<T: IntoEntity> IntoId for T {
-    const IS_PAIR: bool = false;
+impl<T: InternalIntoEntity> IntoId for T {
+    const IS_PAIR: bool = T::IS_TYPED_PAIR;
+    const IS_ENUM: bool = <T as InternalIntoEntity>::IS_ENUM;
+    const IS_TYPE_TAG: bool = <T as InternalIntoEntity>::IS_TYPE_TAG;
+    const IS_TYPED_REF: bool = <T as InternalIntoEntity>::IS_TYPED_REF;
+    const IS_TYPED_MUT_REF: bool = <T as InternalIntoEntity>::IS_TYPED_MUT_REF;
 
     #[doc(hidden)] // not meant to be used by the user
     #[inline]
@@ -101,47 +109,47 @@ impl<T: IntoEntity> IntoId for T {
 //     const IS_PAIR: bool = false;
 // }
 
-impl IntoId for Id {
-    const IS_PAIR: bool = false;
+// impl IntoId for Id {
+//     const IS_PAIR: bool = false;
 
-    #[doc(hidden)] // not meant to be used by the user
-    #[inline]
-    fn into_id<'a>(self, _world: impl WorldProvider<'a>) -> Id {
-        self
-    }
-    #[doc(hidden)] // not meant to be used by the user
-    #[inline]
-    fn get_id_first<'a>(self, world: impl WorldProvider<'a>) -> Entity {
-        ecs_first(*self, world)
-    }
+//     #[doc(hidden)] // not meant to be used by the user
+//     #[inline]
+//     fn into_id<'a>(self, _world: impl WorldProvider<'a>) -> Id {
+//         self
+//     }
+//     #[doc(hidden)] // not meant to be used by the user
+//     #[inline]
+//     fn get_id_first<'a>(self, world: impl WorldProvider<'a>) -> Entity {
+//         ecs_first(*self, world)
+//     }
 
-    #[doc(hidden)] // not meant to be used by the user
-    #[inline]
-    fn get_id_second<'a>(self, world: impl WorldProvider<'a>) -> Entity {
-        ecs_second(*self, world)
-    }
-}
+//     #[doc(hidden)] // not meant to be used by the user
+//     #[inline]
+//     fn get_id_second<'a>(self, world: impl WorldProvider<'a>) -> Entity {
+//         ecs_second(*self, world)
+//     }
+// }
 
-impl IntoId for IdView<'_> {
-    const IS_PAIR: bool = false;
+// impl IntoId for IdView<'_> {
+//     const IS_PAIR: bool = false;
 
-    #[doc(hidden)] // not meant to be used by the user
-    #[inline]
-    fn into_id<'a>(self, _world: impl WorldProvider<'a>) -> Id {
-        self.id
-    }
+//     #[doc(hidden)] // not meant to be used by the user
+//     #[inline]
+//     fn into_id<'a>(self, _world: impl WorldProvider<'a>) -> Id {
+//         self.id
+//     }
 
-    #[doc(hidden)] // not meant to be used by the user
-    #[inline]
-    fn get_id_first<'a>(self, world: impl WorldProvider<'a>) -> Entity {
-        ecs_first(self.id, world)
-    }
-    #[doc(hidden)] // not meant to be used by the user
-    #[inline]
-    fn get_id_second<'a>(self, world: impl WorldProvider<'a>) -> Entity {
-        ecs_second(self.id, world)
-    }
-}
+//     #[doc(hidden)] // not meant to be used by the user
+//     #[inline]
+//     fn get_id_first<'a>(self, world: impl WorldProvider<'a>) -> Entity {
+//         ecs_first(self.id, world)
+//     }
+//     #[doc(hidden)] // not meant to be used by the user
+//     #[inline]
+//     fn get_id_second<'a>(self, world: impl WorldProvider<'a>) -> Entity {
+//         ecs_second(self.id, world)
+//     }
+// }
 
 // impl IntoId for EntityView<'_> {
 //     const IS_PAIR: bool = false;

--- a/flecs_ecs/src/core/utility/traits/into_id.rs
+++ b/flecs_ecs/src/core/utility/traits/into_id.rs
@@ -1,7 +1,7 @@
 use crate::core::*;
 
-/// Extracts the Ecs ID from_access_arg a type.
-/// Extension trait from_access_arg [`Into<Entity>`] for tuples that implement `Into<Entity>`.
+/// Extracts the Ecs ID a type.
+/// Extension trait [`Into<Entity>`] for tuples that implement `Into<Entity>`.
 /// These types can be [`Id`], [`IdView`], [`Entity`], [`EntityView`], [`Component`], [`UntypedComponent`].
 pub trait IntoId: InternalIntoEntity
 where
@@ -131,13 +131,9 @@ where
 {
 }
 
-// impl<T: ComponentId> SingleAccessArg for &crate::core::utility::id::Id<T> {}
-// impl<T: ComponentId> SingleAccessArg for &mut crate::core::utility::id::Id<T> {}
 impl SingleAccessArg for &'static str {}
-//impl<T: IntoEntity> SingleAccessArg for T where Access: FromAccessArg<T> {}
+impl<T: IntoEntity> SingleAccessArg for T where Access: FromAccessArg<T> {}
 
-impl<T: ComponentId> AccessArg for &crate::core::utility::id::Id<T> {}
-impl<T: ComponentId> AccessArg for &mut crate::core::utility::id::Id<T> {}
 impl AccessArg for &'static str {}
 impl<T: IntoId> AccessArg for T where Access: FromAccessArg<T> {}
 impl AccessArg for (&'static str, &'static str) {}

--- a/flecs_ecs/src/core/utility/traits/into_id.rs
+++ b/flecs_ecs/src/core/utility/traits/into_id.rs
@@ -117,7 +117,7 @@ pub trait FromAccessArg<T> {
     fn from_access_arg<'a>(value: T, world: impl WorldProvider<'a>) -> Access;
 }
 
-/// “Only single‐target inputs” (Entity, &str, Id<T>, …)
+/// “Only single‐target inputs” (Entity, &str, `Id<T>`, …)
 pub trait SingleAccessArg: Sized
 where
     Access: FromAccessArg<Self>,

--- a/flecs_ecs/src/core/utility/traits/mod.rs
+++ b/flecs_ecs/src/core/utility/traits/mod.rs
@@ -72,7 +72,6 @@ pub mod private {
         /// * `iter` - The iterator which gets passed in from `C`
         ///
         /// # See also
-        ///
         unsafe extern "C-unwind" fn execute_each<const CALLED_FROM_RUN: bool, Func>(
             iter: *mut sys::ecs_iter_t,
         ) where
@@ -122,7 +121,6 @@ pub mod private {
         /// * `iter` - The iterator which gets passed in from `C`
         ///
         /// # See also
-        ///
         unsafe extern "C-unwind" fn execute_each_entity<const CALLED_FROM_RUN: bool, Func>(
             iter: *mut sys::ecs_iter_t,
         ) where
@@ -184,7 +182,6 @@ pub mod private {
         /// * `iter` - The iterator which gets passed in from `C`
         ///
         /// # See also
-        ///
         unsafe extern "C-unwind" fn execute_each_iter<Func>(iter: *mut sys::ecs_iter_t)
         where
             Func: FnMut(TableIter<false, P>, usize, T::TupleType<'_>),
@@ -229,7 +226,6 @@ pub mod private {
         /// * `iter` - The iterator which gets passed in from `C`
         ///
         /// # See also
-        ///
         unsafe extern "C-unwind" fn execute_run<Func>(iter: *mut sys::ecs_iter_t)
         where
             Func: FnMut(TableIter<true, P>),

--- a/flecs_ecs/src/core/utility/traits/mod.rs
+++ b/flecs_ecs/src/core/utility/traits/mod.rs
@@ -1,6 +1,7 @@
 mod id_operations;
 mod inout_oper;
 mod into_component_id;
+mod into_entity;
 mod into_id;
 mod into_table;
 mod query_api;
@@ -10,6 +11,7 @@ mod world_provider;
 pub use id_operations::*;
 pub use inout_oper::*;
 pub use into_component_id::*;
+pub use into_entity::*;
 pub use into_id::*;
 pub use into_table::*;
 pub use query_api::*;

--- a/flecs_ecs/src/core/utility/traits/query_api.rs
+++ b/flecs_ecs/src/core/utility/traits/query_api.rs
@@ -168,14 +168,14 @@ where
     /// world
     ///     .entity_named("adam")
     ///     .set(Position { x: 10, y: 20 })
-    ///     .add_first::<Likes>(eva);
+    ///     .add((id::<Likes>(), eva));
     ///
     /// world
     ///     .query::<&Position>()
-    ///     .with::<(Likes, flecs::Wildcard)>()
+    ///     .with((id::<Likes>(), id::<flecs::Wildcard>()))
     ///     .build()
     ///     .each_iter(|it, index, p| {
-    ///         let e = it.entity(index);
+    ///         let e = it.entity(index).unwrap();
     ///         println!("{:?}: {:?} - {:?}", e.name(), p, it.id(1).to_str());
     ///     });
     ///
@@ -380,13 +380,13 @@ where
     ///
     /// let world = World::new();
     ///
-    /// world.entity().add::<Tag>().add::<Position>();
-    /// world.entity().add::<Tag>().add::<Position>();
+    /// world.entity().add(id::<Tag>()).add(id::<Position>());
+    /// world.entity().add(id::<Tag>()).add(id::<Position>());
     /// world
     ///     .entity()
-    ///     .add::<Tag>()
-    ///     .add::<Position>()
-    ///     .add::<Velocity>();
+    ///     .add(id::<Tag>())
+    ///     .add(id::<Position>())
+    ///     .add(id::<Velocity>());
     ///
     /// let query = world.new_query::<(&Tag, &Position)>();
     ///
@@ -400,7 +400,7 @@ where
     ///         let pos = it.field::<&Position>(1).unwrap(); //at index 1 in (&Tag, &Position)
     ///         for i in it.iter() {
     ///             count_entities += 1;
-    ///             let entity = it.entity(i);
+    ///             let entity = it.entity(i).unwrap();
     ///             println!("{:?}: {:?}", entity, pos[i]);
     ///         }
     ///     }
@@ -474,15 +474,15 @@ where
     ///
     /// let world = World::new();
     ///
-    /// world.entity().add::<Tag>().add::<Position>();
-    /// world.entity().add::<Tag>().add::<Position>();
+    /// world.entity().add(id::<Tag>()).add(id::<Position>());
+    /// world.entity().add(id::<Tag>()).add(id::<Position>());
     /// world
     ///     .entity()
-    ///     .add::<Tag>()
-    ///     .add::<Position>()
-    ///     .add::<Velocity>();
+    ///     .add(id::<Tag>())
+    ///     .add(id::<Position>())
+    ///     .add(id::<Velocity>());
     ///
-    /// let query = world.query::<(&Position)>().with::<Tag>().build();
+    /// let query = world.query::<(&Position)>().with(id::<Tag>()).build();
     ///
     /// let mut count_tables = 0;
     /// let mut count_entities = 0;
@@ -562,15 +562,15 @@ where
     ///
     /// let world = World::new();
     ///
-    /// world.entity().add::<Tag>().add::<Position>();
-    /// world.entity().add::<Tag>().add::<Position>();
+    /// world.entity().add(id::<Tag>()).add(id::<Position>());
+    /// world.entity().add(id::<Tag>()).add(id::<Position>());
     /// world
     ///     .entity()
-    ///     .add::<Tag>()
-    ///     .add::<Position>()
-    ///     .add::<Velocity>();
+    ///     .add(id::<Tag>())
+    ///     .add(id::<Position>())
+    ///     .add(id::<Velocity>());
     ///
-    /// let query = world.query::<(&Position)>().with::<Tag>().build();
+    /// let query = world.query::<(&Position)>().with(id::<Tag>()).build();
     ///
     /// let mut count_tables = 0;
     /// let mut count_entities = 0;
@@ -1095,20 +1095,9 @@ where
     /// # Arguments
     ///
     /// * `group_id`: the group id to set
-    fn set_group_id(&self, group_id: impl Into<Entity>) -> QueryIter<P, T> {
+    fn set_group(&self, group_id: impl IntoEntity) -> QueryIter<P, T> {
         let mut iter = self.iterable();
-        QueryIter::<P, T>::set_group_id(&mut iter, group_id);
-        iter
-    }
-
-    /// Limit results to tables with specified group id (grouped queries only)
-    ///
-    /// # Type parameters
-    ///
-    /// * `Group`: the group to set
-    fn set_group<Group: ComponentId>(&self) -> QueryIter<P, T> {
-        let mut iter = self.iterable();
-        QueryIter::<P, T>::set_group::<Group>(&mut iter);
+        QueryIter::<P, T>::set_group(&mut iter, group_id);
         iter
     }
 

--- a/flecs_ecs/src/core/utility/traits/system_api.rs
+++ b/flecs_ecs/src/core/utility/traits/system_api.rs
@@ -87,13 +87,13 @@ where
     /// world
     ///     .entity_named("adam")
     ///     .set(Position { x: 10, y: 20 })
-    ///     .add_first::<Likes>(eva);
+    ///     .add((id::<Likes>(), eva));
     ///
     /// world
     ///     .system::<&Position>()
-    ///     .with::<(Likes, flecs::Wildcard)>()
+    ///     .with((id::<Likes>(), id::<flecs::Wildcard>()))
     ///     .each_iter(|it, index, p| {
-    ///         let e = it.entity(index);
+    ///         let e = it.entity(index).unwrap();
     ///         println!("{:?}: {:?} - {:?}", e.name(), p, it.id(1).to_str());
     ///     })
     ///     .run();
@@ -158,13 +158,13 @@ where
     ///
     /// let world = World::new();
     ///
-    /// world.entity().add::<Tag>().add::<Position>();
-    /// world.entity().add::<Tag>().add::<Position>();
+    /// world.entity().add(id::<Tag>()).add(id::<Position>());
+    /// world.entity().add(id::<Tag>()).add(id::<Position>());
     /// world
     ///     .entity()
-    ///     .add::<Tag>()
-    ///     .add::<Position>()
-    ///     .add::<Velocity>();
+    ///     .add(id::<Tag>())
+    ///     .add(id::<Position>())
+    ///     .add(id::<Velocity>());
     ///
     /// let count_entities = Rc::new(RefCell::new(0));
     /// let count_tables = Rc::new(RefCell::new(0));
@@ -179,7 +179,7 @@ where
     ///         let pos = it.field::<&Position>(1).unwrap(); //at index 1 in (&Tag, &Position)
     ///         for i in it.iter() {
     ///             *count_entities_ref.borrow_mut() += 1;
-    ///             let entity = it.entity(i);
+    ///             let entity = it.entity(i).unwrap();
     ///             println!("{:?}: {:?}", entity, pos[i]);
     ///         }
     ///     }
@@ -248,13 +248,13 @@ where
     ///
     /// let world = World::new();
     ///
-    /// world.entity().add::<Tag>().add::<Position>();
-    /// world.entity().add::<Tag>().add::<Position>();
+    /// world.entity().add(id::<Tag>()).add(id::<Position>());
+    /// world.entity().add(id::<Tag>()).add(id::<Position>());
     /// world
     ///     .entity()
-    ///     .add::<Tag>()
-    ///     .add::<Position>()
-    ///     .add::<Velocity>();
+    ///     .add(id::<Tag>())
+    ///     .add(id::<Position>())
+    ///     .add(id::<Velocity>());
     ///
     ///
     ///
@@ -264,7 +264,7 @@ where
     /// let count_entities_ref = count_entities.clone();
     /// let count_tables_ref = count_tables.clone();
     ///
-    /// let system = world.system::<(&Position)>().with::<Tag>()
+    /// let system = world.system::<(&Position)>().with(id::<Tag>())
     /// .run_each(
     ///     move |mut it| {
     ///         println!("start operations");
@@ -358,13 +358,13 @@ where
     ///
     /// let world = World::new();
     ///
-    /// world.entity().add::<Tag>().add::<Position>();
-    /// world.entity().add::<Tag>().add::<Position>();
+    /// world.entity().add(id::<Tag>()).add(id::<Position>());
+    /// world.entity().add(id::<Tag>()).add(id::<Position>());
     /// world
     ///     .entity()
-    ///     .add::<Tag>()
-    ///     .add::<Position>()
-    ///     .add::<Velocity>();
+    ///     .add(id::<Tag>())
+    ///     .add(id::<Position>())
+    ///     .add(id::<Velocity>());
     ///
     ///
     ///
@@ -374,7 +374,7 @@ where
     /// let count_entities_ref = count_entities.clone();
     /// let count_tables_ref = count_tables.clone();
     ///
-    /// let system = world.system::<(&Position)>().with::<Tag>()
+    /// let system = world.system::<(&Position)>().with(id::<Tag>())
     /// .run_each_entity(
     ///     move |mut it| {
     ///         println!("start operations");

--- a/flecs_ecs/src/core/utility/traits/world_provider.rs
+++ b/flecs_ecs/src/core/utility/traits/world_provider.rs
@@ -20,6 +20,13 @@ pub trait WorldProvider<'a> {
     fn world(&self) -> WorldRef<'a>;
 }
 
+impl<'a> WorldProvider<'a> for *mut sys::ecs_world_t {
+    #[inline(always)]
+    fn world(&self) -> WorldRef<'a> {
+        unsafe { WorldRef::from_ptr(*self) }
+    }
+}
+
 impl<'a> WorldProvider<'a> for IdView<'a> {
     #[inline(always)]
     fn world(&self) -> WorldRef<'a> {

--- a/flecs_ecs/src/core/world.rs
+++ b/flecs_ecs/src/core/world.rs
@@ -998,8 +998,6 @@ impl World {
     ///
     /// assert!(e.has(id::<Position>()));
     /// ```
-    /// # See also
-    ///
     pub fn create_async_stage(&self) -> WorldRef {
         unsafe { WorldRef::from_ptr(sys::ecs_stage_new(self.raw_world.as_ptr())) }
     }
@@ -1818,7 +1816,6 @@ impl World {
     /// Returns: The reference singleton component.
     ///
     /// # See also
-    ///
     // #[doc(alias = "world::get_ref")]
     // #[inline(always)]
     pub fn get_ref<T>(&self) -> CachedRef<T::CastType>

--- a/flecs_ecs/src/core/world.rs
+++ b/flecs_ecs/src/core/world.rs
@@ -3358,7 +3358,6 @@ impl World {
     /// # See also
     ///
     /// * [`World::run_pipeline()`]
-    /// * [`World::run_pipeline_id_time()`]
     /// * [`World::run_pipeline_time()`]
     #[inline(always)]
     pub fn run_pipeline(&self, pipeline: impl IntoEntity) {

--- a/flecs_ecs/src/core/world.rs
+++ b/flecs_ecs/src/core/world.rs
@@ -2588,7 +2588,7 @@ impl World {
         EntityView::new_null(self)
     }
 
-    /// Create a new entity with the provided id.
+    /// wraps an [`EntityView`] with the provided id.
     ///
     /// # Arguments
     ///

--- a/flecs_ecs/src/core/world_ctx.rs
+++ b/flecs_ecs/src/core/world_ctx.rs
@@ -88,7 +88,7 @@ fn query_ref_count() {
     struct Tag;
 
     let world = World::new();
-    let query = world.query::<()>().with::<&Tag>().build();
+    let query = world.query::<()>().with(id::<Tag>()).build();
 
     assert_eq!(world.world_ctx().query_ref_count(), 1);
     assert_eq!(query.reference_count(), 1);

--- a/flecs_ecs/src/lib.rs
+++ b/flecs_ecs/src/lib.rs
@@ -59,7 +59,7 @@ mod tests {
     impl World {
         pub fn add_(&self, id: impl IntoEntity) -> EntityView {
             let id = id.into_entity(self);
-            EntityView::new_from(self, id).add_id(id)
+            EntityView::new_from(self, id).add(id)
         }
     }
 
@@ -73,21 +73,68 @@ mod tests {
 
     #[test]
     fn test_add_op() {
+        #[derive(Debug, Component, Default)]
+        struct Position {
+            x: f32,
+            y: f32,
+        }
+
+        #[derive(Debug, Component)]
+        struct Tag;
+
         let world = World::new();
         let e = world.entity();
 
-        // all same API
-        world.add_id(e);
-        world.add_id(id::<Position>());
-        world.add_id((e, e));
-        world.add_id((id::<Position>(), e));
-        world.add_id((e, id::<Position>()));
+        // let e_pair = ecs_pair(e, e);
+        // // dbg!(check_add_id_validity(world.ptr_mut(), e));
+        // // dbg!(check_add_id_validity(world.ptr_mut(), e_pair));
+        // // dbg!(check_add_id_validity(world.ptr_mut(), p));
+        // // dbg!(check_add_id_validity(world.ptr_mut(), t));
+        // let p_t = ecs_pair(p, t);
+        // let t_p = ecs_pair(t, p);
+        // // dbg!(check_add_id_validity(world.ptr_mut(), p_t));
+        // dbg!(check_add_id_validity(world.ptr_mut(), t_p));
 
-        assert!(world.has::<Position>());
-        assert!(world.has_id(e));
-        assert!(world.has_id(id::<Position>()));
-        assert!(world.has_id((e, e)));
-        assert!(world.has_id((id::<Position>(), e)));
-        assert!(world.has_id((e, id::<Position>())));
+        // // all same API
+        //
+        // dbg!(flecs_ecs::core::utility::id::Id::<Position>::IF_ID_IS_DEFAULT);
+        // dbg!(flecs_ecs::core::utility::id::Id::<Position>::IS_TYPED);
+        // dbg!(flecs_ecs::core::utility::id::Id::<Tag>::IF_ID_IS_DEFAULT);
+        // dbg!(flecs_ecs::core::utility::id::Id::<Tag>::IS_TYPED);
+        // dbg!(
+        //     <(
+        //         flecs_ecs::core::utility::id::Id::<Tag>,
+        //         flecs_ecs::core::utility::id::Id::<Position>
+        //     )>::IS_PAIR
+        // );
+        // dbg!(
+        //     <(
+        //         flecs_ecs::core::utility::id::Id::<Tag>,
+        //         flecs_ecs::core::utility::id::Id::<Position>
+        //     )>::IS_TYPED_SECOND
+        // );
+        // dbg!(
+        //     <(
+        //         flecs_ecs::core::utility::id::Id::<Tag>,
+        //         flecs_ecs::core::utility::id::Id::<Position>
+        //     )>::IF_ID_IS_DEFAULT_SECOND
+        // );
+
+        e.add((id::<Tag>(), id::<Position>()));
+        e.add((id::<Position>(), id::<Position>()));
+        e.add((id::<Position>(), id::<Tag>()));
+
+        e.add(e);
+        e.add((e, e));
+        e.add((id::<Position>(), e));
+        e.add((e, id::<Position>()));
+
+        // //ignore
+        // assert!(e.has(id::<Position>()));
+        // assert!(e.has(e));
+        // assert!(e.has(id::<Position>()));
+        // assert!(e.has((e, e)));
+        // assert!(e.has((id::<Position>(), e)));
+        // assert!(e.has((e, id::<Position>())));
     }
 }

--- a/flecs_ecs/src/lib.rs
+++ b/flecs_ecs/src/lib.rs
@@ -44,3 +44,50 @@ pub mod prelude;
 fn register_test_crash_handler() {
     test_crash_handler::register();
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use flecs_ecs::prelude::*;
+
+    #[derive(Debug, Component, Default)]
+    pub struct Position {
+        pub x: f32,
+        pub y: f32,
+    }
+
+    impl World {
+        pub fn add_(&self, id: impl IntoEntity) -> EntityView {
+            let id = id.into_entity(self);
+            EntityView::new_from(self, id).add_id(id)
+        }
+    }
+
+    fn take_copy<T: Copy>(t: T) -> T {
+        t
+    }
+
+    fn take_into_entity<T: IntoEntity>(t: T, world: &World) -> Entity {
+        t.into_entity(world)
+    }
+
+    #[test]
+    fn test_add_op() {
+        let world = World::new();
+        let e = world.entity();
+
+        // all same API
+        world.add_id(e);
+        world.add_id(id::<Position>());
+        world.add_id((e, e));
+        world.add_id((id::<Position>(), e));
+        world.add_id((e, id::<Position>()));
+
+        assert!(world.has::<Position>());
+        assert!(world.has_id(e));
+        assert!(world.has_id(id::<Position>()));
+        assert!(world.has_id((e, e)));
+        assert!(world.has_id((id::<Position>(), e)));
+        assert!(world.has_id((e, id::<Position>())));
+    }
+}

--- a/flecs_ecs/tests/flecs/component_lifecycle_test.rs
+++ b/flecs_ecs/tests/flecs/component_lifecycle_test.rs
@@ -33,7 +33,7 @@ fn component_lifecycle_count_in_remove_hook() {
     world.set(Count(0));
 
     world.component::<Position>().on_remove(|e, _| {
-        e.world().set(Count(e.world().count::<Position>()));
+        e.world().set(Count(e.world().count(id::<Position>())));
     });
 
     let entity = world.entity().set(Position { x: 1, y: 2 });

--- a/flecs_ecs/tests/flecs/component_test.rs
+++ b/flecs_ecs/tests/flecs/component_test.rs
@@ -66,7 +66,7 @@ fn temp_test_hook() {
             });
         });
 
-        entity.remove::<Position>();
+        entity.remove(id::<Position>());
         assert_eq!(unsafe { COUNT_ADD_POS }, 1);
         assert_eq!(unsafe { COUNT_SET_POS }, 3);
 
@@ -79,10 +79,10 @@ fn temp_test_hook() {
 
         assert_eq!(unsafe { COUNT_SET_VEL }, 1);
 
-        entity.remove::<Position>();
+        entity.remove(id::<Position>());
         assert_eq!(unsafe { COUNT_ADD_POS }, 1);
         assert_eq!(unsafe { COUNT_SET_POS }, 3);
-        entity2.remove::<Position>();
+        entity2.remove(id::<Position>());
         assert_eq!(unsafe { COUNT_ADD_POS }, 0);
         assert_eq!(unsafe { COUNT_SET_POS }, 3);
     }
@@ -103,7 +103,7 @@ fn on_component_registration() {
             });
 
             world
-                .component_untyped_from_id(component_id)
+                .component_untyped_from(component_id)
                 .add_trait::<flecs::Prefab>();
         }
     }
@@ -137,7 +137,11 @@ fn on_component_registration() {
         assert_eq!(count.0, 1);
     });
 
-    assert!(world.component::<OnRegistration>().has::<flecs::Prefab>());
+    assert!(
+        world
+            .component::<OnRegistration>()
+            .has(id::<flecs::Prefab>())
+    );
 
     world.component::<OnRegistrationTag>();
 
@@ -167,7 +171,7 @@ fn on_component_registration_named() {
             });
 
             world
-                .component_untyped_from_id(component_id)
+                .component_untyped_from(component_id)
                 .add_trait::<flecs::Prefab>();
         }
     }
@@ -201,7 +205,11 @@ fn on_component_registration_named() {
         assert_eq!(count.0, 1);
     });
 
-    assert!(world.component::<OnRegistration>().has::<flecs::Prefab>());
+    assert!(
+        world
+            .component::<OnRegistration>()
+            .has(id::<flecs::Prefab>())
+    );
 
     world.component::<OnRegistrationTag>();
 

--- a/flecs_ecs/tests/flecs/entity_bulk_rust_test.rs
+++ b/flecs_ecs/tests/flecs/entity_bulk_rust_test.rs
@@ -16,8 +16,8 @@ fn bulk_entity_builder_simple_add() {
 
     for entity in entities {
         let entity = world.entity_from_id(entity);
-        assert!(entity.has::<Position>());
-        assert!(entity.has::<Velocity>());
+        assert!(entity.has(id::<Position>()));
+        assert!(entity.has(id::<Velocity>()));
     }
 }
 
@@ -42,8 +42,8 @@ fn bulk_entity_builder_simple_set() {
     assert_eq!(entities.len(), 10);
     for (index, entity) in entities.into_iter().enumerate() {
         let entity = world.entity_from_id(entity);
-        assert!(entity.has::<Position>());
-        assert!(entity.has::<Velocity>());
+        assert!(entity.has(id::<Position>()));
+        assert!(entity.has(id::<Velocity>()));
         let position = entity.cloned::<&Position>();
         let velocity = entity.cloned::<&Velocity>();
         assert_eq!(position.x, velocity.x / 2);
@@ -61,9 +61,9 @@ fn bulk_entity_builder_table() {
 
     let ent = world
         .entity()
-        .add::<Position>()
-        .add::<Velocity>()
-        .add_id(ent_id);
+        .add(id::<Position>())
+        .add(id::<Velocity>())
+        .add(ent_id);
 
     let mut table = ent.table().unwrap();
 
@@ -90,12 +90,12 @@ fn bulk_entity_builder_table() {
 
     for (index, entity) in entities.into_iter().enumerate() {
         let entity = world.entity_from_id(entity);
-        assert!(entity.has::<Position>());
-        assert!(entity.has::<Velocity>());
-        assert!(entity.has_id(ent_id));
+        assert!(entity.has(id::<Position>()));
+        assert!(entity.has(id::<Velocity>()));
+        assert!(entity.has(ent_id));
 
-        assert!(!entity.has::<Mass>());
-        assert!(!entity.has_id(random_ent_id));
+        assert!(!entity.has(id::<Mass>()));
+        assert!(!entity.has(random_ent_id));
 
         let position = entity.cloned::<&Position>();
         let velocity = entity.cloned::<&Velocity>();
@@ -179,7 +179,7 @@ fn bulk_entity_builder_with_entity_ids() {
 
     for (index, entity) in new_entities.into_iter().enumerate() {
         let entity = world.entity_from_id(entity);
-        assert!(entity.has::<Position>());
+        assert!(entity.has(id::<Position>()));
 
         assert_eq!(entity.id(), entities[index]);
     }
@@ -203,8 +203,8 @@ fn bulk_entity_builder_add_and_set() {
 
     for entity in entities {
         let entity = world.entity_from_id(entity);
-        assert!(entity.has::<Position>());
-        assert!(entity.has::<Velocity>());
+        assert!(entity.has(id::<Position>()));
+        assert!(entity.has(id::<Velocity>()));
         let position = entity.cloned::<&Position>();
         assert_eq!(position.x, position.y);
     }
@@ -222,7 +222,7 @@ fn bulk_entity_builder_build_to_table_missing_default() {
 
     let ent = world
         .entity()
-        .add::<Position>()
+        .add(id::<Position>())
         .set(NonDefaultComponent { value: 5 });
 
     let mut table = ent.table().unwrap();
@@ -249,7 +249,7 @@ fn bulk_entity_builder_duplicate_add() {
 
     for entity in entities {
         let entity = world.entity_from_id(entity);
-        assert!(entity.has::<Position>());
+        assert!(entity.has(id::<Position>()));
     }
 }
 
@@ -271,7 +271,7 @@ fn bulk_entity_builder_set_after_add() {
 
     for entity in entities {
         let entity = world.entity_from_id(entity);
-        assert!(entity.has::<Position>());
+        assert!(entity.has(id::<Position>()));
         let position = entity.cloned::<&Position>();
         assert_eq!(position.x, position.y);
     }
@@ -287,7 +287,7 @@ fn bulk_entity_builder_no_components() {
 
     for entity in entities {
         let entity = world.entity_from_id(entity);
-        assert!(!entity.has::<Position>());
+        assert!(!entity.has(id::<Position>()));
     }
 }
 

--- a/flecs_ecs/tests/flecs/entity_rust_test.rs
+++ b/flecs_ecs/tests/flecs/entity_rust_test.rs
@@ -10,20 +10,20 @@ fn count_target_ids() {
     let r = world.entity();
     let o = world.entity();
 
-    e.add_id((r, o));
-    e.add_id((r, o));
+    e.add((r, o));
+    e.add((r, o));
 
     assert_eq!(e.target_id_count(r).unwrap(), 1);
 
     let e2 = world.entity();
-    e2.add_id((r, o));
+    e2.add((r, o));
 
     assert_eq!(e.target_id_count(r).unwrap(), 1);
     assert_eq!(e2.target_id_count(r).unwrap(), 1);
 
     let o2 = world.entity();
 
-    e.add_id((r, o2));
+    e.add((r, o2));
 
     assert_eq!(e.target_id_count(r).unwrap(), 2);
     assert_eq!(e2.target_id_count(r).unwrap(), 1);
@@ -34,12 +34,12 @@ fn entity_id_reuse() {
     let world = World::new();
 
     let a = world.entity_named("a");
-    let b = world.entity().child_of_id(a);
+    let b = world.entity().child_of(a);
     let first_archetype = b.archetype().to_string();
     a.destruct();
 
     let a = world.entity_named("a");
-    let b = world.entity().child_of_id(a);
+    let b = world.entity().child_of(a);
     assert!(
         b.id() > u32::MAX as u64,
         "this test is not valid if the id was not reused"

--- a/flecs_ecs/tests/flecs/entity_test.rs
+++ b/flecs_ecs/tests/flecs/entity_test.rs
@@ -25,11 +25,11 @@ fn entity_new_named_from_scope() {
     let entity = world.entity_named("Foo");
     assert!(entity.is_valid());
 
-    let prev = world.set_scope_id(entity);
+    let prev = world.set_scope(entity);
     let child = world.entity_named("Bar");
     assert!(child.is_valid());
 
-    world.set_scope_id(prev);
+    world.set_scope(prev);
 
     assert_eq!(child.name(), "Bar");
     assert_eq!(child.path().unwrap(), "::Foo::Bar");
@@ -50,7 +50,7 @@ fn entity_new_nested_named_from_nested_scope() {
     assert_eq!(entity.path().unwrap(), "::Foo::Bar");
 
     // Set the current scope to `entity`
-    let prev = world.set_scope_id(entity);
+    let prev = world.set_scope(entity);
 
     // Create a child entity with nested name "Hello::World" under the current scope
     let child = world.entity_named("Hello::World");
@@ -59,7 +59,7 @@ fn entity_new_nested_named_from_nested_scope() {
     assert!(child.is_valid());
 
     // Restore the previous scope
-    world.set_scope_id(prev);
+    world.set_scope(prev);
 
     // Verify the name and hierarchical path of the child entity
     assert_eq!(child.name(), "World");
@@ -73,7 +73,7 @@ fn entity_new_add() {
     let entity = world.entity().set(Position { x: 0, y: 0 });
 
     assert!(entity.is_valid());
-    assert!(entity.has::<Position>());
+    assert!(entity.has(id::<Position>()));
 }
 
 #[test]
@@ -86,8 +86,8 @@ fn entity_new_add_2() {
         .set(Velocity { x: 0, y: 0 });
 
     assert!(entity.is_valid());
-    assert!(entity.has::<Position>());
-    assert!(entity.has::<Velocity>());
+    assert!(entity.has(id::<Position>()));
+    assert!(entity.has(id::<Velocity>()));
 }
 
 #[test]
@@ -101,7 +101,7 @@ fn entity_new_set() {
     assert!(entity.is_valid());
 
     // Verify that the entity has the Position component
-    assert!(entity.has::<Position>());
+    assert!(entity.has(id::<Position>()));
 
     // Verify the component data
     entity.get::<&Position>(|pos| {
@@ -120,8 +120,8 @@ fn entity_new_set_2() {
         .set(Velocity { x: 1, y: 2 });
 
     assert!(entity.is_valid());
-    assert!(entity.has::<Position>());
-    assert!(entity.has::<Velocity>());
+    assert!(entity.has(id::<Position>()));
+    assert!(entity.has(id::<Velocity>()));
 
     entity.get::<(&Position, &Velocity)>(|(pos, vel)| {
         assert_eq!(pos.x, 10);
@@ -141,7 +141,7 @@ fn entity_add() {
 
     entity.set(Position { x: 0, y: 0 });
 
-    assert!(entity.has::<Position>());
+    assert!(entity.has(id::<Position>()));
 }
 
 #[test]
@@ -152,10 +152,10 @@ fn entity_remove() {
     assert!(entity.is_valid());
 
     entity.set(Position { x: 0, y: 0 });
-    assert!(entity.has::<Position>());
+    assert!(entity.has(id::<Position>()));
 
-    entity.remove::<Position>();
-    assert!(!entity.has::<Position>());
+    entity.remove(id::<Position>());
+    assert!(!entity.has(id::<Position>()));
 }
 
 #[test]
@@ -166,7 +166,7 @@ fn entity_set() {
     assert!(entity.is_valid());
 
     entity.set(Position { x: 10, y: 20 });
-    assert!(entity.has::<Position>());
+    assert!(entity.has(id::<Position>()));
 
     entity.get::<&Position>(|pos| {
         assert_eq!(pos.x, 10);
@@ -185,8 +185,8 @@ fn entity_add_2() {
         .set(Position { x: 0, y: 0 })
         .set(Velocity { x: 0, y: 0 });
 
-    assert!(entity.has::<Position>());
-    assert!(entity.has::<Velocity>());
+    assert!(entity.has(id::<Position>()));
+    assert!(entity.has(id::<Velocity>()));
 }
 
 #[test]
@@ -199,8 +199,8 @@ fn entity_add_entity() {
     let entity = world.entity();
     assert!(entity.is_valid());
 
-    entity.add_id(tag);
-    assert!(entity.has_id(tag));
+    entity.add(tag);
+    assert!(entity.has(tag));
 }
 
 #[test]
@@ -213,8 +213,8 @@ fn entity_add_childof() {
     let entity = world.entity();
     assert!(entity.is_valid());
 
-    entity.add_id((flecs::ChildOf::ID, parent));
-    assert!(entity.has_id((flecs::ChildOf::ID, parent)));
+    entity.add((flecs::ChildOf::ID, parent));
+    assert!(entity.has((flecs::ChildOf::ID, parent)));
 }
 
 #[test]
@@ -227,8 +227,8 @@ fn entity_add_instanceof() {
     let entity = world.entity();
     assert!(entity.is_valid());
 
-    entity.add_id((flecs::IsA::ID, base));
-    assert!(entity.has_id((flecs::IsA::ID, base)));
+    entity.add((flecs::IsA::ID, base));
+    assert!(entity.has((flecs::IsA::ID, base)));
 }
 
 #[test]
@@ -240,13 +240,13 @@ fn entity_remove_2() {
         .set(Position { x: 0, y: 0 })
         .set(Velocity { x: 0, y: 0 });
 
-    assert!(entity.has::<Position>());
-    assert!(entity.has::<Velocity>());
+    assert!(entity.has(id::<Position>()));
+    assert!(entity.has(id::<Velocity>()));
 
-    entity.remove::<Position>().remove::<Velocity>();
+    entity.remove(id::<Position>()).remove(id::<Velocity>());
 
-    assert!(!entity.has::<Position>());
-    assert!(!entity.has::<Velocity>());
+    assert!(!entity.has(id::<Position>()));
+    assert!(!entity.has(id::<Velocity>()));
 }
 
 #[test]
@@ -258,8 +258,8 @@ fn entity_set_2() {
         .set::<Position>(Position { x: 10, y: 20 })
         .set::<Velocity>(Velocity { x: 1, y: 2 });
 
-    assert!(entity.has::<Position>());
-    assert!(entity.has::<Velocity>());
+    assert!(entity.has(id::<Position>()));
+    assert!(entity.has(id::<Velocity>()));
 
     entity.get::<&Position>(|pos| {
         assert_eq!(pos.x, 10);
@@ -282,11 +282,11 @@ fn entity_remove_entity() {
     let entity = world.entity();
     assert!(entity.is_valid());
 
-    entity.add_id(tag);
-    assert!(entity.has_id(tag));
+    entity.add(tag);
+    assert!(entity.has(tag));
 
-    entity.remove_id(tag);
-    assert!(!entity.has_id(tag));
+    entity.remove(tag);
+    assert!(!entity.has(tag));
 }
 
 #[test]
@@ -299,11 +299,11 @@ fn entity_remove_childof() {
     let entity = world.entity();
     assert!(entity.is_valid());
 
-    entity.add_id((flecs::ChildOf::ID, parent));
-    assert!(entity.has_id((flecs::ChildOf::ID, parent)));
+    entity.add((flecs::ChildOf::ID, parent));
+    assert!(entity.has((flecs::ChildOf::ID, parent)));
 
-    entity.remove_id((flecs::ChildOf::ID, parent));
-    assert!(!entity.has_id((flecs::ChildOf::ID, parent)));
+    entity.remove((flecs::ChildOf::ID, parent));
+    assert!(!entity.has((flecs::ChildOf::ID, parent)));
 }
 
 #[test]
@@ -316,11 +316,11 @@ fn entity_remove_instanceof() {
     let entity = world.entity();
     assert!(entity.is_valid());
 
-    entity.add_id((flecs::IsA::ID, base));
-    assert!(entity.has_id((flecs::IsA::ID, base)));
+    entity.add((flecs::IsA::ID, base));
+    assert!(entity.has((flecs::IsA::ID, base)));
 
-    entity.remove_id((flecs::IsA::ID, base));
-    assert!(!entity.has_id((flecs::IsA::ID, base)));
+    entity.remove((flecs::IsA::ID, base));
+    assert!(!entity.has((flecs::IsA::ID, base)));
 }
 
 #[test]
@@ -331,9 +331,9 @@ fn entity_get_generic() {
     let entity = world.entity().set(Position { x: 10, y: 20 });
 
     assert!(entity.is_valid());
-    assert!(entity.has::<Position>());
+    assert!(entity.has(id::<Position>()));
 
-    let pos_void = entity.get_untyped(world.id_from::<Position>());
+    let pos_void = entity.get_untyped(world.id_view_from(id::<Position>()));
     assert!(!pos_void.is_null());
 
     let pos = unsafe { &*(pos_void as *const Position) };
@@ -355,7 +355,7 @@ fn entity_get_generic_mut() {
     let entity = world.entity().set(Position { x: 10, y: 20 });
 
     assert!(entity.is_valid());
-    assert!(entity.has::<Position>());
+    assert!(entity.has(id::<Position>()));
 
     world
         .observer::<flecs::OnSet, &Position>()
@@ -372,7 +372,7 @@ fn entity_get_generic_mut() {
     assert_eq!(pos.x, 10);
     assert_eq!(pos.y, 20);
 
-    entity.modified_id(position);
+    entity.modified(position);
     world.get::<&Flags>(|flags| {
         assert_eq!(flags.invoked, 1);
     });
@@ -387,7 +387,7 @@ fn entity_get_mut_generic_w_id() {
     let entity = world.entity().set(Position { x: 10, y: 20 });
 
     assert!(entity.is_valid());
-    assert!(entity.has::<Position>());
+    assert!(entity.has(id::<Position>()));
 
     let void_p = entity.get_untyped(position);
     assert!(!void_p.is_null());
@@ -412,8 +412,8 @@ fn entity_set_generic() {
         )
     };
 
-    assert!(entity.has::<Position>());
-    assert!(entity.has_id(position));
+    assert!(entity.has(id::<Position>()));
+    assert!(entity.has(position));
 
     entity.try_get::<&Position>(|pos| {
         assert_eq!(pos.x, 10);
@@ -434,8 +434,8 @@ fn entity_set_generic_no_size() {
             .set_ptr(position.id(), &pos as *const _ as *const c_void)
     };
 
-    assert!(entity.has::<Position>());
-    assert!(entity.has_id(position));
+    assert!(entity.has(id::<Position>()));
+    assert!(entity.has(position));
 
     entity.get::<&Position>(|pos| {
         assert_eq!(pos.x, 10);
@@ -619,9 +619,9 @@ fn entity_has_childof() {
 
     let parent = world.entity();
 
-    let child = world.entity().add_id((flecs::ChildOf::ID, parent));
+    let child = world.entity().add((flecs::ChildOf::ID, parent));
 
-    assert!(child.has_id((flecs::ChildOf::ID, parent)));
+    assert!(child.has((flecs::ChildOf::ID, parent)));
 }
 
 #[test]
@@ -630,9 +630,9 @@ fn entity_has_instanceof() {
 
     let base = world.entity();
 
-    let instance = world.entity().add_id((flecs::IsA::ID, base));
+    let instance = world.entity().add((flecs::IsA::ID, base));
 
-    assert!(instance.has_id((flecs::IsA::ID, base)));
+    assert!(instance.has((flecs::IsA::ID, base)));
 }
 
 #[test]
@@ -640,11 +640,11 @@ fn entity_has_instanceof_indirect() {
     let world = World::new();
 
     let base_of_base = world.entity();
-    let base = world.entity().add_id((flecs::IsA::ID, base_of_base));
+    let base = world.entity().add((flecs::IsA::ID, base_of_base));
 
-    let instance = world.entity().add_id((flecs::IsA::ID, base));
+    let instance = world.entity().add((flecs::IsA::ID, base));
 
-    assert!(instance.has_id((flecs::IsA::ID, base_of_base)));
+    assert!(instance.has((flecs::IsA::ID, base_of_base)));
 }
 
 #[test]
@@ -729,8 +729,8 @@ fn entity_clear() {
         .set(Velocity { x: 0, y: 0 });
 
     entity.clear();
-    assert!(!entity.has::<Position>());
-    assert!(!entity.has::<Velocity>());
+    assert!(!entity.has(id::<Position>()));
+    assert!(!entity.has(id::<Velocity>()));
 
     let entity2 = world.entity();
     assert!(entity2 > entity);
@@ -742,23 +742,23 @@ fn entity_force_owned() {
 
     world
         .component::<Position>()
-        .add_id((flecs::OnInstantiate::ID, flecs::Inherit::ID));
+        .add((flecs::OnInstantiate::ID, flecs::Inherit::ID));
     world
         .component::<Velocity>()
-        .add_id((flecs::OnInstantiate::ID, flecs::Inherit::ID));
+        .add((flecs::OnInstantiate::ID, flecs::Inherit::ID));
 
     let prefab = world
         .prefab()
         .set(Position { x: 0, y: 0 })
         .set(Velocity { x: 0, y: 0 })
-        .auto_override::<Position>();
+        .auto_override(id::<Position>());
 
-    let entity = world.entity().add_id((flecs::IsA::ID, prefab));
+    let entity = world.entity().add((flecs::IsA::ID, prefab));
 
-    assert!(entity.has::<Position>());
-    assert!(entity.owns::<Position>());
-    assert!(entity.has::<Velocity>());
-    assert!(!entity.owns::<Velocity>());
+    assert!(entity.has(id::<Position>()));
+    assert!(entity.owns(id::<Position>()));
+    assert!(entity.has(id::<Velocity>()));
+    assert!(!entity.owns(id::<Velocity>()));
 }
 
 #[test]
@@ -767,24 +767,24 @@ fn entity_force_owned_2() {
 
     world
         .component::<Position>()
-        .add_id((*flecs::OnInstantiate, *flecs::Inherit));
+        .add((*flecs::OnInstantiate, *flecs::Inherit));
     world
         .component::<Velocity>()
-        .add_id((*flecs::OnInstantiate, *flecs::Inherit));
+        .add((*flecs::OnInstantiate, *flecs::Inherit));
 
     let prefab = world
         .prefab()
         .set(Position { x: 0, y: 0 })
         .set(Velocity { x: 0, y: 0 })
-        .auto_override::<Position>()
-        .auto_override::<Velocity>();
+        .auto_override(id::<Position>())
+        .auto_override(id::<Velocity>());
 
-    let entity = world.entity().add_id((flecs::IsA::ID, prefab));
+    let entity = world.entity().add((flecs::IsA::ID, prefab));
 
-    assert!(entity.has::<Position>());
-    assert!(entity.owns::<Position>());
-    assert!(entity.has::<Velocity>());
-    assert!(entity.owns::<Velocity>());
+    assert!(entity.has(id::<Position>()));
+    assert!(entity.owns(id::<Position>()));
+    assert!(entity.has(id::<Velocity>()));
+    assert!(entity.owns(id::<Velocity>()));
 }
 
 #[test]
@@ -793,25 +793,25 @@ fn entity_force_owned_nested() {
 
     world
         .component::<Position>()
-        .add_id((*flecs::OnInstantiate, *flecs::Inherit));
+        .add((*flecs::OnInstantiate, *flecs::Inherit));
     world
         .component::<Velocity>()
-        .add_id((*flecs::OnInstantiate, *flecs::Inherit));
+        .add((*flecs::OnInstantiate, *flecs::Inherit));
 
     let prefab = world
         .prefab()
         .set(Position { x: 0, y: 0 })
         .set(Velocity { x: 0, y: 0 })
-        .auto_override::<Position>();
+        .auto_override(id::<Position>());
 
-    let prefab_2 = world.entity().add_id((flecs::IsA::ID, prefab));
+    let prefab_2 = world.entity().add((flecs::IsA::ID, prefab));
 
-    let entity = world.entity().add_id((flecs::IsA::ID, prefab_2));
+    let entity = world.entity().add((flecs::IsA::ID, prefab_2));
 
-    assert!(entity.has::<Position>());
-    assert!(entity.owns::<Position>());
-    assert!(entity.has::<Velocity>());
-    assert!(!entity.owns::<Velocity>());
+    assert!(entity.has(id::<Position>()));
+    assert!(entity.owns(id::<Position>()));
+    assert!(entity.has(id::<Velocity>()));
+    assert!(!entity.owns(id::<Velocity>()));
 }
 
 #[test]
@@ -845,23 +845,23 @@ fn entity_get_target() {
     let obj3 = world.entity().set(Mass { value: 0 });
     let child = world
         .entity()
-        .add_id((rel, obj1))
-        .add_id((rel, obj2))
-        .add_id((rel, obj3));
+        .add((rel, obj1))
+        .add((rel, obj2))
+        .add((rel, obj3));
 
-    let mut target = child.target_id(rel, 0).unwrap();
+    let mut target = child.target(rel, 0).unwrap();
     assert!(target.is_valid());
     assert_eq!(target, obj1);
 
-    target = child.target_id(rel, 1).unwrap();
+    target = child.target(rel, 1).unwrap();
     assert!(target.is_valid());
     assert_eq!(target, obj2);
 
-    target = child.target_id(rel, 2).unwrap();
+    target = child.target(rel, 2).unwrap();
     assert!(target.is_valid());
     assert_eq!(target, obj3);
 
-    assert!(child.target_id(rel, 3).is_none());
+    assert!(child.target(rel, 3).is_none());
 }
 
 #[test]
@@ -869,9 +869,9 @@ fn entity_get_parent() {
     let world = World::new();
 
     let parent = world.entity();
-    let child = world.entity().child_of_id(parent);
+    let child = world.entity().child_of(parent);
 
-    assert_eq!(child.target_id(flecs::ChildOf::ID, 0).unwrap(), parent);
+    assert_eq!(child.target(flecs::ChildOf::ID, 0).unwrap(), parent);
     assert_eq!(child.parent().unwrap(), parent);
 }
 
@@ -881,9 +881,9 @@ fn entity_get_parent() {
 fn entity_is_component_enabled() {
     let world = World::new();
 
-    world.component::<Position>().add_id(flecs::CanToggle::ID);
-    world.component::<Velocity>().add_id(flecs::CanToggle::ID);
-    world.component::<Mass>().add::<flecs::CanToggle>();
+    world.component::<Position>().add(flecs::CanToggle::ID);
+    world.component::<Velocity>().add(flecs::CanToggle::ID);
+    world.component::<Mass>().add(id::<flecs::CanToggle>());
 
     let entity = world
         .entity()
@@ -891,45 +891,45 @@ fn entity_is_component_enabled() {
         .set(Velocity { x: 0, y: 0 })
         .set(Mass { value: 0 });
 
-    assert!(entity.is_enabled::<Position>());
-    assert!(entity.is_enabled::<Velocity>());
-    assert!(entity.is_enabled::<Mass>());
+    assert!(entity.is_enabled(id::<Position>()));
+    assert!(entity.is_enabled(id::<Velocity>()));
+    assert!(entity.is_enabled(id::<Mass>()));
 
-    entity.disable::<Position>();
+    entity.disable(id::<Position>());
 
-    assert!(!entity.is_enabled::<Position>());
-    assert!(entity.is_enabled::<Velocity>());
-    assert!(entity.is_enabled::<Mass>());
+    assert!(!entity.is_enabled(id::<Position>()));
+    assert!(entity.is_enabled(id::<Velocity>()));
+    assert!(entity.is_enabled(id::<Mass>()));
 
-    entity.disable::<Velocity>();
+    entity.disable(id::<Velocity>());
 
-    assert!(!entity.is_enabled::<Position>());
-    assert!(!entity.is_enabled::<Velocity>());
-    assert!(entity.is_enabled::<Mass>());
+    assert!(!entity.is_enabled(id::<Position>()));
+    assert!(!entity.is_enabled(id::<Velocity>()));
+    assert!(entity.is_enabled(id::<Mass>()));
 
-    entity.disable::<Mass>();
+    entity.disable(id::<Mass>());
 
-    assert!(!entity.is_enabled::<Position>());
-    assert!(!entity.is_enabled::<Velocity>());
-    assert!(!entity.is_enabled::<Mass>());
+    assert!(!entity.is_enabled(id::<Position>()));
+    assert!(!entity.is_enabled(id::<Velocity>()));
+    assert!(!entity.is_enabled(id::<Mass>()));
 
-    entity.enable::<Position>();
+    entity.enable(id::<Position>());
 
-    assert!(entity.is_enabled::<Position>());
-    assert!(!entity.is_enabled::<Velocity>());
-    assert!(!entity.is_enabled::<Mass>());
+    assert!(entity.is_enabled(id::<Position>()));
+    assert!(!entity.is_enabled(id::<Velocity>()));
+    assert!(!entity.is_enabled(id::<Mass>()));
 
-    entity.enable::<Velocity>();
+    entity.enable(id::<Velocity>());
 
-    assert!(entity.is_enabled::<Position>());
-    assert!(entity.is_enabled::<Velocity>());
-    assert!(!entity.is_enabled::<Mass>());
+    assert!(entity.is_enabled(id::<Position>()));
+    assert!(entity.is_enabled(id::<Velocity>()));
+    assert!(!entity.is_enabled(id::<Mass>()));
 
-    entity.enable::<Mass>();
+    entity.enable(id::<Mass>());
 
-    assert!(entity.is_enabled::<Position>());
-    assert!(entity.is_enabled::<Velocity>());
-    assert!(entity.is_enabled::<Mass>());
+    assert!(entity.is_enabled(id::<Position>()));
+    assert!(entity.is_enabled(id::<Velocity>()));
+    assert!(entity.is_enabled(id::<Mass>()));
 }
 
 /// # See also
@@ -938,37 +938,37 @@ fn entity_is_component_enabled() {
 fn entity_is_enabled_pair() {
     let world = World::new();
 
-    world.component::<Position>().add_id(flecs::CanToggle::ID);
-    world.component::<TagA>().add_id(flecs::CanToggle::ID);
-    world.component::<TagB>().add_id(flecs::CanToggle::ID);
-    world.component::<TagC>().add_id(flecs::CanToggle::ID);
+    world.component::<Position>().add(flecs::CanToggle::ID);
+    world.component::<TagA>().add(flecs::CanToggle::ID);
+    world.component::<TagB>().add(flecs::CanToggle::ID);
+    world.component::<TagC>().add(flecs::CanToggle::ID);
 
     let entity = world
         .entity()
         .set_pair::<Position, TagA>(Position { x: 0, y: 0 })
         .set_pair::<Position, TagC>(Position { x: 0, y: 0 })
-        .add::<(TagB, TagC)>()
-        .disable::<(Position, TagC)>();
+        .add((id::<TagB>(), id::<TagC>()))
+        .disable((id::<Position>(), id::<TagC>()));
 
-    assert!(entity.is_enabled::<(Position, TagA)>());
-    assert!(!entity.is_enabled::<(Position, TagB)>());
-    assert!(!entity.is_enabled::<(Position, TagC)>());
+    assert!(entity.is_enabled((id::<Position>(), id::<TagA>())));
+    assert!(!entity.is_enabled((id::<Position>(), id::<TagB>())));
+    assert!(!entity.is_enabled((id::<Position>(), id::<TagC>())));
 
-    entity.enable::<(Position, TagC)>();
-    assert!(entity.is_enabled::<(Position, TagC)>());
+    entity.enable((id::<Position>(), id::<TagC>()));
+    assert!(entity.is_enabled((id::<Position>(), id::<TagC>())));
 
-    entity.disable::<(Position, TagA)>();
-    assert!(!entity.is_enabled::<(Position, TagA)>());
+    entity.disable((id::<Position>(), id::<TagA>()));
+    assert!(!entity.is_enabled((id::<Position>(), id::<TagA>())));
 
-    entity.enable::<(Position, TagA)>();
-    entity.enable::<(Position, TagC)>();
-    assert!(entity.is_enabled::<(Position, TagA)>());
-    assert!(entity.is_enabled::<(Position, TagC)>());
+    entity.enable((id::<Position>(), id::<TagA>()));
+    entity.enable((id::<Position>(), id::<TagC>()));
+    assert!(entity.is_enabled((id::<Position>(), id::<TagA>())));
+    assert!(entity.is_enabled((id::<Position>(), id::<TagC>())));
 
-    entity.disable::<(Position, TagC)>();
-    assert!(!entity.is_enabled::<(Position, TagC)>());
+    entity.disable((id::<Position>(), id::<TagC>()));
+    assert!(!entity.is_enabled((id::<Position>(), id::<TagC>())));
     //component it doesn't have
-    assert!(!entity.is_enabled::<(Position, TagB)>());
+    assert!(!entity.is_enabled((id::<Position>(), id::<TagB>())));
 }
 
 /// # See also
@@ -979,26 +979,26 @@ fn entity_is_enabled_pair() {
 fn entity_is_enabled_pair_ids() {
     let world = World::new();
 
-    let rel = world.entity().add_id(flecs::CanToggle::ID);
+    let rel = world.entity().add(flecs::CanToggle::ID);
     let tgt_a = world.entity();
     let tgt_b = world.entity();
 
-    let e = world.entity().add_id((rel, tgt_a));
+    let e = world.entity().add((rel, tgt_a));
 
-    assert!(e.is_enabled_id((rel, tgt_a)));
-    assert!(!e.is_enabled_id((rel, tgt_b)));
+    assert!(e.is_enabled((rel, tgt_a)));
+    assert!(!e.is_enabled((rel, tgt_b)));
 
-    e.disable_id((rel, tgt_a));
-    assert!(!e.is_enabled_id((rel, tgt_a)));
+    e.disable((rel, tgt_a));
+    assert!(!e.is_enabled((rel, tgt_a)));
 
-    e.enable_id((rel, tgt_a));
-    assert!(e.is_enabled_id((rel, tgt_a)));
+    e.enable((rel, tgt_a));
+    assert!(e.is_enabled((rel, tgt_a)));
 
-    e.add_id((rel, tgt_b)).disable_id((rel, tgt_b));
-    assert!(!e.is_enabled_id((rel, tgt_b)));
+    e.add((rel, tgt_b)).disable((rel, tgt_b));
+    assert!(!e.is_enabled((rel, tgt_b)));
 
-    e.enable_id((rel, tgt_b));
-    assert!(e.is_enabled_id((rel, tgt_b)));
+    e.enable((rel, tgt_b));
+    assert!(e.is_enabled((rel, tgt_b)));
 }
 
 #[test]
@@ -1012,8 +1012,8 @@ fn entity_is_first_enabled() {
         .entity()
         .set_first::<Position>(Position { x: 0, y: 0 }, tgt_a);
 
-    assert!(e.is_enabled_first::<Position>(tgt_a));
-    assert!(!e.is_enabled_first::<Position>(tgt_b));
+    assert!(e.is_enabled((id::<Position>(), tgt_a)));
+    assert!(!e.is_enabled((id::<Position>(), tgt_b)));
 }
 
 #[test]
@@ -1033,13 +1033,13 @@ fn entity_get_type() {
     {
         let type_2 = entity.archetype();
         assert_eq!(type_2.count(), 1);
-        assert_eq!(type_2.get(0).unwrap(), world.id_from::<Position>());
+        assert_eq!(type_2.get(0).unwrap(), world.id_view_from(id::<Position>()));
     }
 
     entity.set(Velocity { x: 0, y: 0 });
     let type_3 = entity.archetype();
     assert_eq!(type_3.count(), 2);
-    assert_eq!(type_3.get(1).unwrap(), world.id_from::<Velocity>());
+    assert_eq!(type_3.get(1).unwrap(), world.id_view_from(id::<Velocity>()));
 }
 
 #[test]
@@ -1051,11 +1051,11 @@ fn entity_get_nonempty_type() {
 
     let type_1 = entity.archetype();
     assert_eq!(type_1.count(), 1);
-    assert_eq!(type_1.get(0).unwrap(), world.id_from::<Position>());
+    assert_eq!(type_1.get(0).unwrap(), world.id_view_from(id::<Position>()));
 
     let type_2 = entity.archetype();
     assert_eq!(type_2.count(), 1);
-    assert_eq!(type_2.get(0).unwrap(), world.id_from::<Position>());
+    assert_eq!(type_2.get(0).unwrap(), world.id_view_from(id::<Position>()));
 }
 
 #[test]
@@ -1068,7 +1068,7 @@ fn entity_set_no_copy() {
         assert_eq!(pod.clone_count, 0);
     });
 
-    assert!(entity.has::<Pod>());
+    assert!(entity.has(id::<Pod>()));
 
     entity.get::<&Pod>(|pod| {
         assert_eq!(pod.value, 10);
@@ -1087,13 +1087,13 @@ fn entity_set_copy() {
         assert_eq!(pod.clone_count, 1);
     });
 
-    assert!(entity.has::<Pod>());
+    assert!(entity.has(id::<Pod>()));
 
     entity.get::<&Pod>(|pod| {
         assert_eq!(pod.value, 10);
     });
 
-    assert!(entity_dupl.has::<Pod>());
+    assert!(entity_dupl.has(id::<Pod>()));
 
     entity_dupl.get::<&Pod>(|pod| {
         assert_eq!(pod.value, 10);
@@ -1106,7 +1106,7 @@ fn entity_set_deduced() {
 
     let entity = world.entity().set(Position { x: 10, y: 20 });
 
-    assert!(entity.has::<Position>());
+    assert!(entity.has(id::<Position>()));
 
     entity.get::<&Position>(|p| {
         assert_eq!(p.x, 10);
@@ -1120,36 +1120,32 @@ fn entity_override() {
 
     world
         .component::<Position>()
-        .add_id((*flecs::OnInstantiate, *flecs::Inherit));
+        .add((*flecs::OnInstantiate, *flecs::Inherit));
 
-    let base = world.entity().auto_override::<Position>();
+    let base = world.entity().auto_override(id::<Position>());
 
-    let entity = world.entity().add_id((flecs::IsA::ID, base));
+    let entity = world.entity().add((flecs::IsA::ID, base));
 
-    assert!(entity.has::<Position>());
-    assert!(entity.owns::<Position>());
+    assert!(entity.has(id::<Position>()));
+    assert!(entity.owns(id::<Position>()));
 }
 
 #[test]
-fn entity_auto_override_id() {
+fn entity_auto_override() {
     let world = World::new();
 
-    let tag_a = world
-        .entity()
-        .add_id((*flecs::OnInstantiate, *flecs::Inherit));
-    let tag_b = world
-        .entity()
-        .add_id((*flecs::OnInstantiate, *flecs::Inherit));
+    let tag_a = world.entity().add((*flecs::OnInstantiate, *flecs::Inherit));
+    let tag_b = world.entity().add((*flecs::OnInstantiate, *flecs::Inherit));
 
-    let base = world.entity().auto_override_id(tag_a).add_id(tag_b);
+    let base = world.entity().auto_override(tag_a).add(tag_b);
 
-    let entity = world.entity().add_id((flecs::IsA::ID, base));
+    let entity = world.entity().add((flecs::IsA::ID, base));
 
-    assert!(entity.has_id(tag_a));
-    assert!(entity.owns_id(tag_a));
+    assert!(entity.has(tag_a));
+    assert!(entity.owns(tag_a));
 
-    assert!(entity.has_id(tag_b));
-    assert!(!entity.owns_id(tag_b));
+    assert!(entity.has(tag_b));
+    assert!(!entity.owns(tag_b));
 }
 
 #[test]
@@ -1158,47 +1154,42 @@ fn entity_override_pair_w_tgt_id() {
 
     world
         .component::<Position>()
-        .add_id((*flecs::OnInstantiate, *flecs::Inherit));
+        .add((*flecs::OnInstantiate, *flecs::Inherit));
 
     let tgt_a = world.entity();
     let tgt_b = world.entity();
 
     let base = world
         .entity()
-        .auto_override_first::<Position>(tgt_a)
+        .auto_override((id::<Position>(), tgt_a))
         .set_first::<Position>(Position { x: 0, y: 0 }, tgt_b);
 
-    let entity = world.entity().add_id((flecs::IsA::ID, base));
+    let entity = world.entity().add((flecs::IsA::ID, base));
 
-    assert!(entity.has_first::<Position>(tgt_a));
-    assert!(entity.owns_first::<Position>(tgt_a));
+    assert!(entity.has((id::<Position>(), tgt_a)));
+    assert!(entity.owns((id::<Position>(), tgt_a)));
 
-    assert!(entity.has_first::<Position>(tgt_b));
-    assert!(!entity.owns_first::<Position>(tgt_b));
+    assert!(entity.has((id::<Position>(), tgt_b)));
+    assert!(!entity.owns((id::<Position>(), tgt_b)));
 }
 
 #[test]
 fn entity_override_pair_w_ids() {
     let world = World::new();
 
-    let rel = world
-        .entity()
-        .add_id((*flecs::OnInstantiate, *flecs::Inherit));
+    let rel = world.entity().add((*flecs::OnInstantiate, *flecs::Inherit));
     let tgt_a = world.entity();
     let tgt_b = world.entity();
 
-    let base = world
-        .entity()
-        .auto_override_id((rel, tgt_a))
-        .add_id((rel, tgt_b));
+    let base = world.entity().auto_override((rel, tgt_a)).add((rel, tgt_b));
 
-    let entity = world.entity().add_id((flecs::IsA::ID, base));
+    let entity = world.entity().add((flecs::IsA::ID, base));
 
-    assert!(entity.has_id((rel, tgt_a)));
-    assert!(entity.owns_id((rel, tgt_a)));
+    assert!(entity.has((rel, tgt_a)));
+    assert!(entity.owns((rel, tgt_a)));
 
-    assert!(entity.has_id((rel, tgt_b)));
-    assert!(!entity.owns_id((rel, tgt_b)));
+    assert!(entity.has((rel, tgt_b)));
+    assert!(!entity.owns((rel, tgt_b)));
 }
 
 #[test]
@@ -1207,19 +1198,19 @@ fn entity_override_pair() {
 
     world
         .component::<Position>()
-        .add_id((*flecs::OnInstantiate, *flecs::Inherit));
+        .add((*flecs::OnInstantiate, *flecs::Inherit));
     let base = world
         .entity()
-        .auto_override::<(Position, TagA)>()
+        .auto_override((id::<Position>(), id::<TagA>()))
         .set_pair::<Position, TagB>(Position { x: 0, y: 0 });
 
-    let entity = world.entity().add_id((flecs::IsA::ID, base));
+    let entity = world.entity().add((flecs::IsA::ID, base));
 
-    assert!(entity.has::<(Position, TagA)>());
-    assert!(entity.owns::<(Position, TagA)>());
+    assert!(entity.has((id::<Position>(), id::<TagA>())));
+    assert!(entity.owns((id::<Position>(), id::<TagA>())));
 
-    assert!(entity.has::<(Position, TagB)>());
-    assert!(!entity.owns::<(Position, TagB)>());
+    assert!(entity.has((id::<Position>(), id::<TagB>())));
+    assert!(!entity.owns((id::<Position>(), id::<TagB>())));
 }
 
 #[test]
@@ -1228,14 +1219,14 @@ fn entity_set_auto_override() {
 
     world
         .component::<Position>()
-        .add_id((*flecs::OnInstantiate, *flecs::Inherit));
+        .add((*flecs::OnInstantiate, *flecs::Inherit));
 
     let base = world.entity().set_auto_override(Position { x: 10, y: 20 });
 
-    let entity = world.entity().add_id((flecs::IsA::ID, base));
+    let entity = world.entity().add((flecs::IsA::ID, base));
 
-    assert!(entity.has::<Position>());
-    assert!(entity.owns::<Position>());
+    assert!(entity.has(id::<Position>()));
+    assert!(entity.owns(id::<Position>()));
 
     entity.get::<&Position>(|pos| {
         assert_eq!(pos.x, 10);
@@ -1254,16 +1245,16 @@ fn entity_set_auto_override_lvalue() {
 
     world
         .component::<Position>()
-        .add_id((*flecs::OnInstantiate, *flecs::Inherit));
+        .add((*flecs::OnInstantiate, *flecs::Inherit));
 
     let plvalue = Position { x: 10, y: 20 };
 
     let base = world.entity().set_auto_override(plvalue);
 
-    let entity = world.entity().add_id((flecs::IsA::ID, base));
+    let entity = world.entity().add((flecs::IsA::ID, base));
 
-    assert!(entity.has::<Position>());
-    assert!(entity.owns::<Position>());
+    assert!(entity.has(id::<Position>()));
+    assert!(entity.owns(id::<Position>()));
 
     entity.get::<&Position>(|pos| {
         assert_eq!(pos.x, 10);
@@ -1282,16 +1273,16 @@ fn entity_set_auto_override_pair() {
 
     world
         .component::<Position>()
-        .add_id((*flecs::OnInstantiate, *flecs::Inherit));
+        .add((*flecs::OnInstantiate, *flecs::Inherit));
 
     let base = world
         .entity()
         .set_pair_override::<Position, TagA>(Position { x: 10, y: 20 });
 
-    let entity = world.entity().add_id((flecs::IsA::ID, base));
+    let entity = world.entity().add((flecs::IsA::ID, base));
 
-    assert!(entity.has::<(Position, TagA)>());
-    assert!(entity.owns::<(Position, TagA)>());
+    assert!(entity.has((id::<Position>(), id::<TagA>())));
+    assert!(entity.owns((id::<Position>(), id::<TagA>())));
 
     entity.get::<&(Position, TagA)>(|pos| {
         assert_eq!(pos.x, 10);
@@ -1315,13 +1306,13 @@ fn entity_set_auto_override_pair_w_tgt_id() {
     // let base = unsafe {
     //     world
     //         .entity()
-    //         .set_auto_override_first::<Position>(Position { x: 10, y: 20 }, tgt)
+    //         .set_auto_override((id::<Position>(), Position { x: 10, y: 20 }, tgt))
     // };
 
-    // let entity = world.entity().add_id((flecs::IsA::ID, base));
+    // let entity = world.entity().add((flecs::IsA::ID, base));
 
-    // assert!(entity.has_first::<Position>(tgt));
-    // assert!(entity.owns_first::<Position>(tgt));
+    // assert!(entity.has((id::<Position>(), tgt)));
+    // assert!(entity.owns((id::<Position>(), tgt)));
 
     // let p = entity.try_get_first_id::<Position>(tgt);
     // assert!(p.is_some());
@@ -1342,16 +1333,16 @@ fn entity_set_auto_override_pair_w_rel_tag() {
 
     world
         .component::<Position>()
-        .add_id((*flecs::OnInstantiate, *flecs::Inherit));
+        .add((*flecs::OnInstantiate, *flecs::Inherit));
 
     let base = world
         .entity()
         .set_pair_override::<TagA, Position>(Position { x: 10, y: 20 });
 
-    let entity = world.entity().add_id((flecs::IsA::ID, base));
+    let entity = world.entity().add((flecs::IsA::ID, base));
 
-    assert!(entity.has::<(TagA, Position)>());
-    assert!(entity.owns::<(TagA, Position)>());
+    assert!(entity.has((id::<TagA>(), id::<Position>())));
+    assert!(entity.owns((id::<TagA>(), id::<Position>())));
 
     entity.get::<&(TagA, Position)>(|pos| {
         assert_eq!(pos.x, 10);
@@ -1393,7 +1384,7 @@ fn entity_path() {
     let world = World::new();
 
     let parent = world.entity_named("parent");
-    world.set_scope_id(parent.id());
+    world.set_scope(parent.id());
     let child = world.entity_named("child");
 
     assert_eq!(&child.path().unwrap(), "::parent::child");
@@ -1404,16 +1395,13 @@ fn entity_path_from() {
     let world = World::new();
 
     let parent = world.entity_named("parent");
-    world.set_scope_id(parent.id());
+    world.set_scope(parent.id());
     let child = world.entity_named("child");
-    world.set_scope_id(child.id());
+    world.set_scope(child.id());
     let grandchild = world.entity_named("grandchild");
 
     assert_eq!(&grandchild.path().unwrap(), "::parent::child::grandchild");
-    assert_eq!(
-        &grandchild.path_from_id(parent).unwrap(),
-        "child::grandchild"
-    );
+    assert_eq!(&grandchild.path_from(parent).unwrap(), "child::grandchild");
 }
 
 #[test]
@@ -1421,16 +1409,13 @@ fn entity_path_from_type() {
     let world = World::new();
 
     let parent = world.entity_named("parent");
-    world.set_scope_id(parent.id());
+    world.set_scope(parent.id());
     let child = world.entity_named("child");
-    world.set_scope_id(child.id());
+    world.set_scope(child.id());
     let grandchild = world.entity_named("grandchild");
 
     assert_eq!(&grandchild.path().unwrap(), "::parent::child::grandchild");
-    assert_eq!(
-        &grandchild.path_from_id(parent).unwrap(),
-        "child::grandchild"
-    );
+    assert_eq!(&grandchild.path_from(parent).unwrap(), "child::grandchild");
 }
 
 #[test]
@@ -1438,7 +1423,7 @@ fn entity_path_custom_sep() {
     let world = World::new();
 
     let parent = world.entity_named("parent");
-    world.set_scope_id(parent.id());
+    world.set_scope(parent.id());
     let child = world.entity_named("child");
 
     assert_eq!(&child.path_w_sep("_", "?").unwrap(), "?parent_child");
@@ -1449,9 +1434,9 @@ fn entity_path_from_custom_sep() {
     let world = World::new();
 
     let parent = world.entity_named("parent");
-    world.set_scope_id(parent.id());
+    world.set_scope(parent.id());
     let child = world.entity_named("child");
-    world.set_scope_id(child.id());
+    world.set_scope(child.id());
     let grandchild = world.entity_named("grandchild");
 
     assert_eq!(
@@ -1459,7 +1444,7 @@ fn entity_path_from_custom_sep() {
         "?parent_child_grandchild"
     );
     assert_eq!(
-        &grandchild.path_from_id_w_sep(parent, "_", "::").unwrap(),
+        &grandchild.path_from_w_sep(parent, "_", "::").unwrap(),
         "child_grandchild"
     );
 }
@@ -1469,9 +1454,9 @@ fn entity_path_from_type_custom_sep() {
     let world = World::new();
 
     let parent = world.entity_from::<Parent>();
-    world.set_scope_id(parent.id());
+    world.set_scope(parent.id());
     let child = world.entity_named("child");
-    world.set_scope_id(child.id());
+    world.set_scope(child.id());
     let grandchild = world.entity_named("grandchild");
 
     assert_eq!(
@@ -1479,7 +1464,7 @@ fn entity_path_from_type_custom_sep() {
         "?flecs_common\\_test_Parent_child_grandchild"
     );
     assert_eq!(
-        &grandchild.path_from_id_w_sep(parent, "_", "::").unwrap(),
+        &grandchild.path_from_w_sep(parent, "_", "::").unwrap(),
         "child_grandchild"
     );
 }
@@ -1537,7 +1522,7 @@ fn entity_entity_view_to_entity_world() {
     let entity_mut = entity_view.mut_current_stage(&world);
     entity_mut.set(Position { x: 10, y: 20 });
 
-    assert!(entity_view.has::<Position>());
+    assert!(entity_view.has(id::<Position>()));
     entity_view.get::<&Position>(|p| {
         assert_eq!(p.x, 10);
         assert_eq!(p.y, 20);
@@ -1555,12 +1540,12 @@ fn entity_entity_view_to_entity_stage() {
 
     let entity_mut = entity_view.mut_current_stage(stage);
     entity_mut.set(Position { x: 10, y: 20 });
-    assert!(!entity_mut.has::<Position>());
+    assert!(!entity_mut.has(id::<Position>()));
 
     world.readonly_end();
 
-    assert!(entity_mut.has::<Position>());
-    assert!(entity_view.has::<Position>());
+    assert!(entity_mut.has(id::<Position>()));
+    assert!(entity_view.has(id::<Position>()));
 
     entity_view.get::<&Position>(|p| {
         assert_eq!(p.x, 10);
@@ -1580,7 +1565,7 @@ fn entity_create_entity_view_from_stage() {
 
     let entity_mut = entity_view.mut_current_stage(&world);
     entity_mut.set(Position { x: 10, y: 20 });
-    assert!(entity_view.has::<Position>());
+    assert!(entity_view.has(id::<Position>()));
 
     entity_mut.get::<&Position>(|p| {
         assert_eq!(p.x, 10);
@@ -1823,11 +1808,11 @@ fn entity_defer_set_1_component() {
 
     let e = world.entity().set(Position { x: 10, y: 20 });
 
-    assert!(!e.has::<Position>());
+    assert!(!e.has(id::<Position>()));
 
     world.defer_end();
 
-    assert!(e.has::<Position>());
+    assert!(e.has(id::<Position>()));
 
     e.get::<&Position>(|p| {
         assert_eq!(p.x, 10);
@@ -1846,13 +1831,13 @@ fn entity_defer_set_2_components() {
         .set(Position { x: 10, y: 20 })
         .set(Velocity { x: 1, y: 2 });
 
-    assert!(!e.has::<Position>());
-    assert!(!e.has::<Velocity>());
+    assert!(!e.has(id::<Position>()));
+    assert!(!e.has(id::<Velocity>()));
 
     world.defer_end();
 
-    assert!(e.has::<Position>());
-    assert!(e.has::<Velocity>());
+    assert!(e.has(id::<Position>()));
+    assert!(e.has(id::<Velocity>()));
 
     e.get::<(&Velocity, &Position)>(|(v, p)| {
         assert_eq!(p.x, 10);
@@ -1874,15 +1859,15 @@ fn entity_defer_set_3_components() {
         .set(Velocity { x: 1, y: 2 })
         .set(Mass { value: 50 });
 
-    assert!(!e.has::<Position>());
-    assert!(!e.has::<Velocity>());
-    assert!(!e.has::<Mass>());
+    assert!(!e.has(id::<Position>()));
+    assert!(!e.has(id::<Velocity>()));
+    assert!(!e.has(id::<Mass>()));
 
     world.defer_end();
 
-    assert!(e.has::<Position>());
-    assert!(e.has::<Velocity>());
-    assert!(e.has::<Mass>());
+    assert!(e.has(id::<Position>()));
+    assert!(e.has(id::<Velocity>()));
+    assert!(e.has(id::<Mass>()));
 
     e.get::<(&Velocity, &Position, &Mass)>(|(v, p, m)| {
         assert_eq!(p.x, 10);
@@ -2007,7 +1992,7 @@ fn entity_set_2_after_set_1() {
 
     let e = world.entity().set(Position { x: 5, y: 10 });
 
-    assert!(e.has::<Position>());
+    assert!(e.has(id::<Position>()));
 
     e.get::<&Position>(|p| {
         assert_eq!(p.x, 5);
@@ -2037,8 +2022,8 @@ fn entity_set_2_after_set_2() {
         .set(Position { x: 5, y: 10 })
         .set(Velocity { x: 1, y: 2 });
 
-    assert!(e.has::<Position>());
-    assert!(e.has::<Velocity>());
+    assert!(e.has(id::<Position>()));
+    assert!(e.has(id::<Velocity>()));
 
     e.get::<(&Position, &Velocity)>(|(p, v)| {
         assert_eq!(p.x, 5);
@@ -2076,13 +2061,13 @@ fn entity_with_self() {
 
     // Ensures that while Self is (implicitly) registered within the with, it
     // does not get the tag.
-    assert!(!world.component::<SelfRef>().has_id(tag));
+    assert!(!world.component::<SelfRef>().has(tag));
 
     let mut count = 0;
-    let q = world.query::<()>().with_id(tag).build();
+    let q = world.query::<()>().with(tag).build();
 
     q.each_entity(|e, _| {
-        assert!(e.has_id(tag));
+        assert!(e.has(tag));
 
         e.get::<&SelfRef>(|s| {
             assert_eq!(s.value, e);
@@ -2098,7 +2083,7 @@ fn entity_with_self() {
 fn entity_with_relation_type_self() {
     let world = World::new();
 
-    let bob = world.entity().with_first::<Likes>(|| {
+    let bob = world.entity().with_first(id::<Likes>(), || {
         let e1 = world.entity();
         e1.set(SelfRef { value: e1.into() });
 
@@ -2109,13 +2094,13 @@ fn entity_with_relation_type_self() {
         e3.set(SelfRef { value: e3.into() });
     });
 
-    assert!(!world.component::<SelfRef>().has_first::<Likes>(bob));
+    assert!(!world.component::<SelfRef>().has((id::<Likes>(), bob)));
 
     let mut count = 0;
-    let q = world.query::<()>().with_first::<&Likes>(bob).build();
+    let q = world.query::<()>().with((id::<&Likes>(), bob)).build();
 
     q.each_entity(|e, _| {
-        assert!(e.has_first::<Likes>(bob));
+        assert!(e.has((id::<Likes>(), bob)));
 
         e.get::<&SelfRef>(|s| {
             assert_eq!(s.value, e);
@@ -2131,7 +2116,7 @@ fn entity_with_relation_type_self() {
 fn entity_with_relation_self() {
     let world = World::new();
 
-    let bob = world.entity().with_first::<Likes>(|| {
+    let bob = world.entity().with_first(id::<Likes>(), || {
         let e1 = world.entity();
         e1.set(SelfRef { value: e1.into() });
 
@@ -2142,13 +2127,13 @@ fn entity_with_relation_self() {
         e3.set(SelfRef { value: e3.into() });
     });
 
-    assert!(!world.component::<SelfRef>().has_first::<Likes>(bob));
+    assert!(!world.component::<SelfRef>().has((id::<Likes>(), bob)));
 
     let mut count = 0;
-    let q = world.query::<()>().with_first::<&Likes>(bob).build();
+    let q = world.query::<()>().with((id::<&Likes>(), bob)).build();
 
     q.each_entity(|e, _| {
-        assert!(e.has_first::<Likes>(bob));
+        assert!(e.has((id::<Likes>(), bob)));
 
         e.get::<&SelfRef>(|s| {
             assert_eq!(s.value, e);
@@ -2173,7 +2158,7 @@ fn entity_with_self_w_name() {
     let tier2 = world.try_lookup_recursive("Tier2");
     assert!(tier2.is_some());
     let tier2 = tier2.unwrap();
-    assert!(tier2.has_id(tier1));
+    assert!(tier2.has(tier1));
 }
 
 #[test]
@@ -2189,8 +2174,8 @@ fn entity_with_self_nested() {
     let tier2 = world.try_lookup_recursive("Tier2").unwrap();
     let tier3 = world.try_lookup_recursive("Tier3").unwrap();
 
-    assert!(tier2.has_id(tier1));
-    assert!(tier3.has_id(tier2));
+    assert!(tier2.has(tier1));
+    assert!(tier3.has(tier2));
 }
 
 #[test]
@@ -2240,17 +2225,14 @@ fn entity_with_scope() {
     assert!(
         !world
             .component::<SelfRef>()
-            .has_id((flecs::ChildOf::ID, parent))
+            .has((flecs::ChildOf::ID, parent))
     );
 
     let mut count = 0;
-    let q = world
-        .query::<()>()
-        .with_id((*flecs::ChildOf, parent))
-        .build();
+    let q = world.query::<()>().with((*flecs::ChildOf, parent)).build();
 
     q.each_entity(|e, _| {
-        assert!(e.has_id((*flecs::ChildOf, parent)));
+        assert!(e.has((*flecs::ChildOf, parent)));
 
         e.get::<&SelfRef>(|s| {
             assert_eq!(s.value, e);
@@ -2282,10 +2264,10 @@ fn entity_with_scope_nested() {
     assert!(world.try_lookup_recursive("C::GC").is_none());
 
     let child = world.lookup_recursive("P::C");
-    assert!(child.has_id((flecs::ChildOf::ID, parent)));
+    assert!(child.has((flecs::ChildOf::ID, parent)));
 
     let grandchild = world.lookup_recursive("P::C::GC");
-    assert!(grandchild.has_id((flecs::ChildOf::ID, child)));
+    assert!(grandchild.has((flecs::ChildOf::ID, child)));
 }
 
 #[test]
@@ -2307,10 +2289,10 @@ fn entity_with_scope_nested_same_name_as_parent() {
     assert!(world.try_lookup_recursive("C::C").is_none());
 
     let child = world.lookup_recursive("P::C");
-    assert!(child.has_id((flecs::ChildOf::ID, parent)));
+    assert!(child.has((flecs::ChildOf::ID, parent)));
 
     let gchild = world.lookup_recursive("P::C::C");
-    assert!(gchild.has_id((flecs::ChildOf::ID, child)));
+    assert!(gchild.has((flecs::ChildOf::ID, child)));
 }
 
 #[test]
@@ -2318,8 +2300,8 @@ fn entity_no_recursive_lookup() {
     let world = World::new();
 
     let p = world.entity_named("P");
-    let c = world.entity_named("C").child_of_id(p);
-    let gc = world.entity_named("GC").child_of_id(c);
+    let c = world.entity_named("C").child_of(p);
+    let gc = world.entity_named("GC").child_of(c);
 
     assert_eq!(c.lookup("GC"), gc);
     assert!(c.try_lookup("C").is_none());
@@ -2336,7 +2318,7 @@ fn entity_defer_new_w_name() {
         assert!(e.is_valid());
     });
 
-    assert!(e.has_first::<flecs::Identifier>(flecs::Name::ID));
+    assert!(e.has((id::<flecs::Identifier>(), flecs::Name::ID)));
     assert_eq!(e.name(), "Foo");
 }
 
@@ -2350,7 +2332,7 @@ fn entity_defer_new_w_nested_name() {
         assert!(e.is_valid());
     });
 
-    assert!(e.has_first::<flecs::Identifier>(flecs::Name::ID));
+    assert!(e.has((id::<flecs::Identifier>(), flecs::Name::ID)));
     assert_eq!(e.name(), "Bar");
     assert_eq!(e.path().unwrap(), "::Foo::Bar");
 }
@@ -2368,7 +2350,7 @@ fn entity_defer_new_w_scope_name() {
         });
     });
 
-    assert!(e.has_first::<flecs::Identifier>(flecs::Name::ID));
+    assert!(e.has((id::<flecs::Identifier>(), flecs::Name::ID)));
     assert_eq!(e.name(), "Foo");
     assert_eq!(e.path().unwrap(), "::Parent::Foo");
 }
@@ -2386,7 +2368,7 @@ fn entity_defer_new_w_scope_nested_name() {
         });
     });
 
-    assert!(e.has_first::<flecs::Identifier>(flecs::Name::ID));
+    assert!(e.has((id::<flecs::Identifier>(), flecs::Name::ID)));
     assert_eq!(e.name(), "Bar");
     assert_eq!(e.path().unwrap(), "::Parent::Foo::Bar");
 }
@@ -2405,7 +2387,7 @@ fn entity_defer_new_w_scope() {
         });
     });
 
-    assert!(e.has_first::<flecs::ChildOf>(parent));
+    assert!(e.has((id::<flecs::ChildOf>(), parent)));
 }
 
 #[test]
@@ -2418,11 +2400,11 @@ fn entity_defer_new_w_with() {
         tag.with(|| {
             e = world.entity();
             assert!(e.is_valid());
-            assert!(!e.has_id(tag));
+            assert!(!e.has(tag));
         });
     });
 
-    assert!(e.has_id(tag));
+    assert!(e.has(tag));
 }
 
 #[test]
@@ -2437,17 +2419,17 @@ fn entity_defer_new_w_name_scope_with() {
             parent.scope(|_w| {
                 e = world.entity_named("Foo");
                 assert!(e.is_valid());
-                assert!(!e.has_id(tag));
+                assert!(!e.has(tag));
             });
 
-            assert!(!e.has_id(tag));
+            assert!(!e.has(tag));
         });
 
-        assert!(!e.has_id(tag));
+        assert!(!e.has(tag));
     });
 
-    assert!(e.has_id(tag));
-    assert!(e.has_first::<flecs::Identifier>(flecs::Name::ID));
+    assert!(e.has(tag));
+    assert!(e.has((id::<flecs::Identifier>(), flecs::Name::ID)));
     assert_eq!(e.name(), "Foo");
     assert_eq!(e.path().unwrap(), "::Parent::Foo");
 }
@@ -2464,17 +2446,17 @@ fn entity_defer_new_w_nested_name_scope_with() {
             parent.scope(|_w| {
                 e = world.entity_named("Foo::Bar");
                 assert!(e.is_valid());
-                assert!(!e.has_id(tag));
+                assert!(!e.has(tag));
             });
 
-            assert!(!e.has_id(tag));
+            assert!(!e.has(tag));
         });
 
-        assert!(!e.has_id(tag));
+        assert!(!e.has(tag));
     });
 
-    assert!(e.has_id(tag));
-    assert!(e.has_first::<flecs::Identifier>(flecs::Name::ID));
+    assert!(e.has(tag));
+    assert!(e.has((id::<flecs::Identifier>(), flecs::Name::ID)));
     assert_eq!(e.name(), "Bar");
     assert_eq!(e.path().unwrap(), "::Parent::Foo::Bar");
 }
@@ -2485,15 +2467,15 @@ fn entity_defer_w_with_implicit_component() {
     let mut e = world.entity_null();
 
     world.defer(|| {
-        world.with::<Tag>(|| {
+        world.with(id::<Tag>(), || {
             e = world.entity();
-            assert!(!e.has::<Tag>());
+            assert!(!e.has(id::<Tag>()));
         });
 
-        assert!(!e.has::<Tag>());
+        assert!(!e.has(id::<Tag>()));
     });
 
-    assert!(e.has::<Tag>());
+    assert!(e.has(id::<Tag>()));
 }
 
 #[test]
@@ -2503,20 +2485,20 @@ fn entity_defer_suspend_resume() {
 
     world.defer(|| {
         e.set(Position { x: 10, y: 20 });
-        assert!(!e.has::<Position>());
+        assert!(!e.has(id::<Position>()));
 
         world.defer_suspend();
         e.set(Velocity { x: 1, y: 2 });
-        assert!(!e.has::<Position>());
-        assert!(e.has::<Velocity>());
+        assert!(!e.has(id::<Position>()));
+        assert!(e.has(id::<Velocity>()));
         world.defer_resume();
 
-        assert!(!e.has::<Position>());
-        assert!(e.has::<Velocity>());
+        assert!(!e.has(id::<Position>()));
+        assert!(e.has(id::<Velocity>()));
     });
 
-    assert!(e.has::<Position>());
-    assert!(e.has::<Velocity>());
+    assert!(e.has(id::<Position>()));
+    assert!(e.has(id::<Velocity>()));
 }
 
 #[test]
@@ -2530,14 +2512,14 @@ fn entity_with_after_builder_method() {
     let b = world
         .entity()
         .set(Position { x: 30, y: 40 })
-        .with_first::<Likes>(|| {
+        .with_first(id::<Likes>(), || {
             world.entity_named("Y");
         });
 
     let c = world
         .entity()
         .set(Position { x: 50, y: 60 })
-        .with_first_id(*flecs::IsA, || {
+        .with_first(*flecs::IsA, || {
             world.entity_named("Z");
         });
 
@@ -2557,13 +2539,13 @@ fn entity_with_after_builder_method() {
     });
 
     let x = world.lookup_recursive("X");
-    assert!(x.has_id(a));
+    assert!(x.has(a));
 
     let y = world.lookup_recursive("Y");
-    assert!(y.has_first::<Likes>(b));
+    assert!(y.has((id::<Likes>(), b)));
 
     let z = world.lookup_recursive("Z");
-    assert!(z.has_id((*flecs::IsA, c)));
+    assert!(z.has((*flecs::IsA, c)));
 }
 
 #[test]
@@ -2579,14 +2561,14 @@ fn entity_with_before_builder_method() {
 
     let b = world
         .entity()
-        .with_first::<Likes>(|| {
+        .with_first(id::<Likes>(), || {
             world.entity_named("Y");
         })
         .set(Position { x: 30, y: 40 });
 
     let c = world
         .entity()
-        .with_first_id(*flecs::IsA, || {
+        .with_first(*flecs::IsA, || {
             world.entity_named("Z");
         })
         .set(Position { x: 50, y: 60 });
@@ -2607,13 +2589,13 @@ fn entity_with_before_builder_method() {
     });
 
     let x = world.lookup_recursive("X");
-    assert!(x.has_id(a));
+    assert!(x.has(a));
 
     let y = world.lookup_recursive("Y");
-    assert!(y.has_first::<Likes>(b));
+    assert!(y.has((id::<Likes>(), b)));
 
     let z = world.lookup_recursive("Z");
-    assert!(z.has_id((*flecs::IsA, c)));
+    assert!(z.has((*flecs::IsA, c)));
 }
 
 #[test]
@@ -2651,7 +2633,7 @@ fn entity_insert() {
     let world = World::new();
 
     let e = world.entity().set(Position { x: 10, y: 20 });
-    assert!(e.has::<Position>());
+    assert!(e.has(id::<Position>()));
 
     e.get::<&Position>(|p| {
         assert_eq!(p.x, 10);
@@ -2671,7 +2653,7 @@ fn entity_entity_id_str() {
 fn entity_pair_id_str() {
     let world = World::new();
 
-    let id = world.id_from_id((world.entity_named("Rel"), world.entity_named("Obj")));
+    let id = world.id_view_from((world.entity_named("Rel"), world.entity_named("Obj")));
 
     assert_eq!(id.to_str(), "(Rel,Obj)");
 }
@@ -2680,7 +2662,7 @@ fn entity_pair_id_str() {
 fn entity_role_id_str() {
     let world = World::new();
 
-    let id = world.id_from_id(flecs::id_flags::AutoOverride::ID | world.entity_named("Foo").id());
+    let id = world.id_view_from(flecs::id_flags::AutoOverride::ID | world.entity_named("Foo").id());
 
     assert_eq!(id.to_str(), "AUTO_OVERRIDE|Foo");
 }
@@ -2716,10 +2698,10 @@ fn entity_is_wildcard() {
     let e2 = world.entity();
 
     let p0 = e1;
-    let p1 = world.id_from_id((e1, e2));
-    let p2 = world.id_from_id((e1, *flecs::Wildcard));
-    let p3 = world.id_from_id((*flecs::Wildcard, e2));
-    let p4 = world.id_from_id((*flecs::Wildcard, *flecs::Wildcard));
+    let p1 = world.id_view_from((e1, e2));
+    let p2 = world.id_view_from((e1, *flecs::Wildcard));
+    let p3 = world.id_view_from((*flecs::Wildcard, e2));
+    let p4 = world.id_view_from((*flecs::Wildcard, *flecs::Wildcard));
 
     assert!(!e1.is_wildcard());
     assert!(!e2.is_wildcard());
@@ -2737,10 +2719,10 @@ fn entity_has_id_t() {
     let id_1 = world.entity();
     let id_2 = world.entity();
 
-    let e = world.entity().add_id(id_1);
+    let e = world.entity().add(id_1);
 
-    assert!(e.has_id(id_1));
-    assert!(!e.has_id(id_2));
+    assert!(e.has(id_1));
+    assert!(!e.has(id_2));
 }
 
 #[test]
@@ -2751,10 +2733,10 @@ fn entity_has_pair_id_t() {
     let id_2 = world.entity();
     let id_3 = world.entity();
 
-    let e = world.entity().add_id((id_1, id_2));
+    let e = world.entity().add((id_1, id_2));
 
-    assert!(e.has_id((id_1, id_2)));
-    assert!(!e.has_id((id_1, id_3)));
+    assert!(e.has((id_1, id_2)));
+    assert!(!e.has((id_1, id_3)));
 }
 
 #[test]
@@ -2764,10 +2746,10 @@ fn entity_has_pair_id_t_w_type() {
     let id_2 = world.entity();
     let id_3 = world.entity();
 
-    let e = world.entity().add_first::<Rel>(id_2);
+    let e = world.entity().add((id::<Rel>(), id_2));
 
-    assert!(e.has_first::<Rel>(id_2));
-    assert!(!e.has_first::<Rel>(id_3));
+    assert!(e.has((id::<Rel>(), id_2)));
+    assert!(!e.has((id::<Rel>(), id_3)));
 }
 
 #[test]
@@ -2777,10 +2759,10 @@ fn entity_has_id() {
     let id_1 = world.entity();
     let id_2 = world.entity();
 
-    let e = world.entity().add_id(id_1);
+    let e = world.entity().add(id_1);
 
-    assert!(e.has_id(id_1));
-    assert!(!e.has_id(id_2));
+    assert!(e.has(id_1));
+    assert!(!e.has(id_2));
 }
 
 #[test]
@@ -2791,10 +2773,10 @@ fn entity_has_pair_id() {
     let id_2 = world.entity();
     let id_3 = world.entity();
 
-    let e = world.entity().add_id((id_1, id_2));
+    let e = world.entity().add((id_1, id_2));
 
-    assert!(e.has_id((id_1, id_2)));
-    assert!(!e.has_id((id_1, id_3)));
+    assert!(e.has((id_1, id_2)));
+    assert!(!e.has((id_1, id_3)));
 }
 
 #[test]
@@ -2804,10 +2786,10 @@ fn entity_has_pair_id_w_type() {
     let id_2 = world.entity();
     let id_3 = world.entity();
 
-    let e = world.entity().add_first::<Rel>(id_2);
+    let e = world.entity().add((id::<Rel>(), id_2));
 
-    assert!(e.has_first::<Rel>(id_2));
-    assert!(!e.has_first::<Rel>(id_3));
+    assert!(e.has((id::<Rel>(), id_2)));
+    assert!(!e.has((id::<Rel>(), id_3)));
 }
 
 #[test]
@@ -2816,11 +2798,11 @@ fn entity_has_wildcard_id() {
 
     let id = world.entity();
 
-    let e1 = world.entity().add_id(id);
+    let e1 = world.entity().add(id);
     let e2 = world.entity();
 
-    assert!(e1.has_id(*flecs::Wildcard));
-    assert!(!e2.has_id(*flecs::Wildcard));
+    assert!(e1.has(*flecs::Wildcard));
+    assert!(!e2.has(*flecs::Wildcard));
 }
 
 #[test]
@@ -2831,29 +2813,29 @@ fn entity_has_wildcard_pair_id() {
     let obj = world.entity();
     let obj_2 = world.entity();
 
-    let w1 = world.id_from_id((rel, *flecs::Wildcard));
-    let w2 = world.id_from_id((*flecs::Wildcard, obj));
+    let w1 = world.id_view_from((rel, *flecs::Wildcard));
+    let w2 = world.id_view_from((*flecs::Wildcard, obj));
 
-    let e1 = world.entity().add_id((rel, obj));
-    let e2 = world.entity().add_id((rel, obj_2));
+    let e1 = world.entity().add((rel, obj));
+    let e2 = world.entity().add((rel, obj_2));
 
-    assert!(e1.has_id(w1));
-    assert!(e1.has_id(w2));
-    assert!(e2.has_id(w1));
-    assert!(!e2.has_id(w2));
+    assert!(e1.has(w1));
+    assert!(e1.has(w2));
+    assert!(e2.has(w1));
+    assert!(!e2.has(w2));
 }
 
 #[test]
-fn entity_owns_id_t() {
+fn entity_owns_t() {
     let world = World::new();
 
     let id_1 = world.entity();
     let id_2 = world.entity();
 
-    let e = world.entity().add_id(id_1);
+    let e = world.entity().add(id_1);
 
-    assert!(e.owns_id(id_1));
-    assert!(!e.owns_id(id_2));
+    assert!(e.owns(id_1));
+    assert!(!e.owns(id_2));
 }
 
 #[test]
@@ -2864,10 +2846,10 @@ fn entity_owns_pair_id_t() {
     let id_2 = world.entity();
     let id_3 = world.entity();
 
-    let e = world.entity().add_id((id_1, id_2));
+    let e = world.entity().add((id_1, id_2));
 
-    assert!(e.owns_id((id_1, id_2)));
-    assert!(!e.owns_id((id_1, id_3)));
+    assert!(e.owns((id_1, id_2)));
+    assert!(!e.owns((id_1, id_3)));
 }
 
 #[test]
@@ -2877,23 +2859,23 @@ fn entity_owns_pair_id_t_w_type() {
     let id_2 = world.entity();
     let id_3 = world.entity();
 
-    let e = world.entity().add_first::<Rel>(id_2);
+    let e = world.entity().add((id::<Rel>(), id_2));
 
-    assert!(e.owns_first::<Rel>(id_2));
-    assert!(!e.owns_first::<Rel>(id_3));
+    assert!(e.owns((id::<Rel>(), id_2)));
+    assert!(!e.owns((id::<Rel>(), id_3)));
 }
 
 #[test]
-fn entity_owns_id() {
+fn entity_owns() {
     let world = World::new();
 
     let id_1 = world.entity();
     let id_2 = world.entity();
 
-    let e = world.entity().add_id(id_1);
+    let e = world.entity().add(id_1);
 
-    assert!(e.owns_id(id_1));
-    assert!(!e.owns_id(id_2));
+    assert!(e.owns(id_1));
+    assert!(!e.owns(id_2));
 }
 
 #[test]
@@ -2904,10 +2886,10 @@ fn entity_owns_pair_id() {
     let id_2 = world.entity();
     let id_3 = world.entity();
 
-    let e = world.entity().add_id((id_1, id_2));
+    let e = world.entity().add((id_1, id_2));
 
-    assert!(e.owns_id((id_1, id_2)));
-    assert!(!e.owns_id((id_1, id_3)));
+    assert!(e.owns((id_1, id_2)));
+    assert!(!e.owns((id_1, id_3)));
 }
 
 #[test]
@@ -2916,11 +2898,11 @@ fn entity_owns_wildcard_id() {
 
     let id = world.entity();
 
-    let e1 = world.entity().add_id(id);
+    let e1 = world.entity().add(id);
     let e2 = world.entity();
 
-    assert!(e1.owns_id(*flecs::Wildcard));
-    assert!(!e2.owns_id(*flecs::Wildcard));
+    assert!(e1.owns(*flecs::Wildcard));
+    assert!(!e2.owns(*flecs::Wildcard));
 }
 
 #[test]
@@ -2931,16 +2913,16 @@ fn entity_owns_wildcard_pair() {
     let obj = world.entity();
     let obj_2 = world.entity();
 
-    let w1 = world.id_from_id((rel, *flecs::Wildcard));
-    let w2 = world.id_from_id((*flecs::Wildcard, obj));
+    let w1 = world.id_view_from((rel, *flecs::Wildcard));
+    let w2 = world.id_view_from((*flecs::Wildcard, obj));
 
-    let e1 = world.entity().add_id((rel, obj));
-    let e2 = world.entity().add_id((rel, obj_2));
+    let e1 = world.entity().add((rel, obj));
+    let e2 = world.entity().add((rel, obj_2));
 
-    assert!(e1.owns_id(w1));
-    assert!(e1.owns_id(w2));
-    assert!(e2.owns_id(w1));
-    assert!(!e2.owns_id(w2));
+    assert!(e1.owns(w1));
+    assert!(e1.owns(w2));
+    assert!(e2.owns(w1));
+    assert!(!e2.owns(w2));
 }
 
 #[test]
@@ -2950,10 +2932,10 @@ fn entity_owns_pair_id_w_type() {
     let id_2 = world.entity();
     let id_3 = world.entity();
 
-    let e = world.entity().add_first::<Rel>(id_2);
+    let e = world.entity().add((id::<Rel>(), id_2));
 
-    assert!(e.owns_first::<Rel>(id_2));
-    assert!(!e.owns_first::<Rel>(id_3));
+    assert!(e.owns((id::<Rel>(), id_2)));
+    assert!(!e.owns((id::<Rel>(), id_3)));
 }
 
 #[test]
@@ -2963,14 +2945,14 @@ fn entity_id_from_world() {
     let e = world.entity();
     assert!(e.is_valid());
 
-    let id_1 = world.id_from_id(e);
+    let id_1 = world.id_view_from(e);
     assert!(id_1.is_valid());
     assert_eq!(id_1, e.id());
     assert_eq!(id_1.world().ptr_mut(), world.ptr_mut());
     assert!(!id_1.is_pair());
     assert!(!id_1.is_wildcard());
 
-    let id_2 = world.id_from_id(*flecs::Wildcard);
+    let id_2 = world.id_view_from(*flecs::Wildcard);
     assert!(id_2.is_valid());
     assert_eq!(id_2, *flecs::Wildcard);
     assert_eq!(id_2.world().ptr_mut(), world.ptr_mut());
@@ -2988,14 +2970,14 @@ fn entity_id_pair_from_world() {
     let obj = world.entity();
     assert!(obj.is_valid());
 
-    let id_1 = world.id_from_id((rel, obj));
+    let id_1 = world.id_view_from((rel, obj));
     assert_eq!(id_1.first_id(), rel);
     assert_eq!(id_1.second_id(), obj);
     assert_eq!(id_1.world().ptr_mut(), world.ptr_mut());
     assert!(id_1.is_pair());
     assert!(!id_1.is_wildcard());
 
-    let id_2 = world.id_from_id((rel, *flecs::Wildcard));
+    let id_2 = world.id_view_from((rel, *flecs::Wildcard));
     assert_eq!(id_2.first_id(), rel);
     assert_eq!(id_2.second_id(), *flecs::Wildcard);
     assert_eq!(id_2.world().ptr_mut(), world.ptr_mut());
@@ -3009,9 +2991,9 @@ fn entity_is_a_id() {
 
     let base = world.entity();
 
-    let e = world.entity().is_a_id(base);
+    let e = world.entity().is_a(base);
 
-    assert!(e.has_id((*flecs::IsA, base)));
+    assert!(e.has((*flecs::IsA, base)));
 }
 
 #[test]
@@ -3020,10 +3002,10 @@ fn entity_is_a_w_type() {
 
     let base = world.entity_from::<Prefab>();
 
-    let e = world.entity().is_a::<Prefab>();
+    let e = world.entity().is_a(id::<Prefab>());
 
-    assert!(e.has_id((*flecs::IsA, base)));
-    assert!(e.has_second::<Prefab>(*flecs::IsA));
+    assert!(e.has((*flecs::IsA, base)));
+    assert!(e.has((id::<flecs::IsA>(), id::<Prefab>())));
 }
 
 #[test]
@@ -3032,9 +3014,9 @@ fn entity_child_of_id() {
 
     let base = world.entity();
 
-    let e = world.entity().child_of_id(base);
+    let e = world.entity().child_of(base);
 
-    assert!(e.has_id((*flecs::ChildOf, base)));
+    assert!(e.has((*flecs::ChildOf, base)));
 }
 
 #[test]
@@ -3043,10 +3025,10 @@ fn entity_child_of_w_type() {
 
     let base = world.entity_from::<Parent>();
 
-    let e = world.entity().child_of::<Parent>();
+    let e = world.entity().child_of(id::<Parent>());
 
-    assert!(e.has_id((*flecs::ChildOf, base)));
-    assert!(e.has_second::<Parent>(*flecs::ChildOf));
+    assert!(e.has((*flecs::ChildOf, base)));
+    assert!(e.has((*flecs::ChildOf, id::<Parent>())));
 }
 
 #[test]
@@ -3054,12 +3036,12 @@ fn entity_slot_of() {
     let world = World::new();
 
     let base = world.prefab();
-    let base_child = world.prefab().child_of_id(base).slot_of_id(base);
+    let base_child = world.prefab().child_of(base).slot_of(base);
 
-    assert!(base_child.has_id((*flecs::SlotOf, base)));
+    assert!(base_child.has((*flecs::SlotOf, base)));
 
-    let inst = world.entity().is_a_id(base);
-    assert!(inst.has_id((base_child, *flecs::Wildcard)));
+    let inst = world.entity().is_a(base);
+    assert!(inst.has((base_child, *flecs::Wildcard)));
 }
 
 #[test]
@@ -3067,12 +3049,12 @@ fn entity_slot_of_w_type() {
     let world = World::new();
 
     let base = world.prefab_type::<Parent>();
-    let base_child = world.prefab().child_of_id(base).slot_of::<Parent>();
+    let base_child = world.prefab().child_of(base).slot_of(id::<Parent>());
 
-    assert!(base_child.has_id((*flecs::SlotOf, base)));
+    assert!(base_child.has((*flecs::SlotOf, base)));
 
-    let inst = world.entity().is_a_id(base);
-    assert!(inst.has_id((base_child, *flecs::Wildcard)));
+    let inst = world.entity().is_a(base);
+    assert!(inst.has((base_child, *flecs::Wildcard)));
 }
 
 #[test]
@@ -3080,12 +3062,12 @@ fn entity_slot() {
     let world = World::new();
 
     let base = world.prefab();
-    let base_child = world.prefab().child_of_id(base).slot();
+    let base_child = world.prefab().child_of(base).slot();
 
-    assert!(base_child.has_id((*flecs::SlotOf, base)));
+    assert!(base_child.has((*flecs::SlotOf, base)));
 
-    let inst = world.entity().is_a_id(base);
-    assert!(inst.has_id((base_child, *flecs::Wildcard)));
+    let inst = world.entity().is_a(base);
+    assert!(inst.has((base_child, *flecs::Wildcard)));
 }
 
 #[test]
@@ -3094,7 +3076,7 @@ fn entity_id_get_entity() {
 
     let e = world.entity();
 
-    let id = world.id_from_id(e);
+    let id = world.id_view_from(e);
 
     assert_eq!(id.entity_view(), e);
 }
@@ -3106,7 +3088,7 @@ fn entity_id_get_invalid_entity() {
     let r = world.entity();
     let o = world.entity();
 
-    let id = world.id_from_id((r, o));
+    let id = world.id_view_from((r, o));
 
     assert!(!id.is_valid());
 }
@@ -3115,17 +3097,17 @@ fn entity_id_get_invalid_entity() {
 fn entity_each_in_stage() {
     let world = World::new();
 
-    let e = world.entity().add::<(Rel, Obj)>();
-    assert!(e.has::<(Rel, Obj)>());
+    let e = world.entity().add((id::<Rel>(), id::<Obj>()));
+    assert!(e.has((id::<Rel>(), id::<Obj>())));
 
     world.readonly_begin(false);
 
     let s = world.stage(0);
     let em = e.mut_current_stage(s);
-    assert!(em.has::<(Rel, Obj)>());
+    assert!(em.has((id::<Rel>(), id::<Obj>())));
     let mut count = 0;
 
-    em.each_target::<Rel>(|obj| {
+    em.each_target(id::<Rel>(), |obj| {
         count += 1;
         assert_eq!(obj, world.entity_from::<Obj>());
     });
@@ -3146,7 +3128,7 @@ fn entity_iter_recycled_parent() {
     assert_ne!(e, e2);
     assert_eq!(*e.id() as u32, *e2.id() as u32);
 
-    let e_child = world.entity().child_of_id(e2);
+    let e_child = world.entity().child_of(e2);
     let mut count = 0;
 
     e2.each_child(|child| {
@@ -3165,11 +3147,11 @@ fn entity_get_obj_by_template() {
     let o1 = world.entity();
     let o2 = world.entity();
 
-    e1.add_first::<Rel>(o1);
-    e1.add_first::<Rel>(o2);
+    e1.add((id::<Rel>(), o1));
+    e1.add((id::<Rel>(), o2));
 
-    assert_eq!(o1, e1.target::<Rel>(0).unwrap());
-    assert_eq!(o2, e1.target::<Rel>(1).unwrap());
+    assert_eq!(o1, e1.target(id::<Rel>(), 0).unwrap());
+    assert_eq!(o2, e1.target(id::<Rel>(), 1).unwrap());
 }
 
 #[test]
@@ -3204,10 +3186,10 @@ fn entity_clone() {
 
     let v = Position { x: 10, y: 20 };
 
-    let src = world.entity().add::<Tag>().set(v);
+    let src = world.entity().add(id::<Tag>()).set(v);
     let dst = src.duplicate(true);
-    assert!(dst.has::<Tag>());
-    assert!(dst.has::<Position>());
+    assert!(dst.has(id::<Tag>()));
+    assert!(dst.has(id::<Position>()));
 
     dst.get::<&Position>(|pos| {
         assert_eq!(pos.x, 10);
@@ -3221,10 +3203,10 @@ fn entity_clone_w_value() {
 
     let v = Position { x: 10, y: 20 };
 
-    let src = world.entity().add::<Tag>().set(v);
+    let src = world.entity().add(id::<Tag>()).set(v);
     let dst = src.duplicate(true);
-    assert!(dst.has::<Tag>());
-    assert!(dst.has::<Position>());
+    assert!(dst.has(id::<Tag>()));
+    assert!(dst.has(id::<Position>()));
 
     dst.get::<&Position>(|pos| {
         assert_eq!(pos.x, 10);
@@ -3238,13 +3220,13 @@ fn entity_clone_to_existing() {
 
     let v = Position { x: 10, y: 20 };
 
-    let src = world.entity().add::<Tag>().set(v);
+    let src = world.entity().add(id::<Tag>()).set(v);
     let dst = world.entity();
     let result = src.duplicate_into(true, dst);
     assert_eq!(result, dst);
 
-    assert!(dst.has::<Tag>());
-    assert!(dst.has::<Position>());
+    assert!(dst.has(id::<Tag>()));
+    assert!(dst.has(id::<Position>()));
 
     dst.get::<&Position>(|pos| {
         assert_eq!(pos.x, 10);
@@ -3260,7 +3242,7 @@ fn entity_clone_to_existing_overlap() {
 
     let v = Position { x: 10, y: 20 };
 
-    let src = world.entity().add::<Tag>().set(v);
+    let src = world.entity().add(id::<Tag>()).set(v);
     let dst = world.entity().set(Position { x: 0, y: 0 });
 
     src.duplicate_into(true, dst);
@@ -3282,9 +3264,9 @@ fn entity_entity_w_root_name_from_scope() {
     let world = World::new();
 
     let p = world.entity_named("parent");
-    world.set_scope_id(p);
+    world.set_scope(p);
     let e = world.entity_named("::foo");
-    world.set_scope_id(0);
+    world.set_scope(0);
 
     assert_eq!(e.name(), "foo");
     assert_eq!(e.path().unwrap(), "::foo");
@@ -3298,7 +3280,7 @@ fn entity_entity_w_type() {
 
     assert_eq!(e.name(), "EntityType");
     assert_eq!(e.path().unwrap(), "::flecs::common_test::EntityType");
-    //assert!(!e.has::<flecs::Component>());
+    //assert!(!e.has(id::<flecs::Component>()));
     //TODO this assert should work, but we register it a bit different than cpp, no problem though.
     let e_2 = world.entity_from::<EntityType>();
     assert_eq!(e, e_2);
@@ -3312,9 +3294,9 @@ fn entity_prefab_w_type() {
 
     assert_eq!(e.name(), "EntityType");
     assert_eq!(e.path().unwrap(), "::flecs::common_test::EntityType");
-    //assert!(!e.has::<flecs::Component>());
+    //assert!(!e.has(id::<flecs::Component>()));
     //TODO this assert should work, but we register it a bit different than cpp, no problem though.
-    assert!(e.has::<flecs::Prefab>());
+    assert!(e.has(id::<flecs::Prefab>()));
 
     let e_2 = world.entity_from::<EntityType>();
     assert_eq!(e, e_2);
@@ -3327,12 +3309,12 @@ fn entity_prefab_hierarchy_w_types() {
     let turret = world.prefab_type::<Turret>();
     let turret_base = world
         .prefab_type::<Base>()
-        .child_of::<Turret>()
-        .slot_of::<Turret>();
+        .child_of(id::<Turret>())
+        .slot_of(id::<Turret>());
 
     assert!(turret.is_valid());
     assert!(turret_base.is_valid());
-    assert!(turret_base.has_id((*flecs::ChildOf, turret)));
+    assert!(turret_base.has((*flecs::ChildOf, turret)));
 
     assert_eq!(turret.path().unwrap(), "::flecs::common_test::Turret");
     assert_eq!(
@@ -3343,24 +3325,24 @@ fn entity_prefab_hierarchy_w_types() {
     assert_eq!(turret.symbol(), "flecs::common_test::Turret");
     assert_eq!(turret_base.symbol(), "flecs::common_test::Base");
 
-    let railgun = world.prefab_type::<Railgun>().is_a::<Turret>();
+    let railgun = world.prefab_type::<Railgun>().is_a(id::<Turret>());
     let railgun_base = railgun.lookup_recursive("Base");
     let railgun_head = world
         .prefab_type::<Head>()
-        .child_of::<Railgun>()
-        .slot_of::<Railgun>();
+        .child_of(id::<Railgun>())
+        .slot_of(id::<Railgun>());
     let railgun_beam = world
         .prefab_type::<Beam>()
-        .child_of::<Railgun>()
-        .slot_of::<Railgun>();
+        .child_of(id::<Railgun>())
+        .slot_of(id::<Railgun>());
 
     assert!(railgun.is_valid());
     assert!(railgun_base.is_valid());
     assert!(railgun_head.is_valid());
     assert!(railgun_beam.is_valid());
-    assert!(railgun_base.has_id((*flecs::ChildOf, railgun)));
-    assert!(railgun_head.has_id((*flecs::ChildOf, railgun)));
-    assert!(railgun_beam.has_id((*flecs::ChildOf, railgun)));
+    assert!(railgun_base.has((*flecs::ChildOf, railgun)));
+    assert!(railgun_head.has((*flecs::ChildOf, railgun)));
+    assert!(railgun_beam.has((*flecs::ChildOf, railgun)));
 
     assert_eq!(railgun.path().unwrap(), "::flecs::common_test::Railgun");
     assert_eq!(
@@ -3388,12 +3370,12 @@ fn entity_prefab_hierarchy_w_root_types() {
     let turret = world.prefab_type::<Turret>();
     let turret_base = world
         .prefab_type::<Base>()
-        .child_of::<Turret>()
-        .slot_of::<Turret>();
+        .child_of(id::<Turret>())
+        .slot_of(id::<Turret>());
 
     assert!(turret.is_valid());
     assert!(turret_base.is_valid());
-    assert!(turret_base.has_id((*flecs::ChildOf, turret)));
+    assert!(turret_base.has((*flecs::ChildOf, turret)));
 
     assert_eq!(turret.path().unwrap(), "::flecs::common_test::Turret");
     assert_eq!(
@@ -3404,7 +3386,7 @@ fn entity_prefab_hierarchy_w_root_types() {
     assert_eq!(turret.symbol(), "flecs::common_test::Turret");
     assert_eq!(turret_base.symbol(), "flecs::common_test::Base");
 
-    let inst = world.entity().is_a::<Turret>();
+    let inst = world.entity().is_a(id::<Turret>());
     assert!(inst.is_valid());
 
     let inst_base = inst.lookup_recursive("Base");
@@ -3418,11 +3400,11 @@ fn entity_entity_array() {
     let entities = [world.entity(), world.entity(), world.entity()];
 
     for e in entities.iter() {
-        e.add::<TagA>().add::<TagB>();
+        e.add(id::<TagA>()).add(id::<TagB>());
     }
 
-    assert_eq!(world.count::<TagA>(), 3);
-    assert_eq!(world.count::<TagB>(), 3);
+    assert_eq!(world.count(id::<TagA>()), 3);
+    assert_eq!(world.count(id::<TagB>()), 3);
 }
 
 #[test]
@@ -3437,7 +3419,7 @@ fn entity_entity_w_type_defer() {
 
     assert_eq!(e.name(), "Tag");
     assert_eq!(e.symbol(), "flecs::common_test::Tag");
-    assert_eq!(world.id_from::<Tag>(), e);
+    assert_eq!(world.id_view_from(id::<Tag>()), e);
 }
 
 #[test]
@@ -3446,8 +3428,8 @@ fn entity_add_if_true_t() {
 
     let e = world.entity();
 
-    e.add_if::<Tag>(true);
-    assert!(e.has::<Tag>());
+    e.add_if(id::<Tag>(), true);
+    assert!(e.has(id::<Tag>()));
 }
 
 #[test]
@@ -3456,13 +3438,13 @@ fn entity_add_if_false_t() {
 
     let e = world.entity();
 
-    e.add_if::<Tag>(false);
-    assert!(!e.has::<Tag>());
+    e.add_if(id::<Tag>(), false);
+    assert!(!e.has(id::<Tag>()));
 
-    e.add::<Tag>();
-    assert!(e.has::<Tag>());
-    e.add_if::<Tag>(false);
-    assert!(!e.has::<Tag>());
+    e.add(id::<Tag>());
+    assert!(e.has(id::<Tag>()));
+    e.add_if(id::<Tag>(), false);
+    assert!(!e.has(id::<Tag>()));
 }
 
 #[test]
@@ -3472,8 +3454,8 @@ fn entity_add_if_true_id() {
     let e = world.entity();
     let t = world.entity();
 
-    e.add_id_if(t, true);
-    assert!(e.has_id(t));
+    e.add_if(t, true);
+    assert!(e.has(t));
 }
 
 #[test]
@@ -3483,13 +3465,13 @@ fn entity_add_if_false_id() {
     let e = world.entity();
     let t = world.entity();
 
-    e.add_id_if(t, false);
-    assert!(!e.has_id(t));
+    e.add_if(t, false);
+    assert!(!e.has(t));
 
-    e.add_id(t);
-    assert!(e.has_id(t));
-    e.add_id_if(t, false);
-    assert!(!e.has_id(t));
+    e.add(t);
+    assert!(e.has(t));
+    e.add_if(t, false);
+    assert!(!e.has(t));
 }
 
 #[test]
@@ -3498,8 +3480,8 @@ fn entity_add_if_true_r_o() {
 
     let e = world.entity();
 
-    e.add_if::<(Rel, Obj)>(true);
-    assert!(e.has::<(Rel, Obj)>());
+    e.add_if((id::<Rel>(), id::<Obj>()), true);
+    assert!(e.has((id::<Rel>(), id::<Obj>())));
 }
 
 #[test]
@@ -3507,12 +3489,12 @@ fn entity_add_if_false_r_o() {
     let world = World::new();
 
     let e = world.entity();
-    e.add_if::<(Rel, Obj2)>(false);
-    assert!(!e.has::<(Rel, Obj2)>());
-    e.add::<(Rel, Obj2)>();
-    assert!(e.has::<(Rel, Obj2)>());
-    e.add_if::<(Rel, Obj2)>(false);
-    assert!(!e.has::<(Rel, Obj2)>());
+    e.add_if((id::<Rel>(), id::<Obj2>()), false);
+    assert!(!e.has((id::<Rel>(), id::<Obj2>())));
+    e.add((id::<Rel>(), id::<Obj2>()));
+    assert!(e.has((id::<Rel>(), id::<Obj2>())));
+    e.add_if((id::<Rel>(), id::<Obj2>()), false);
+    assert!(!e.has((id::<Rel>(), id::<Obj2>())));
 }
 
 #[test]
@@ -3522,8 +3504,8 @@ fn entity_add_if_true_r_o_2() {
     let e = world.entity();
     let o = world.entity();
 
-    e.add_first_if::<Rel>(o, true);
-    assert!(e.has_first::<Rel>(o));
+    e.add_if((id::<Rel>(), o), true);
+    assert!(e.has((id::<Rel>(), o)));
 }
 
 #[test]
@@ -3533,12 +3515,12 @@ fn entity_add_if_false_r_o_2() {
     let e = world.entity();
     let o = world.entity();
 
-    e.add_first_if::<Rel>(o, false);
-    assert!(!e.has_first::<Rel>(o));
-    e.add_first::<Rel>(o);
-    assert!(e.has_first::<Rel>(o));
-    e.add_first_if::<Rel>(o, false);
-    assert!(!e.has_first::<Rel>(o));
+    e.add_if((id::<Rel>(), o), false);
+    assert!(!e.has((id::<Rel>(), o)));
+    e.add((id::<Rel>(), o));
+    assert!(e.has((id::<Rel>(), o)));
+    e.add_if((id::<Rel>(), o), false);
+    assert!(!e.has((id::<Rel>(), o)));
 }
 
 #[test]
@@ -3549,8 +3531,8 @@ fn entity_add_if_true_r_o_3() {
     let r = world.entity();
     let o = world.entity();
 
-    e.add_id_if((r, o), true);
-    assert!(e.has_id((r, o)));
+    e.add_if((r, o), true);
+    assert!(e.has((r, o)));
 }
 
 #[test]
@@ -3561,12 +3543,12 @@ fn entity_add_if_false_r_o_3() {
     let r = world.entity();
     let o = world.entity();
 
-    e.add_id_if((r, o), false);
-    assert!(!e.has_id((r, o)));
-    e.add_id((r, o));
-    assert!(e.has_id((r, o)));
-    e.add_id_if((r, o), false);
-    assert!(!e.has_id((r, o)));
+    e.add_if((r, o), false);
+    assert!(!e.has((r, o)));
+    e.add((r, o));
+    assert!(e.has((r, o)));
+    e.add_if((r, o), false);
+    assert!(!e.has((r, o)));
 }
 
 #[test]
@@ -3574,62 +3556,62 @@ fn entity_add_if_exclusive_r_o() {
     let world = World::new();
 
     let e = world.entity();
-    let r = world.entity().add::<flecs::Exclusive>();
+    let r = world.entity().add(flecs::Exclusive::ID);
     let o_1 = world.entity();
     let o_2 = world.entity();
 
-    e.add_id((r, o_1));
-    assert!(e.has_id((r, o_1)));
+    e.add((r, o_1));
+    assert!(e.has((r, o_1)));
 
-    e.add_id_if((r, o_2), true);
-    assert!(!e.has_id((r, o_1)));
-    assert!(e.has_id((r, o_2)));
+    e.add_if((r, o_2), true);
+    assert!(!e.has((r, o_1)));
+    assert!(e.has((r, o_2)));
 
-    e.add_id_if((r, o_1), false);
-    assert!(!e.has_id((r, o_1)));
-    assert!(!e.has_id((r, o_2)));
+    e.add_if((r, o_1), false);
+    assert!(!e.has((r, o_1)));
+    assert!(!e.has((r, o_2)));
 }
 
 #[test]
 fn entity_add_if_exclusive_r_o_2() {
     let world = World::new();
 
-    world.component::<First>().add::<flecs::Exclusive>();
+    world.component::<First>().add(flecs::Exclusive::ID);
 
     let e = world.entity();
     let o_1 = world.entity();
     let o_2 = world.entity();
 
-    e.add_first::<First>(o_1);
-    assert!(e.has_first::<First>(o_1));
+    e.add((id::<First>(), o_1));
+    assert!(e.has((id::<First>(), o_1)));
 
-    e.add_first_if::<First>(o_2, true);
-    assert!(!e.has_first::<First>(o_1));
-    assert!(e.has_first::<First>(o_2));
+    e.add_if((id::<First>(), o_2), true);
+    assert!(!e.has((id::<First>(), o_1)));
+    assert!(e.has((id::<First>(), o_2)));
 
-    e.add_first_if::<First>(o_1, false);
-    assert!(!e.has_first::<First>(o_1));
-    assert!(!e.has_first::<First>(o_2));
+    e.add_if((id::<First>(), o_1), false);
+    assert!(!e.has((id::<First>(), o_1)));
+    assert!(!e.has((id::<First>(), o_2)));
 }
 
 #[test]
 fn entity_add_if_exclusive_r_o_3() {
     let world = World::new();
 
-    world.component::<Rel>().add::<flecs::Exclusive>();
+    world.component::<Rel>().add(id::<flecs::Exclusive>());
 
     let e = world.entity();
 
-    e.add::<(Rel, Obj)>();
-    assert!(e.has::<(Rel, Obj)>());
+    e.add((id::<Rel>(), id::<Obj>()));
+    assert!(e.has((id::<Rel>(), id::<Obj>())));
 
-    e.add_if::<(Rel, Obj2)>(true);
-    assert!(!e.has::<(Rel, Obj)>());
-    assert!(e.has::<(Rel, Obj2)>());
+    e.add_if((id::<Rel>(), id::<Obj2>()), true);
+    assert!(!e.has((id::<Rel>(), id::<Obj>())));
+    assert!(e.has((id::<Rel>(), id::<Obj2>())));
 
-    e.add_if::<(Rel, Obj)>(false);
-    assert!(!e.has::<(Rel, Obj)>());
-    assert!(!e.has::<(Rel, Obj2)>());
+    e.add_if((id::<Rel>(), id::<Obj>()), false);
+    assert!(!e.has((id::<Rel>(), id::<Obj>())));
+    assert!(!e.has((id::<Rel>(), id::<Obj2>())));
 }
 
 #[test]
@@ -3640,12 +3622,12 @@ fn entity_add_if_pair_w_0_object() {
     let r = world.entity();
     let o_1 = world.entity();
 
-    e.add_id((r, o_1));
-    assert!(e.has_id((r, o_1)));
+    e.add((r, o_1));
+    assert!(e.has((r, o_1)));
 
-    e.add_id_if((r, 0), false);
-    assert!(!e.has_id((r, o_1)));
-    assert!(!e.has_id((r, *flecs::Wildcard)));
+    e.add_if((r, 0), false);
+    assert!(!e.has((r, o_1)));
+    assert!(!e.has((r, *flecs::Wildcard)));
 }
 
 #[test]
@@ -3655,15 +3637,15 @@ fn entity_children_w_custom_relation() {
     let rel = world.entity();
 
     let parent = world.entity();
-    let child_1 = world.entity().add_id((rel, parent));
-    let child_2 = world.entity().add_id((rel, parent));
-    world.entity().child_of_id(parent);
+    let child_1 = world.entity().add((rel, parent));
+    let child_2 = world.entity().add((rel, parent));
+    world.entity().child_of(parent);
 
     let mut child_1_found = false;
     let mut child_2_found = false;
     let mut count = 0;
 
-    parent.each_child_of_id(rel, |child| {
+    parent.each_child_of(rel, |child| {
         if child == child_1 {
             child_1_found = true;
         } else if child == child_2 {
@@ -3682,15 +3664,15 @@ fn entity_children_w_custom_relation_type() {
     let world = World::new();
 
     let parent = world.entity();
-    let child_1 = world.entity().add_first::<Rel>(parent);
-    let child_2 = world.entity().add_first::<Rel>(parent);
-    world.entity().child_of_id(parent);
+    let child_1 = world.entity().add((id::<Rel>(), parent));
+    let child_2 = world.entity().add((id::<Rel>(), parent));
+    world.entity().child_of(parent);
 
     let mut child_1_found = false;
     let mut child_2_found = false;
     let mut count = 0;
 
-    parent.each_child_of::<Rel>(|child| {
+    parent.each_child_of(id::<Rel>(), |child| {
         if child == child_1 {
             child_1_found = true;
         } else if child == child_2 {
@@ -3766,31 +3748,31 @@ fn entity_get_depth() {
     let world = World::new();
 
     let e1 = world.entity();
-    let e2 = world.entity().child_of_id(e1);
-    let e3 = world.entity().child_of_id(e2);
-    let e4 = world.entity().child_of_id(e3);
+    let e2 = world.entity().child_of(e1);
+    let e3 = world.entity().child_of(e2);
+    let e4 = world.entity().child_of(e3);
 
-    assert_eq!(e1.depth_id(*flecs::ChildOf), 0);
-    assert_eq!(e2.depth_id(*flecs::ChildOf), 1);
-    assert_eq!(e3.depth_id(*flecs::ChildOf), 2);
-    assert_eq!(e4.depth_id(*flecs::ChildOf), 3);
+    assert_eq!(e1.depth(*flecs::ChildOf), 0);
+    assert_eq!(e2.depth(*flecs::ChildOf), 1);
+    assert_eq!(e3.depth(*flecs::ChildOf), 2);
+    assert_eq!(e4.depth(*flecs::ChildOf), 3);
 }
 
 #[test]
 fn entity_get_depth_w_type() {
     let world = World::new();
 
-    world.component::<Rel>().add::<flecs::Traversable>();
+    world.component::<Rel>().add(id::<flecs::Traversable>());
 
     let e1 = world.entity();
-    let e2 = world.entity().add_first::<Rel>(e1);
-    let e3 = world.entity().add_first::<Rel>(e2);
-    let e4 = world.entity().add_first::<Rel>(e3);
+    let e2 = world.entity().add((id::<Rel>(), e1));
+    let e3 = world.entity().add((id::<Rel>(), e2));
+    let e4 = world.entity().add((id::<Rel>(), e3));
 
-    assert_eq!(e1.depth::<Rel>(), 0);
-    assert_eq!(e2.depth::<Rel>(), 1);
-    assert_eq!(e3.depth::<Rel>(), 2);
-    assert_eq!(e4.depth::<Rel>(), 3);
+    assert_eq!(e1.depth(id::<Rel>()), 0);
+    assert_eq!(e2.depth(id::<Rel>()), 1);
+    assert_eq!(e3.depth(id::<Rel>()), 2);
+    assert_eq!(e4.depth(id::<Rel>()), 3);
 }
 
 #[test]
@@ -3810,15 +3792,15 @@ fn entity_insert_w_observer() {
 
     world
         .observer::<flecs::OnAdd, ()>()
-        .with::<Position>()
+        .with(id::<Position>())
         .each_entity(|e, _| {
             e.set(Velocity { x: 1, y: 2 });
         });
 
     let e = world.entity().set(Position { x: 10, y: 20 });
 
-    assert!(e.has::<Position>());
-    assert!(e.has::<Velocity>());
+    assert!(e.has(id::<Position>()));
+    assert!(e.has(id::<Velocity>()));
     e.get::<(&Position, &Velocity)>(|(pos, vel)| {
         assert_eq!(pos.x, 10);
         assert_eq!(pos.y, 20);
@@ -3849,14 +3831,14 @@ fn entity_world_lookup_not_recursive() {
 fn entity_override_sparse() {
     let world = World::new();
 
-    world.component::<Velocity>().add::<flecs::Sparse>();
+    world.component::<Velocity>().add(id::<flecs::Sparse>());
 
     let base = world.entity().set(Velocity { x: 1, y: 2 });
 
-    let e = world.entity().is_a_id(base);
+    let e = world.entity().is_a(base);
 
-    assert!(e.has::<Velocity>());
-    assert!(e.owns::<Velocity>());
+    assert!(e.has(id::<Velocity>()));
+    assert!(e.owns(id::<Velocity>()));
 
     e.get::<&Velocity>(|v| {
         assert_eq!(v.x, 1);
@@ -3868,14 +3850,14 @@ fn entity_override_sparse() {
 fn entity_delete_w_override_sparse() {
     let world = World::new();
 
-    world.component::<Velocity>().add::<flecs::Sparse>();
+    world.component::<Velocity>().add(id::<flecs::Sparse>());
 
     let base = world.entity().set(Velocity { x: 1, y: 2 });
 
-    let e = world.entity().is_a_id(base);
+    let e = world.entity().is_a(base);
 
-    assert!(e.has::<Velocity>());
-    assert!(e.owns::<Velocity>());
+    assert!(e.has(id::<Velocity>()));
+    assert!(e.owns(id::<Velocity>()));
 
     e.get::<&Velocity>(|v| {
         assert_eq!(v.x, 1);
@@ -3889,7 +3871,7 @@ fn entity_delete_w_override_sparse() {
 fn entity_iter_type() {
     let world = World::new();
 
-    let e = world.entity().add::<Position>().add::<Velocity>();
+    let e = world.entity().add(id::<Position>()).add(id::<Velocity>());
 
     let mut count = 0;
     let mut pos_found = false;
@@ -3897,10 +3879,10 @@ fn entity_iter_type() {
 
     for id in e.archetype().as_slice() {
         count += 1;
-        if *id == world.id_from::<Position>() {
+        if *id == world.id_view_from(flecs_ecs::core::id::<Position>()) {
             pos_found = true;
         }
-        if *id == world.id_from::<Velocity>() {
+        if *id == world.id_view_from(flecs_ecs::core::id::<Velocity>()) {
             velocity_found = true;
         }
     }

--- a/flecs_ecs/tests/flecs/eq_test.rs
+++ b/flecs_ecs/tests/flecs/eq_test.rs
@@ -14,7 +14,7 @@ fn entity_eq_test() {
     let e1_id: Id = e1_entity.into();
 
     let comp1 = world.component::<Position>();
-    let comp_untyped1 = world.component_untyped_from::<Position>();
+    let comp_untyped1 = world.component_untyped_from(id::<Position>());
 
     assert_eq!(e1_id, e1_id);
     assert_eq!(e1_id, e1_entity);
@@ -119,9 +119,9 @@ fn entity_eq_test() {
 fn table_eq_test() {
     let world = World::new();
 
-    let ent1 = world.entity().add::<Position>();
-    let ent2 = world.entity().add::<Position>();
-    let ent3 = world.entity().add::<Position>().add::<Velocity>();
+    let ent1 = world.entity().add(id::<Position>());
+    let ent2 = world.entity().add(id::<Position>());
+    let ent3 = world.entity().add(id::<Position>()).add(id::<Velocity>());
 
     let table1 = ent1.table().unwrap();
     let table2 = ent2.table().unwrap();
@@ -130,7 +130,7 @@ fn table_eq_test() {
     assert_eq!(table1, table2);
     assert_ne!(table1, table3);
 
-    ent1.add::<Velocity>();
+    ent1.add(id::<Velocity>());
     let table1 = ent1.table().unwrap();
 
     assert_ne!(table1, table2);

--- a/flecs_ecs/tests/flecs/flecs_docs_test.rs
+++ b/flecs_ecs/tests/flecs/flecs_docs_test.rs
@@ -546,8 +546,8 @@ fn flecs_query_docs_compile_test() {
 
     let q = world
         .query::<(&Position, &Npc)>()
-        .with_name("npc")
-        .with_name("Position")
+        .with("npc")
+        .with("Position")
         .build();
 
     let e = world.entity().add(id::<Position>()).add(id::<Velocity>());

--- a/flecs_ecs/tests/flecs/flecs_docs_test.rs
+++ b/flecs_ecs/tests/flecs/flecs_docs_test.rs
@@ -594,8 +594,8 @@ fn flecs_query_docs_compile_test() {
     let q = world
         .query::<()>()
         .term()
-        .set_first_name("Eats")
-        .set_second_name("Apples")
+        .set_first("Eats")
+        .set_second("Apples")
         .build();
 
     let q = world
@@ -776,11 +776,11 @@ fn flecs_query_docs_compile_test() {
         .without((id::<flecs::PredEq>(), id::<Bar>()))
         // $this == "Foo"
         .with(id::<flecs::PredEq>())
-        .set_second_name("Foo")
+        .set_second("Foo")
         .flags(sys::EcsIsName)
         // $this ~= "Fo"
         .with(id::<flecs::PredMatch>())
-        .set_second_name("Fo")
+        .set_second("Fo")
         .flags(sys::EcsIsName)
         .build();
 
@@ -890,9 +890,9 @@ fn flecs_query_docs_compile_test() {
     let q = world
         .query::<(&SimConfig, &SimTime)>()
         .term_at(0)
-        .set_src_name("cfg")
+        .set_src("cfg")
         .term_at(1)
-        .set_src_name("game")
+        .set_src("game")
         .build();
 
     let q = world
@@ -1038,9 +1038,9 @@ fn flecs_query_docs_compile_test() {
         .query::<()>()
         .with(id::<SpaceShip>())
         .with(id::<DockedTo>())
-        .set_second_name("$Location")
+        .set_second("$Location")
         .with(id::<Planet>())
-        .set_src_name("$Location")
+        .set_src("$Location")
         .build();
 
     let q = world
@@ -1208,7 +1208,7 @@ fn flecs_query_docs_compile_test() {
     let q = world
         .query::<()>()
         .with(id::<LocatedIn>())
-        .set_second_name("$Place")
+        .set_second("$Place")
         .build();
 
     #[derive(Component)]
@@ -1225,9 +1225,9 @@ fn flecs_query_docs_compile_test() {
     let q = world
         .query::<()>()
         .with(id::<LocatedIn>())
-        .set_second_name("$Place")
+        .set_second("$Place")
         .with(id::<City>())
-        .set_src_name("$Place")
+        .set_src("$Place")
         .build();
 
     let tree = world.entity();

--- a/flecs_ecs/tests/flecs/meta_macro_test.rs
+++ b/flecs_ecs/tests/flecs/meta_macro_test.rs
@@ -84,7 +84,7 @@ fn meta_struct() {
 
     let a = c.lookup("a");
     assert_ne!(a.id(), 0);
-    assert!(a.has::<flecs::meta::Member>());
+    assert!(a.has(id::<flecs::meta::Member>()));
 
     a.get::<&flecs::meta::Member>(|mem| {
         assert_eq!(mem.type_, flecs::meta::I32);
@@ -92,7 +92,7 @@ fn meta_struct() {
 
     let b = c.lookup("b");
     assert_ne!(b.id(), 0);
-    assert!(b.has::<flecs::meta::Member>());
+    assert!(b.has(id::<flecs::meta::Member>()));
 
     b.get::<&flecs::meta::Member>(|mem| {
         assert_eq!(mem.type_, flecs::meta::F32);
@@ -121,7 +121,7 @@ fn meta_nested_struct() {
 
     let a = n.lookup("a");
     assert_ne!(a.id(), 0);
-    assert!(a.has::<flecs::meta::Member>());
+    assert!(a.has(id::<flecs::meta::Member>()));
 
     a.get::<&flecs::meta::Member>(|mem| {
         assert_eq!(mem.type_, t.id());
@@ -154,7 +154,7 @@ fn meta_struct_w_portable_type() {
 
     let a = t.lookup("a");
     assert_ne!(a.id(), 0);
-    assert!(a.has::<flecs::meta::Member>());
+    assert!(a.has(id::<flecs::meta::Member>()));
 
     a.get::<&flecs::meta::Member>(|mem| {
         assert_eq!(mem.type_, flecs::meta::UPtr);
@@ -162,7 +162,7 @@ fn meta_struct_w_portable_type() {
 
     let b = t.lookup("b");
     assert_ne!(b.id(), 0);
-    assert!(b.has::<flecs::meta::Member>());
+    assert!(b.has(id::<flecs::meta::Member>()));
 
     // b.get::<&flecs::meta::Member>(|mem| {
     //     assert_eq!(mem.type_, flecs::meta::UPtr);
@@ -170,7 +170,7 @@ fn meta_struct_w_portable_type() {
 
     // let c = t.lookup("c");
     // assert_ne!(c.id(), 0);
-    // assert!(c.has::<flecs::meta::Member>());
+    // assert!(c.has(id::<flecs::meta::Member>()));
 
     // c.get::<&flecs::meta::Member>(|mem| {
     //     assert_eq!(mem.type_, flecs::meta::Entity);
@@ -178,7 +178,7 @@ fn meta_struct_w_portable_type() {
 
     // let d = t.lookup("d");
     // assert_!(d.id(), 0);
-    // assert!(d.has::<flecs::meta::Member>());
+    // assert!(d.has(id::<flecs::meta::Member>()));
 
     // d.get::<&flecs::meta::Member>(|mem| {
     //     assert_eq!(mem.type_, flecs::meta::Entity);
@@ -210,7 +210,7 @@ fn meta_partial_struct() {
 
     let xe = c.lookup("x");
     assert_ne!(xe.id(), 0);
-    assert!(xe.has::<flecs::meta::Member>());
+    assert!(xe.has(id::<flecs::meta::Member>()));
     xe.get::<&flecs::meta::Member>(|x| {
         assert_eq!(x.type_, flecs::meta::F32);
         assert_eq!(x.offset, 0);
@@ -238,7 +238,7 @@ fn meta_partial_struct_custom_offset() {
 
     let xe = c.lookup("y");
     assert_ne!(xe.id(), 0);
-    assert!(xe.has::<flecs::meta::Member>());
+    assert!(xe.has(id::<flecs::meta::Member>()));
     xe.get::<&flecs::meta::Member>(|x| {
         assert_eq!(x.type_, flecs::meta::F32);
         assert_eq!(x.offset, 4);
@@ -509,7 +509,7 @@ fn meta_struct_member_ptr() {
 
     let x = t.lookup("x");
     assert_ne!(x.id(), 0);
-    assert!(x.has::<flecs::meta::Member>());
+    assert!(x.has(id::<flecs::meta::Member>()));
     x.get::<&flecs::meta::Member>(|xm| {
         assert_eq!(xm.type_, flecs::meta::I32);
         assert_eq!(xm.offset, offset_of!(Test, x) as i32);
@@ -520,7 +520,7 @@ fn meta_struct_member_ptr() {
 
     let y = t2.lookup("y");
     assert_ne!(y.id(), 0);
-    assert!(y.has::<flecs::meta::Member>());
+    assert!(y.has(id::<flecs::meta::Member>()));
     y.get::<&flecs::meta::Member>(|ym| {
         assert_eq!(ym.type_, flecs::meta::F64);
         assert_eq!(ym.offset, offset_of!(Test2, y) as i32);
@@ -531,7 +531,7 @@ fn meta_struct_member_ptr() {
 
     let a = n.lookup("a");
     assert_ne!(a.id(), 0);
-    assert!(a.has::<flecs::meta::Member>());
+    assert!(a.has(id::<flecs::meta::Member>()));
     a.get::<&flecs::meta::Member>(|am| {
         assert_eq!(am.type_, t.id());
         let offset = offset_of!(Nested, a) as i32;
@@ -540,7 +540,7 @@ fn meta_struct_member_ptr() {
 
     let b = n.lookup("b");
     assert_ne!(b.id(), 0);
-    assert!(b.has::<flecs::meta::Member>());
+    assert!(b.has(id::<flecs::meta::Member>()));
     b.get::<&flecs::meta::Member>(|bm| {
         assert_eq!(bm.type_, t2.id());
         assert_eq!(bm.offset, offset_of!(Nested, b) as i32);
@@ -563,7 +563,7 @@ fn meta_struct_field_order() {
     assert_ne!(t.id(), 0);
     let a = t.lookup("a");
     assert_ne!(a.id(), 0);
-    assert!(a.has::<flecs::meta::Member>());
+    assert!(a.has(id::<flecs::meta::Member>()));
     a.get::<&flecs::meta::Member>(|am| {
         assert_eq!(am.type_, flecs::meta::U32);
         assert_eq!(am.offset, offset_of!(Test, a) as i32);
@@ -572,7 +572,7 @@ fn meta_struct_field_order() {
     assert_ne!(t.id(), 0);
     let b = t.lookup("b");
     assert_ne!(b.id(), 0);
-    assert!(b.has::<flecs::meta::Member>());
+    assert!(b.has(id::<flecs::meta::Member>()));
     b.get::<&flecs::meta::Member>(|bm| {
         assert_eq!(bm.type_, flecs::meta::I32);
         assert_eq!(bm.offset, offset_of!(Test, b) as i32);

--- a/flecs_ecs/tests/flecs/meta_test.rs
+++ b/flecs_ecs/tests/flecs/meta_test.rs
@@ -81,14 +81,14 @@ fn meta_struct() {
 
     let c = world
         .component::<Test>()
-        .member::<i32>("a")
-        .member::<f32>("b");
+        .member(id::<i32>(), "a")
+        .member(id::<f32>(), "b");
 
     assert_ne!(c.id(), 0);
 
     let a = c.lookup("a");
     assert_ne!(a.id(), 0);
-    assert!(a.has::<flecs::meta::Member>());
+    assert!(a.has(id::<flecs::meta::Member>()));
 
     a.get::<&flecs::meta::Member>(|mem| {
         assert_eq!(mem.type_, flecs::meta::I32);
@@ -96,7 +96,7 @@ fn meta_struct() {
 
     let b = c.lookup("b");
     assert_ne!(b.id(), 0);
-    assert!(b.has::<flecs::meta::Member>());
+    assert!(b.has(id::<flecs::meta::Member>()));
 
     b.get::<&flecs::meta::Member>(|mem| {
         assert_eq!(mem.type_, flecs::meta::F32);
@@ -117,15 +117,15 @@ fn meta_nested_struct() {
         a: Test,
     }
 
-    let t = world.component::<Test>().member::<i32>("x");
+    let t = world.component::<Test>().member(id::<i32>(), "x");
 
-    let n = world.component::<Nested>().member_id(t, "a");
+    let n = world.component::<Nested>().member(t, "a");
 
     assert_ne!(n.id(), 0);
 
     let a = n.lookup("a");
     assert_ne!(a.id(), 0);
-    assert!(a.has::<flecs::meta::Member>());
+    assert!(a.has(id::<flecs::meta::Member>()));
 
     a.get::<&flecs::meta::Member>(|mem| {
         assert_eq!(mem.type_, t.id());
@@ -195,16 +195,16 @@ fn meta_struct_w_portable_type() {
 
     let t = world
         .component::<Test>()
-        .member::<usize>("a")
-        .member::<usize>("b")
-        .member::<Entity>("c")
-        .member::<Entity>("d");
+        .member(id::<usize>(), "a")
+        .member(id::<usize>(), "b")
+        .member(id::<Entity>(), "c")
+        .member(id::<Entity>(), "d");
 
     assert_ne!(t.id(), 0);
 
     let a = t.lookup("a");
     assert_ne!(a.id(), 0);
-    assert!(a.has::<flecs::meta::Member>());
+    assert!(a.has(id::<flecs::meta::Member>()));
 
     a.get::<&flecs::meta::Member>(|mem| {
         assert_eq!(mem.type_, flecs::meta::UPtr);
@@ -212,7 +212,7 @@ fn meta_struct_w_portable_type() {
 
     let b = t.lookup("b");
     assert_ne!(b.id(), 0);
-    assert!(b.has::<flecs::meta::Member>());
+    assert!(b.has(id::<flecs::meta::Member>()));
 
     // b.get::<&flecs::meta::Member>(|mem| {
     //     assert_eq!(mem.type_, flecs::meta::UPtr);
@@ -220,7 +220,7 @@ fn meta_struct_w_portable_type() {
 
     // let c = t.lookup("c");
     // assert_ne!(c.id(), 0);
-    // assert!(c.has::<flecs::meta::Member>());
+    // assert!(c.has(id::<flecs::meta::Member>()));
 
     // c.get::<&flecs::meta::Member>(|mem| {
     //     assert_eq!(mem.type_, flecs::meta::Entity);
@@ -228,7 +228,7 @@ fn meta_struct_w_portable_type() {
 
     // let d = t.lookup("d");
     // assert_ne!(d.id(), 0);
-    // assert!(d.has::<flecs::meta::Member>());
+    // assert!(d.has(id::<flecs::meta::Member>()));
 
     // d.get::<&flecs::meta::Member>(|mem| {
     //     assert_eq!(mem.type_, flecs::meta::Entity);
@@ -249,7 +249,7 @@ fn meta_partial_struct() {
         x: f32,
     }
 
-    let c = world.component::<Position>().member::<f32>("x");
+    let c = world.component::<Position>().member(id::<f32>(), "x");
 
     assert_ne!(c.id(), 0);
 
@@ -260,7 +260,7 @@ fn meta_partial_struct() {
 
     let xe = c.lookup("x");
     assert_ne!(xe.id(), 0);
-    assert!(xe.has::<flecs::meta::Member>());
+    assert!(xe.has(id::<flecs::meta::Member>()));
     xe.get::<&flecs::meta::Member>(|x| {
         assert_eq!(x.type_, flecs::meta::F32);
         assert_eq!(x.offset, 0);
@@ -279,7 +279,7 @@ fn meta_partial_struct_custom_offset() {
 
     let c = world
         .component::<Position>()
-        .member::<f32>(("y", Count(1), offset_of!(Position, y)));
+        .member(id::<f32>(), ("y", Count(1), offset_of!(Position, y)));
 
     assert_ne!(c.id(), 0);
 
@@ -290,7 +290,7 @@ fn meta_partial_struct_custom_offset() {
 
     let xe = c.lookup("y");
     assert_ne!(xe.id(), 0);
-    assert!(xe.has::<flecs::meta::Member>());
+    assert!(xe.has(id::<flecs::meta::Member>()));
     xe.get::<&flecs::meta::Member>(|x| {
         assert_eq!(x.type_, flecs::meta::F32);
         assert_eq!(x.offset, 4);
@@ -359,11 +359,10 @@ fn meta_bitmask() {
         .bit("lettuce", Toppings::LETTUCE)
         .bit("tomato", Toppings::TOMATO);
 
-    world.component::<Sandwich>().member::<Toppings>((
-        "toppings",
-        Count(1),
-        offset_of!(Sandwich, toppings),
-    ));
+    world.component::<Sandwich>().member(
+        id::<Toppings>(),
+        ("toppings", Count(1), offset_of!(Sandwich, toppings)),
+    );
 
     // Create entity with Sandwich as usual
     let e = world.entity().set(Sandwich {
@@ -440,7 +439,9 @@ fn meta_world_ser_deser_flecs_entity() {
 
     let world = World::new();
 
-    world.component::<RustEntity>().member::<Entity>("entity");
+    world
+        .component::<RustEntity>()
+        .member(id::<Entity>(), "entity");
 
     let e1 = world.entity_named("ent1");
     let e2 = world
@@ -457,7 +458,9 @@ fn meta_world_ser_deser_flecs_entity() {
 
     let world = World::new();
 
-    world.component::<RustEntity>().member::<Entity>("entity");
+    world
+        .component::<RustEntity>()
+        .member(id::<Entity>(), "entity");
 
     world.from_json_world(json.as_str(), None);
 
@@ -480,7 +483,9 @@ fn meta_new_world_ser_deser_flecs_entity() {
 
     let world = World::new();
 
-    world.component::<RustEntity>().member::<Entity>("entity");
+    world
+        .component::<RustEntity>()
+        .member(id::<Entity>(), "entity");
 
     let e1 = world.entity_named("ent1");
     let e2 = world
@@ -497,7 +502,9 @@ fn meta_new_world_ser_deser_flecs_entity() {
 
     let world = World::new();
 
-    world.component::<RustEntity>().member::<Entity>("entity");
+    world
+        .component::<RustEntity>()
+        .member(id::<Entity>(), "entity");
 
     world.from_json_world(json.as_str(), None);
 
@@ -526,7 +533,9 @@ fn meta_new_world_ser_deser_empty_flecs_entity() {
 
     let world = World::new();
 
-    world.component::<RustEntity>().member::<Entity>("entity");
+    world
+        .component::<RustEntity>()
+        .member(id::<Entity>(), "entity");
 
     let e1 = Entity::null();
     let e2 = world.entity_named("ent2").set(RustEntity { entity: e1 });
@@ -541,7 +550,9 @@ fn meta_new_world_ser_deser_empty_flecs_entity() {
 
     let world = World::new();
 
-    world.component::<RustEntity>().member::<Entity>("entity");
+    world
+        .component::<RustEntity>()
+        .member(id::<Entity>(), "entity");
 
     world.from_json_world(json.as_str(), None);
 
@@ -650,13 +661,13 @@ fn meta_enum_w_bits() {
 
     world
         .component::<EnumWithBitsStruct>()
-        .member::<EnumWithBits>("bits");
+        .member(id::<EnumWithBits>(), "bits");
 
     for _ in 0..30 {
         world
             .entity()
-            .child_of_id(world.entity())
-            .add::<EnumWithBitsStruct>();
+            .child_of(world.entity())
+            .add(id::<EnumWithBitsStruct>());
     }
 
     let q = world.new_query::<&EnumWithBitsStruct>();
@@ -676,14 +687,14 @@ fn meta_value_range() {
 
     let c = world
         .component::<Position>()
-        .member::<f32>("x")
+        .member(id::<f32>(), "x")
         .range(-1.0, 1.0)
-        .member::<f32>("y")
+        .member(id::<f32>(), "y")
         .range(-2.0, 2.0);
 
     let x = c.lookup("x");
     assert_ne!(x.id(), 0);
-    assert!(x.has::<flecs::meta::MemberRanges>());
+    assert!(x.has(id::<flecs::meta::MemberRanges>()));
 
     x.get::<&flecs::meta::MemberRanges>(|ranges| {
         assert_eq!(ranges.value.min, -1.0);
@@ -692,7 +703,7 @@ fn meta_value_range() {
 
     let y = c.lookup("y");
     assert_ne!(y.id(), 0);
-    assert!(y.has::<flecs::meta::MemberRanges>());
+    assert!(y.has(id::<flecs::meta::MemberRanges>()));
 
     y.get::<&flecs::meta::MemberRanges>(|ranges| {
         assert_eq!(ranges.value.min, -2.0);
@@ -712,14 +723,14 @@ fn meta_warning_range() {
 
     let c = world
         .component::<Position>()
-        .member::<f32>("x")
+        .member(id::<f32>(), "x")
         .warning_range(-1.0, 1.0)
-        .member::<f32>("y")
+        .member(id::<f32>(), "y")
         .warning_range(-2.0, 2.0);
 
     let x = c.lookup("x");
     assert_ne!(x.id(), 0);
-    assert!(x.has::<flecs::meta::MemberRanges>());
+    assert!(x.has(id::<flecs::meta::MemberRanges>()));
 
     x.get::<&flecs::meta::MemberRanges>(|range| {
         assert_eq!(range.warning.min, -1.0);
@@ -728,7 +739,7 @@ fn meta_warning_range() {
 
     let y = c.lookup("y");
     assert_ne!(y.id(), 0);
-    assert!(y.has::<flecs::meta::MemberRanges>());
+    assert!(y.has(id::<flecs::meta::MemberRanges>()));
 
     y.get::<&flecs::meta::MemberRanges>(|range| {
         assert_eq!(range.warning.min, -2.0);
@@ -748,14 +759,14 @@ fn meta_error_range() {
 
     let c = world
         .component::<Position>()
-        .member::<f32>("x")
+        .member(id::<f32>(), "x")
         .error_range(-1.0, 1.0)
-        .member::<f32>("y")
+        .member(id::<f32>(), "y")
         .error_range(-2.0, 2.0);
 
     let x = c.lookup("x");
     assert_ne!(x.id(), 0);
-    assert!(x.has::<flecs::meta::MemberRanges>());
+    assert!(x.has(id::<flecs::meta::MemberRanges>()));
 
     x.get::<&flecs::meta::MemberRanges>(|range| {
         assert_eq!(range.error.min, -1.0);
@@ -764,7 +775,7 @@ fn meta_error_range() {
 
     let y = c.lookup("y");
     assert_ne!(y.id(), 0);
-    assert!(y.has::<flecs::meta::MemberRanges>());
+    assert!(y.has(id::<flecs::meta::MemberRanges>()));
 
     y.get::<&flecs::meta::MemberRanges>(|range| {
         assert_eq!(range.error.min, -2.0);
@@ -793,21 +804,21 @@ fn meta_struct_member_ptr() {
         b: [Test2; 2],
     }
 
-    let t = world.component::<Test>().member::<i32>("x");
+    let t = world.component::<Test>().member(id::<i32>(), "x");
 
-    let t2 = world.component::<Test2>().member::<f64>("y");
+    let t2 = world.component::<Test2>().member(id::<f64>(), "y");
 
     let n = world
         .component::<Nested>()
-        .member::<Test>(("a", Count(1), offset_of!(Nested, a)))
-        .member_id(t2, ("b", Count(2), offset_of!(Nested, b)));
+        .member(id::<Test>(), ("a", Count(1), offset_of!(Nested, a)))
+        .member(t2, ("b", Count(2), offset_of!(Nested, b)));
 
     //validate Test #1
     assert_ne!(t.id(), 0);
 
     let x = t.lookup("x");
     assert_ne!(x.id(), 0);
-    assert!(x.has::<flecs::meta::Member>());
+    assert!(x.has(id::<flecs::meta::Member>()));
     x.get::<&flecs::meta::Member>(|xm| {
         assert_eq!(xm.type_, flecs::meta::I32);
         assert_eq!(xm.offset, offset_of!(Test, x) as i32);
@@ -818,7 +829,7 @@ fn meta_struct_member_ptr() {
 
     let y = t2.lookup("y");
     assert_ne!(y.id(), 0);
-    assert!(y.has::<flecs::meta::Member>());
+    assert!(y.has(id::<flecs::meta::Member>()));
     y.get::<&flecs::meta::Member>(|ym| {
         assert_eq!(ym.type_, flecs::meta::F64);
         assert_eq!(ym.offset, offset_of!(Test2, y) as i32);
@@ -829,7 +840,7 @@ fn meta_struct_member_ptr() {
 
     let a = n.lookup("a");
     assert_ne!(a.id(), 0);
-    assert!(a.has::<flecs::meta::Member>());
+    assert!(a.has(id::<flecs::meta::Member>()));
     a.get::<&flecs::meta::Member>(|am| {
         assert_eq!(am.type_, t.id());
         let offset = offset_of!(Nested, a) as i32;
@@ -838,7 +849,7 @@ fn meta_struct_member_ptr() {
 
     let b = n.lookup("b");
     assert_ne!(b.id(), 0);
-    assert!(b.has::<flecs::meta::Member>());
+    assert!(b.has(id::<flecs::meta::Member>()));
     b.get::<&flecs::meta::Member>(|bm| {
         assert_eq!(bm.type_, t2.id());
         assert_eq!(bm.offset, offset_of!(Nested, b) as i32);
@@ -858,7 +869,7 @@ fn meta_component_as_array() {
 
     let c = world.component::<Position>().array::<f32>(2);
 
-    assert!(c.has::<flecs::meta::Array>());
+    assert!(c.has(id::<flecs::meta::Array>()));
 
     c.get::<&flecs::meta::Array>(|ptr| {
         assert_eq!(ptr.type_, world.component_id::<f32>());

--- a/flecs_ecs/tests/flecs/meta_test_rust.rs
+++ b/flecs_ecs/tests/flecs/meta_test_rust.rs
@@ -16,11 +16,11 @@ fn meta_struct_field_order() {
 
     world
         .component::<Test>()
-        .member::<u32>(("a", Count(1), offset_of!(Test, a)))
-        .member::<i64>(("b", Count(1), offset_of!(Test, b)))
-        .member::<i16>(("c", Count(1), offset_of!(Test, c)))
-        .member::<i8>(("d", Count(1), offset_of!(Test, d)))
-        .member::<i64>(("e", Count(1), offset_of!(Test, e)));
+        .member(id::<u32>(), ("a", Count(1), offset_of!(Test, a)))
+        .member(id::<i64>(), ("b", Count(1), offset_of!(Test, b)))
+        .member(id::<i16>(), ("c", Count(1), offset_of!(Test, c)))
+        .member(id::<i8>(), ("d", Count(1), offset_of!(Test, d)))
+        .member(id::<i64>(), ("e", Count(1), offset_of!(Test, e)));
 
     let e = world.entity().set(Test {
         a: 10,

--- a/flecs_ecs/tests/flecs/meta_trait_test.rs
+++ b/flecs_ecs/tests/flecs/meta_trait_test.rs
@@ -97,7 +97,11 @@ fn test_enum() {
     // Register the TypeWithEnum component
     world.component::<TypeWithEnum>().meta();
 
-    assert!(world.component::<TypeWithEnum>().has::<flecs::meta::Type>());
+    assert!(
+        world
+            .component::<TypeWithEnum>()
+            .has(id::<flecs::meta::Type>())
+    );
 
     // Create a new entity
     let e = world
@@ -134,7 +138,7 @@ fn test_type_w_string() {
     assert!(
         world
             .component::<TypeWithString>()
-            .has::<flecs::meta::Type>()
+            .has(id::<flecs::meta::Type>())
     );
 
     // Create a new entity
@@ -167,7 +171,7 @@ fn test_type_w_vec_string() {
     assert!(
         world
             .component::<TypeWithVecString>()
-            .has::<flecs::meta::Type>()
+            .has(id::<flecs::meta::Type>())
     );
 
     // Create a new entity

--- a/flecs_ecs/tests/flecs/observer_rust_test.rs
+++ b/flecs_ecs/tests/flecs/observer_rust_test.rs
@@ -11,7 +11,7 @@ fn observer_panic_on_add_1() {
 
     world
         .observer::<flecs::OnAdd, ()>()
-        .with::<&Position>()
+        .with(id::<&Position>())
         .each_entity(|_, _| {});
 
     world.entity().set(Position { x: 10, y: 20 });
@@ -24,7 +24,7 @@ fn observer_panic_on_add_2() {
 
     world
         .observer::<flecs::OnAdd, ()>()
-        .with::<&mut Position>()
+        .with(id::<&mut Position>())
         .each_entity(|_, _| {});
 
     world.entity().set(Position { x: 10, y: 20 });

--- a/flecs_ecs/tests/flecs/observer_test.rs
+++ b/flecs_ecs/tests/flecs/observer_test.rs
@@ -16,8 +16,8 @@ fn observer_2_terms_on_add() {
 
     world
         .observer::<flecs::OnAdd, ()>()
-        .with::<Position>()
-        .with::<Velocity>()
+        .with(id::<Position>())
+        .with(id::<Velocity>())
         .each_entity(|e, _| {
             let world = e.world();
             world.get::<&mut Count>(|count| {
@@ -70,11 +70,11 @@ fn observer_2_terms_on_remove() {
     world.get::<&mut Count>(|count| {
         assert_eq!(count, 0);
     });
-    e.remove::<Velocity>();
+    e.remove(id::<Velocity>());
     world.get::<&mut Count>(|count| {
         assert_eq!(count, 1);
     });
-    e.remove::<Position>();
+    e.remove(id::<Position>());
     world.get::<&mut Count>(|count| {
         assert_eq!(count, 1);
     });
@@ -124,36 +124,36 @@ fn observer_10_terms() {
 
     world
         .observer::<flecs::OnAdd, ()>()
-        .with::<TagA>()
-        .with::<TagB>()
-        .with::<TagC>()
-        .with::<TagD>()
-        .with::<TagE>()
-        .with::<TagF>()
-        .with::<TagG>()
-        .with::<TagH>()
-        .with::<TagI>()
-        .with::<TagJ>()
+        .with(id::<TagA>())
+        .with(id::<TagB>())
+        .with(id::<TagC>())
+        .with(id::<TagD>())
+        .with(id::<TagE>())
+        .with(id::<TagF>())
+        .with(id::<TagG>())
+        .with(id::<TagH>())
+        .with(id::<TagI>())
+        .with(id::<TagJ>())
         .each_iter(move |it, _i, _| {
             let world = it.world();
             assert_eq!(it.count(), 1);
-            assert!(it.entity(0) == e_id);
+            assert!(it.entity(0).unwrap() == e_id);
             assert_eq!(it.field_count(), 10);
             world.get::<&mut Count>(|count| {
                 count.0 += 1;
             });
         });
 
-    e.add::<TagA>()
-        .add::<TagB>()
-        .add::<TagC>()
-        .add::<TagD>()
-        .add::<TagE>()
-        .add::<TagF>()
-        .add::<TagG>()
-        .add::<TagH>()
-        .add::<TagI>()
-        .add::<TagJ>();
+    e.add(id::<TagA>())
+        .add(id::<TagB>())
+        .add(id::<TagC>())
+        .add(id::<TagD>())
+        .add(id::<TagE>())
+        .add(id::<TagF>())
+        .add(id::<TagG>())
+        .add(id::<TagH>())
+        .add(id::<TagI>())
+        .add(id::<TagJ>());
 
     world.get::<&mut Count>(|count| {
         assert_eq!(count, 1);
@@ -171,52 +171,52 @@ fn observer_16_terms() {
 
     world
         .observer::<flecs::OnAdd, ()>()
-        .with::<TagA>()
-        .with::<TagB>()
-        .with::<TagC>()
-        .with::<TagD>()
-        .with::<TagE>()
-        .with::<TagF>()
-        .with::<TagG>()
-        .with::<TagH>()
-        .with::<TagI>()
-        .with::<TagJ>()
-        .with::<TagK>()
-        .with::<TagL>()
-        .with::<TagM>()
-        .with::<TagN>()
-        .with::<TagO>()
-        .with::<TagP>()
+        .with(id::<TagA>())
+        .with(id::<TagB>())
+        .with(id::<TagC>())
+        .with(id::<TagD>())
+        .with(id::<TagE>())
+        .with(id::<TagF>())
+        .with(id::<TagG>())
+        .with(id::<TagH>())
+        .with(id::<TagI>())
+        .with(id::<TagJ>())
+        .with(id::<TagK>())
+        .with(id::<TagL>())
+        .with(id::<TagM>())
+        .with(id::<TagN>())
+        .with(id::<TagO>())
+        .with(id::<TagP>())
         .each_iter(move |it, _i, _| {
             let world = it.world();
             assert_eq!(it.count(), 1);
-            assert!(it.entity(0) == e_id);
+            assert!(it.entity(0).unwrap() == e_id);
             assert_eq!(it.field_count(), 16);
             world.get::<&mut Count>(|count| {
                 count.0 += 1;
             });
         });
 
-    e.add::<TagA>()
-        .add::<TagB>()
-        .add::<TagC>()
-        .add::<TagD>()
-        .add::<TagE>()
-        .add::<TagF>()
-        .add::<TagG>()
-        .add::<TagH>()
-        .add::<TagI>()
-        .add::<TagJ>()
-        .add::<TagK>()
-        .add::<TagL>()
-        .add::<TagM>()
-        .add::<TagN>()
-        .add::<TagO>()
-        .add::<TagP>()
-        .add::<TagQ>()
-        .add::<TagR>()
-        .add::<TagS>()
-        .add::<TagT>();
+    e.add(id::<TagA>())
+        .add(id::<TagB>())
+        .add(id::<TagC>())
+        .add(id::<TagD>())
+        .add(id::<TagE>())
+        .add(id::<TagF>())
+        .add(id::<TagG>())
+        .add(id::<TagH>())
+        .add(id::<TagI>())
+        .add(id::<TagJ>())
+        .add(id::<TagK>())
+        .add(id::<TagL>())
+        .add(id::<TagM>())
+        .add(id::<TagN>())
+        .add(id::<TagO>())
+        .add(id::<TagP>())
+        .add(id::<TagQ>())
+        .add(id::<TagR>())
+        .add(id::<TagS>())
+        .add(id::<TagT>());
 
     world.get::<&mut Count>(|count| {
         assert_eq!(count, 1);
@@ -247,10 +247,10 @@ fn observer_2_entities_iter() {
                     world.get::<&mut Count>(|count| {
                         count.0 += 1;
                     });
-                    if it.entity(i) == e1_id {
+                    if it.entity(i).unwrap() == e1_id {
                         assert_eq!(p[i].x, 10);
                         assert_eq!(p[i].y, 20);
-                    } else if it.entity(i) == e2_id {
+                    } else if it.entity(i).unwrap() == e2_id {
                         assert_eq!(p[i].x, 30);
                         assert_eq!(p[i].y, 40);
                     } else {
@@ -258,7 +258,7 @@ fn observer_2_entities_iter() {
                     }
 
                     world.get::<&mut LastEntity>(|last| {
-                        last.0 = it.entity(i).id();
+                        last.0 = it.entity(i).unwrap().id();
                     });
                 }
             }
@@ -299,17 +299,17 @@ fn observer_2_entities_table_column() {
         .run(move |mut it| {
             let world = it.world();
             while it.next() {
-                let table_range = it.range().unwrap();
+                let mut table_range = it.range().unwrap();
                 let p = table_range.get_mut::<Position>().unwrap();
 
                 for i in it.iter() {
                     world.get::<&mut Count>(|count| {
                         count.0 += 1;
                     });
-                    if it.entity(i) == e1_id {
+                    if it.entity(i).unwrap() == e1_id {
                         assert_eq!(p[i].x, 10);
                         assert_eq!(p[i].y, 20);
-                    } else if it.entity(i) == e2_id {
+                    } else if it.entity(i).unwrap() == e2_id {
                         assert_eq!(p[i].x, 30);
                         assert_eq!(p[i].y, 40);
                     } else {
@@ -317,7 +317,7 @@ fn observer_2_entities_table_column() {
                     }
 
                     world.get::<&mut LastEntity>(|last| {
-                        last.0 = it.entity(i).id();
+                        last.0 = it.entity(i).unwrap().id();
                     });
                 }
             }
@@ -402,7 +402,7 @@ fn observer_create_w_no_template_args() {
 
     world
         .observer::<flecs::OnAdd, ()>()
-        .with::<Position>()
+        .with(id::<Position>())
         .each_entity(move |e, _| {
             let world = e.world();
             assert!(e == e1_id);
@@ -422,9 +422,9 @@ fn observer_create_w_no_template_args() {
 fn observer_yield_existing() {
     let world = World::new();
 
-    let e1 = world.entity().add::<TagA>();
-    let e2 = world.entity().add::<TagA>();
-    let e3 = world.entity().add::<TagA>().add::<TagB>();
+    let e1 = world.entity().add(id::<TagA>());
+    let e2 = world.entity().add(id::<TagA>());
+    let e3 = world.entity().add(id::<TagA>()).add(id::<TagB>());
 
     let e1_id = e1.id();
     let e2_id = e2.id();
@@ -433,12 +433,12 @@ fn observer_yield_existing() {
     world.set(Count(0));
     world
         .observer::<flecs::OnAdd, ()>()
-        .with::<TagA>()
+        .with(id::<TagA>())
         .yield_existing()
         .run(move |mut it| {
             while it.next() {
                 for i in it.iter() {
-                    let e = it.entity(i);
+                    let e = it.entity(i).unwrap();
                     let world = e.world();
                     world.get::<&mut Count>(|count| {
                         if e == e1_id {
@@ -462,22 +462,26 @@ fn observer_yield_existing() {
 fn observer_yield_existing_2_terms() {
     let world = World::new();
 
-    let e1 = world.entity().add::<TagA>().add::<TagB>();
-    let e2 = world.entity().add::<TagA>().add::<TagB>();
-    let e3 = world.entity().add::<TagA>().add::<TagB>().add::<TagC>();
+    let e1 = world.entity().add(id::<TagA>()).add(id::<TagB>());
+    let e2 = world.entity().add(id::<TagA>()).add(id::<TagB>());
+    let e3 = world
+        .entity()
+        .add(id::<TagA>())
+        .add(id::<TagB>())
+        .add(id::<TagC>());
 
     let e1_id = e1.id();
     let e2_id = e2.id();
     let e3_id = e3.id();
 
-    world.entity().add::<TagA>();
-    world.entity().add::<TagB>();
+    world.entity().add(id::<TagA>());
+    world.entity().add(id::<TagB>());
 
     world.set(Count(0));
     world
         .observer::<flecs::OnAdd, ()>()
-        .with::<TagA>()
-        .with::<TagB>()
+        .with(id::<TagA>())
+        .with(id::<TagB>())
         .yield_existing()
         .each_entity(move |e, _| {
             let world = e.world();
@@ -503,7 +507,7 @@ fn observer_on_add() {
     world.set(Count(0));
     world
         .observer::<flecs::OnAdd, ()>()
-        .with::<Position>()
+        .with(id::<Position>())
         .each_entity(|e, _| {
             let world = e.world();
             world.get::<&mut Count>(|count| {
@@ -511,7 +515,7 @@ fn observer_on_add() {
             });
         });
 
-    world.entity().add::<Position>();
+    world.entity().add(id::<Position>());
 
     world.get::<&mut Count>(|count| {
         assert_eq!(count, 1);
@@ -529,13 +533,13 @@ fn observer_on_remove() {
                 count.0 += 1;
             });
         });
-    let e = world.entity().add::<Position>();
+    let e = world.entity().add(id::<Position>());
 
     world.get::<&mut Count>(|count| {
         assert_eq!(count, 0);
     });
 
-    e.remove::<Position>();
+    e.remove(id::<Position>());
 
     world.get::<&mut Count>(|count| {
         assert_eq!(count, 1);
@@ -548,7 +552,7 @@ fn observer_on_add_tag_action() {
     world.set(Count(0));
     world
         .observer::<flecs::OnAdd, ()>()
-        .with::<TagA>()
+        .with(id::<TagA>())
         .run(|mut it| {
             let world = it.world();
             while it.next() {
@@ -557,7 +561,7 @@ fn observer_on_add_tag_action() {
                 });
             }
         });
-    world.entity().add::<TagA>();
+    world.entity().add(id::<TagA>());
 
     world.get::<&mut Count>(|count| {
         assert_eq!(count, 1);
@@ -570,7 +574,7 @@ fn observer_on_add_tag_iter() {
     world.set(Count(0));
     world
         .observer::<flecs::OnAdd, ()>()
-        .with::<TagA>()
+        .with(id::<TagA>())
         .run(|mut it| {
             let world = it.world();
             while it.next() {
@@ -579,7 +583,7 @@ fn observer_on_add_tag_iter() {
                 });
             }
         });
-    world.entity().add::<TagA>();
+    world.entity().add(id::<TagA>());
     world.get::<&mut Count>(|count| {
         assert_eq!(count, 1);
     });
@@ -591,7 +595,7 @@ fn observer_on_add_tag_each() {
     world.set(Count(0));
     world
         .observer::<flecs::OnAdd, ()>()
-        .with::<TagA>()
+        .with(id::<TagA>())
         .run(|mut it| {
             while it.next() {
                 for _ in it.iter() {
@@ -601,7 +605,7 @@ fn observer_on_add_tag_each() {
                 }
             }
         });
-    world.entity().add::<TagA>();
+    world.entity().add(id::<TagA>());
     world.get::<&mut Count>(|count| {
         assert_eq!(count, 1);
     });
@@ -620,11 +624,11 @@ fn observer_on_add_expr() {
                 count.0 += 1;
             });
         });
-    let e = world.entity().add::<Tag>();
+    let e = world.entity().add(id::<Tag>());
     world.get::<&mut Count>(|count| {
         assert_eq!(count, 1);
     });
-    e.remove::<Tag>();
+    e.remove(id::<Tag>());
     world.get::<&mut Count>(|count| {
         assert_eq!(count, 1);
     });
@@ -638,8 +642,8 @@ fn observer_observer_w_filter_term() {
     world.set(Count(0));
     world
         .observer::<flecs::OnAdd, ()>()
-        .with_id(tag_a)
-        .with_id(tag_b)
+        .with(tag_a)
+        .with(tag_b)
         .filter()
         .each_entity(|e, _| {
             e.world().get::<&mut Count>(|count| {
@@ -652,25 +656,25 @@ fn observer_observer_w_filter_term() {
         assert_eq!(count, 0);
     });
 
-    e.add_id(tag_b);
+    e.add(tag_b);
 
     world.get::<&mut Count>(|count| {
         assert_eq!(count, 0);
     });
 
-    e.add_id(tag_a);
+    e.add(tag_a);
 
     world.get::<&mut Count>(|count| {
         assert_eq!(count, 1);
     });
 
-    e.remove_id(tag_b);
+    e.remove(tag_b);
 
     world.get::<&mut Count>(|count| {
         assert_eq!(count, 1);
     });
 
-    e.add_id(tag_b);
+    e.add(tag_b);
 
     world.get::<&mut Count>(|count| {
         assert_eq!(count, 1);
@@ -682,7 +686,7 @@ fn observer_observer_w_filter_term() {
         assert_eq!(count, 1);
     });
 
-    e.add_id(tag_a);
+    e.add(tag_a);
 
     world.get::<&mut Count>(|count| {
         assert_eq!(count, 1);
@@ -696,7 +700,7 @@ fn observer_run_callback() {
     world.set(Count(0));
     world
         .observer::<flecs::OnAdd, ()>()
-        .with::<Position>()
+        .with(id::<Position>())
         .run_each_entity(
             |mut it| {
                 while it.next() {
@@ -714,7 +718,7 @@ fn observer_run_callback() {
         assert_eq!(count, 0);
     });
 
-    e.add::<Position>();
+    e.add(id::<Position>());
 
     world.get::<&mut Count>(|count| {
         assert_eq!(count, 1);
@@ -869,7 +873,7 @@ fn observer_on_add_pair_singleton() {
     let tgt = world.entity();
     world
         .observer::<flecs::OnSet, ()>()
-        .with_first::<Position>(tgt)
+        .with((id::<Position>(), tgt))
         .singleton()
         .run(|mut it| {
             let world = it.world();
@@ -928,7 +932,7 @@ fn observer_on_add_with_pair_singleton() {
     let tgt = world.entity();
     world
         .observer::<flecs::OnSet, ()>()
-        .with_first::<Position>(tgt)
+        .with((id::<Position>(), tgt))
         .singleton()
         .each_iter(|it, _, _| {
             it.world().get::<&mut Count>(|count| {
@@ -949,18 +953,18 @@ fn observer_add_in_yield_existing() {
     let e3 = world.entity().set(Position::default());
     world
         .observer::<flecs::OnAdd, ()>()
-        .with::<Position>()
+        .with(id::<Position>())
         .yield_existing()
         .each_entity(|e, _| {
-            e.add::<Velocity>();
+            e.add(id::<Velocity>());
         });
 
-    assert!(e1.has::<Position>());
-    assert!(e1.has::<Velocity>());
-    assert!(e2.has::<Position>());
-    assert!(e2.has::<Velocity>());
-    assert!(e3.has::<Position>());
-    assert!(e3.has::<Velocity>());
+    assert!(e1.has(id::<Position>()));
+    assert!(e1.has(id::<Velocity>()));
+    assert!(e2.has(id::<Position>()));
+    assert!(e2.has(id::<Velocity>()));
+    assert!(e3.has(id::<Position>()));
+    assert!(e3.has(id::<Velocity>()));
 }
 
 #[test]
@@ -971,21 +975,21 @@ fn observer_add_in_yield_existing_multi() {
     let e3 = world.entity().set(Position::default()).set(Mass::default());
     world
         .observer::<flecs::OnAdd, ()>()
-        .with::<Position>()
-        .with::<Mass>()
+        .with(id::<Position>())
+        .with(id::<Mass>())
         .yield_existing()
         .each_entity(|e, _| {
-            e.add::<Velocity>();
+            e.add(id::<Velocity>());
         });
-    assert!(e1.has::<Position>());
-    assert!(e1.has::<Mass>());
-    assert!(e1.has::<Velocity>());
-    assert!(e2.has::<Position>());
-    assert!(e2.has::<Mass>());
-    assert!(e2.has::<Velocity>());
-    assert!(e3.has::<Position>());
-    assert!(e3.has::<Mass>());
-    assert!(e3.has::<Velocity>());
+    assert!(e1.has(id::<Position>()));
+    assert!(e1.has(id::<Mass>()));
+    assert!(e1.has(id::<Velocity>()));
+    assert!(e2.has(id::<Position>()));
+    assert!(e2.has(id::<Mass>()));
+    assert!(e2.has(id::<Velocity>()));
+    assert!(e3.has(id::<Position>()));
+    assert!(e3.has(id::<Mass>()));
+    assert!(e3.has(id::<Velocity>()));
 }
 
 #[test]
@@ -1007,8 +1011,8 @@ fn observer_name_from_root() {
 //     struct Tag;
 
 //     let world = World::new();
-//     world.observer::<flecs::OnAdd, ()>().with::<Tag>().run(|_| panic!());
-//     world.add::<Tag>();
+//     world.observer::<flecs::OnAdd, ()>().with(id::<Tag>()).run(|_| panic!());
+//     world.add(id::<Tag>());
 // }
 
 #[test]

--- a/flecs_ecs/tests/flecs/query_builder_test.rs
+++ b/flecs_ecs/tests/flecs/query_builder_test.rs
@@ -3614,7 +3614,7 @@ fn query_builder_with_name() {
     let q = world
         .query::<()>()
         .with(id::<&Position>())
-        .with_name("flecs.common_test.Velocity")
+        .with("flecs.common_test.Velocity")
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
@@ -3703,7 +3703,7 @@ fn query_builder_with_pair_name() {
     let q = world
         .query::<()>()
         .with(id::<&Position>())
-        .with_names("likes", "Apples")
+        .with(("likes", "Apples"))
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
@@ -3797,7 +3797,7 @@ fn query_builder_with_pair_name_component_id() {
     let q = world
         .query::<()>()
         .with(id::<Position>())
-        .with_name_first("Likes", apples)
+        .with(("Likes", apples))
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
@@ -3829,7 +3829,7 @@ fn query_builder_with_pair_component_name() {
     let q = world
         .query::<()>()
         .with(id::<&Position>())
-        .with_name_second(id::<Likes>(), "Apples")
+        .with((id::<Likes>(), "Apples"))
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
@@ -3923,7 +3923,7 @@ fn query_builder_without_name() {
     let q = world
         .query::<()>()
         .with(world.id_view_from(id::<Position>()))
-        .without_name("flecs.common_test.Velocity")
+        .without("flecs.common_test.Velocity")
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
@@ -4012,7 +4012,7 @@ fn query_builder_without_pair_name() {
     let q = world
         .query::<()>()
         .with(id::<&Position>())
-        .without_names("likes", "Apples")
+        .without(("likes", "Apples"))
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
@@ -4105,7 +4105,7 @@ fn query_builder_without_pair_component_name() {
     let q = world
         .query::<()>()
         .with(id::<&Position>())
-        .without_name_second(id::<Likes>(), "Apples")
+        .without((id::<Likes>(), "Apples"))
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
@@ -4138,7 +4138,7 @@ fn query_builder_without_pair_name_component_id() {
     let q = world
         .query::<()>()
         .with(id::<&Position>())
-        .without_name_first("Likes", apples)
+        .without(("Likes", apples))
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
@@ -4222,7 +4222,7 @@ fn query_builder_write_name() {
     let q = world
         .query::<()>()
         .with(id::<&Position>())
-        .write_name("flecs.common_test.Position")
+        .write("flecs.common_test.Position")
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
@@ -4279,7 +4279,7 @@ fn query_builder_write_pair_name() {
     let q = world
         .query::<()>()
         .with(id::<&Position>())
-        .write_names("likes", "Apples")
+        .write(("likes", "Apples"))
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
@@ -4334,7 +4334,7 @@ fn query_builder_write_pair_component_name() {
     let q = world
         .query::<()>()
         .with(id::<&Position>())
-        .write_name_second(id::<Likes>(), "Apples")
+        .write((id::<Likes>(), "Apples"))
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
@@ -4394,7 +4394,7 @@ fn query_builder_read_name() {
     let q = world
         .query::<()>()
         .with(id::<&Position>())
-        .read_name("flecs.common_test.Position")
+        .read("flecs.common_test.Position")
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
@@ -4451,7 +4451,7 @@ fn query_builder_read_pair_name() {
     let q = world
         .query::<()>()
         .with(id::<&Position>())
-        .read_names("likes", "Apples")
+        .read(("likes", "Apples"))
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
@@ -4506,7 +4506,7 @@ fn query_builder_read_pair_component_name() {
     let q = world
         .query::<()>()
         .with(id::<&Position>())
-        .read_name_second(id::<Likes>(), "Apples")
+        .read((id::<Likes>(), "Apples"))
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
@@ -4922,7 +4922,7 @@ fn query_builder_term_w_second_var_string() {
 
     let r = world
         .query::<()>()
-        .with_name_second(foo_, "$Var")
+        .with((foo_, "$Var"))
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
@@ -4948,7 +4948,7 @@ fn query_builder_term_type_w_second_var_string() {
 
     let r = world
         .query::<()>()
-        .with_name_second(id::<Foo>(), "$Var")
+        .with((id::<Foo>(), "$Var"))
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 

--- a/flecs_ecs/tests/flecs/query_builder_test.rs
+++ b/flecs_ecs/tests/flecs/query_builder_test.rs
@@ -2155,7 +2155,7 @@ unsafe extern "C-unwind" fn group_by_rel(
         let mut id_matched: u64 = 0;
         let ref_id = &mut id_matched;
         if sys::ecs_search(world, table, ecs_pair(id, *flecs::Wildcard), ref_id) != -1 {
-            return *ecs_second(id_matched);
+            return *ecs_second(id_matched, world);
         }
         0
     }

--- a/flecs_ecs/tests/flecs/query_builder_test.rs
+++ b/flecs_ecs/tests/flecs/query_builder_test.rs
@@ -4843,7 +4843,7 @@ fn query_builder_var_src_w_prefixed_name() {
     let r = world
         .query::<()>()
         .with(id::<&Foo>())
-        .set_src_name("$Var")
+        .set_src("$Var")
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
@@ -4868,7 +4868,7 @@ fn query_builder_var_first_w_prefixed_name() {
         .query::<()>()
         .with(id::<&Foo>())
         .term()
-        .set_first_name("$Var")
+        .set_first("$Var")
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
@@ -4894,7 +4894,7 @@ fn query_builder_var_second_w_prefixed_name() {
     let r = world
         .query::<()>()
         .with(id::<&Foo>())
-        .set_second_name("$Var")
+        .set_second("$Var")
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 

--- a/flecs_ecs/tests/flecs/query_builder_test.rs
+++ b/flecs_ecs/tests/flecs/query_builder_test.rs
@@ -60,8 +60,8 @@ fn query_builder_builder_assign_from_empty() {
     let q = world
         .query::<()>()
         .set_cache_kind(QueryCacheKind::Auto)
-        .with::<&Position>()
-        .with::<&Velocity>()
+        .with(id::<&Position>())
+        .with(id::<&Velocity>())
         .build();
 
     let e1 = world
@@ -132,8 +132,8 @@ fn query_builder_builder_build_n_statements() {
     let world = World::new();
 
     let mut q = world.query::<()>();
-    q.with::<&Position>();
-    q.with::<&Velocity>();
+    q.with(id::<&Position>());
+    q.with(id::<&Velocity>());
     q.set_cache_kind(QueryCacheKind::Auto);
     let q = q.build();
 
@@ -209,13 +209,13 @@ fn query_builder_id_term() {
 
     let tag = world.entity();
 
-    let e1 = world.entity().add_id(tag);
+    let e1 = world.entity().add(tag);
 
     world.entity().set(Velocity { x: 10, y: 20 });
 
     let r = world
         .query::<()>()
-        .with_id(tag)
+        .with(tag)
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
@@ -238,7 +238,7 @@ fn query_builder_type_term() {
 
     let r = world
         .query::<()>()
-        .with::<&Position>()
+        .with(id::<&Position>())
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
@@ -259,13 +259,13 @@ fn query_builder_id_pair_term() {
     let apples = world.entity();
     let pears = world.entity();
 
-    let e1 = world.entity().add_id((likes, apples));
+    let e1 = world.entity().add((likes, apples));
 
-    world.entity().add_id((likes, pears));
+    world.entity().add((likes, pears));
 
     let r = world
         .query::<()>()
-        .with_id((likes, apples))
+        .with((likes, apples))
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
@@ -286,24 +286,24 @@ fn query_builder_id_pair_wildcard_term() {
     let apples = world.entity();
     let pears = world.entity();
 
-    let e1 = world.entity().add_id((likes, apples));
+    let e1 = world.entity().add((likes, apples));
 
-    let e2 = world.entity().add_id((likes, pears));
+    let e2 = world.entity().add((likes, pears));
 
     let r = world
         .query::<()>()
-        .with_id((likes, *flecs::Wildcard))
+        .with((likes, *flecs::Wildcard))
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
     let mut count = 0;
     r.each_iter(|it, index, ()| {
-        if it.entity(index) == e1 {
-            assert_eq!(it.id(0), world.id_from_id((likes, apples)));
+        if it.entity(index).unwrap() == e1 {
+            assert_eq!(it.id(0), world.id_view_from((likes, apples)));
             count += 1;
         }
-        if it.entity(index) == e2 {
-            assert_eq!(it.id(0), world.id_from_id((likes, pears)));
+        if it.entity(index).unwrap() == e2 {
+            assert_eq!(it.id(0), world.id_view_from((likes, pears)));
             count += 1;
         }
     });
@@ -314,24 +314,27 @@ fn query_builder_id_pair_wildcard_term() {
 fn query_builder_type_pair_term() {
     let world = World::new();
 
-    let e1 = world.entity().add::<(Likes, Apples)>();
+    let e1 = world.entity().add((id::<Likes>(), id::<Apples>()));
 
-    let e2 = world.entity().add::<(Likes, Pears)>();
+    let e2 = world.entity().add((id::<Likes>(), id::<Pears>()));
 
     let r = world
         .query::<()>()
-        .with_first::<&Likes>(*flecs::Wildcard)
+        .with((id::<&Likes>(), *flecs::Wildcard))
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
     let mut count = 0;
     r.each_iter(|it, index, ()| {
-        if it.entity(index) == e1 {
-            assert_eq!(it.id(0), world.id_from::<(Likes, Apples)>());
+        if it.entity(index).unwrap() == e1 {
+            assert_eq!(
+                it.id(0),
+                world.id_view_from((id::<Likes>(), id::<Apples>()))
+            );
             count += 1;
         }
-        if it.entity(index) == e2 {
-            assert_eq!(it.id(0), world.id_from::<(Likes, Pears)>());
+        if it.entity(index).unwrap() == e2 {
+            assert_eq!(it.id(0), world.id_view_from((id::<Likes>(), id::<Pears>())));
             count += 1;
         }
     });
@@ -342,13 +345,13 @@ fn query_builder_type_pair_term() {
 fn query_builder_pair_term_w_var() {
     let world = World::new();
 
-    let e1 = world.entity().add::<(Likes, Apples)>();
+    let e1 = world.entity().add((id::<Likes>(), id::<Apples>()));
 
-    let e2 = world.entity().add::<(Likes, Pears)>();
+    let e2 = world.entity().add((id::<Likes>(), id::<Pears>()));
 
     let r = world
         .query::<()>()
-        .with::<&Likes>()
+        .with(id::<&Likes>())
         .second()
         .set_var("Food")
         .set_cache_kind(QueryCacheKind::Auto)
@@ -358,16 +361,25 @@ fn query_builder_pair_term_w_var() {
 
     let mut count = 0;
     r.each_iter(|it, index, ()| {
-        if it.entity(index) == e1 {
-            assert_eq!(it.id(0), world.id_from::<(Likes, Apples)>());
-            assert_eq!(it.get_var_by_name("Food"), world.id_from::<Apples>());
-            assert_eq!(it.get_var(foo_d_var), world.id_from::<Apples>());
+        if it.entity(index).unwrap() == e1 {
+            assert_eq!(
+                it.id(0),
+                world.id_view_from((id::<Likes>(), id::<Apples>()))
+            );
+            assert_eq!(
+                it.get_var_by_name("Food"),
+                world.id_view_from(id::<Apples>())
+            );
+            assert_eq!(it.get_var(foo_d_var), world.id_view_from(id::<Apples>()));
             count += 1;
         }
-        if it.entity(index) == e2 {
-            assert_eq!(it.id(0), world.id_from::<(Likes, Pears)>());
-            assert_eq!(it.get_var_by_name("Food"), world.id_from::<Pears>());
-            assert_eq!(it.get_var(foo_d_var), world.id_from::<Pears>());
+        if it.entity(index).unwrap() == e2 {
+            assert_eq!(it.id(0), world.id_view_from((id::<Likes>(), id::<Pears>())));
+            assert_eq!(
+                it.get_var_by_name("Food"),
+                world.id_view_from(id::<Pears>())
+            );
+            assert_eq!(it.get_var(foo_d_var), world.id_view_from(id::<Pears>()));
             count += 1;
         }
     });
@@ -378,21 +390,21 @@ fn query_builder_pair_term_w_var() {
 fn query_builder_2_pair_terms_w_var() {
     let world = World::new();
 
-    let bob = world.entity().add::<(Eats, Apples)>();
+    let bob = world.entity().add((id::<Eats>(), id::<Apples>()));
 
     let alice = world
         .entity()
-        .add::<(Eats, Pears)>()
-        .add_first::<Likes>(bob);
+        .add((id::<Eats>(), id::<Pears>()))
+        .add((id::<Likes>(), bob));
 
-    bob.add_first::<Likes>(alice);
+    bob.add((id::<Likes>(), alice));
 
     let r = world
         .query::<()>()
-        .with::<&Eats>()
+        .with(id::<&Eats>())
         .second()
         .set_var("Food")
-        .with::<&Likes>()
+        .with(id::<&Likes>())
         .second()
         .set_var("Person")
         .set_cache_kind(QueryCacheKind::Auto)
@@ -403,22 +415,28 @@ fn query_builder_2_pair_terms_w_var() {
 
     let mut count = 0;
     r.each_iter(|it, index, ()| {
-        if it.entity(index) == bob {
-            assert_eq!(it.id(0), world.id_from::<(Eats, Apples)>());
-            assert_eq!(it.get_var_by_name("Food"), world.id_from::<Apples>());
-            assert_eq!(it.get_var(foo_d_var), world.id_from::<Apples>());
+        if it.entity(index).unwrap() == bob {
+            assert_eq!(it.id(0), world.id_view_from((id::<Eats>(), id::<Apples>())));
+            assert_eq!(
+                it.get_var_by_name("Food"),
+                world.id_view_from(id::<Apples>())
+            );
+            assert_eq!(it.get_var(foo_d_var), world.id_view_from(id::<Apples>()));
 
-            assert_eq!(it.id(1), world.id_first::<Likes>(alice));
+            assert_eq!(it.id(1), world.id_view_from((id::<Likes>(), alice)));
             assert_eq!(it.get_var_by_name("Person"), alice);
             assert_eq!(it.get_var(person_var), alice);
             count += 1;
         }
-        if it.entity(index) == alice {
-            assert_eq!(it.id(0), world.id_from::<(Eats, Pears)>());
-            assert_eq!(it.get_var_by_name("Food"), world.id_from::<Pears>());
-            assert_eq!(it.get_var(foo_d_var), world.id_from::<Pears>());
+        if it.entity(index).unwrap() == alice {
+            assert_eq!(it.id(0), world.id_view_from((id::<Eats>(), id::<Pears>())));
+            assert_eq!(
+                it.get_var_by_name("Food"),
+                world.id_view_from(id::<Pears>())
+            );
+            assert_eq!(it.get_var(foo_d_var), world.id_view_from(id::<Pears>()));
 
-            assert_eq!(it.id(1), world.id_first::<Likes>(bob));
+            assert_eq!(it.id(1), world.id_view_from((id::<Likes>(), bob)));
             assert_eq!(it.get_var_by_name("Person"), bob);
             assert_eq!(it.get_var(person_var), bob);
             count += 1;
@@ -434,13 +452,13 @@ fn query_builder_set_var() {
     let apples = world.entity();
     let pears = world.entity();
 
-    world.entity().add_first::<Likes>(apples);
+    world.entity().add((id::<Likes>(), apples));
 
-    let e2 = world.entity().add_first::<Likes>(pears);
+    let e2 = world.entity().add((id::<Likes>(), pears));
 
     let r = world
         .query::<()>()
-        .with::<&Likes>()
+        .with(id::<&Likes>())
         .second()
         .set_var("Food")
         .set_cache_kind(QueryCacheKind::Auto)
@@ -452,8 +470,8 @@ fn query_builder_set_var() {
     r.iterable()
         .set_var(foo_d_var, pears)
         .each_iter(|it, index, ()| {
-            assert_eq!(it.entity(index), e2);
-            assert_eq!(it.id(0), world.id_first::<Likes>(pears));
+            assert_eq!(it.entity(index).unwrap(), e2);
+            assert_eq!(it.id(0), world.id_view_from((id::<Likes>(), pears)));
             assert_eq!(it.get_var_by_name("Food"), pears);
             assert_eq!(it.get_var(foo_d_var), pears);
             count += 1;
@@ -469,21 +487,21 @@ fn query_builder_set_2_vars() {
     let apples = world.entity();
     let pears = world.entity();
 
-    let bob = world.entity().add_first::<Eats>(apples);
+    let bob = world.entity().add((id::<Eats>(), apples));
 
     let alice = world
         .entity()
-        .add_first::<Eats>(pears)
-        .add_first::<Likes>(bob);
+        .add((id::<Eats>(), pears))
+        .add((id::<Likes>(), bob));
 
-    bob.add_first::<Likes>(alice);
+    bob.add((id::<Likes>(), alice));
 
     let r = world
         .query::<()>()
-        .with::<&Eats>()
+        .with(id::<&Eats>())
         .second()
         .set_var("Food")
-        .with::<&Likes>()
+        .with(id::<&Likes>())
         .second()
         .set_var("Person")
         .set_cache_kind(QueryCacheKind::Auto)
@@ -497,9 +515,9 @@ fn query_builder_set_2_vars() {
         .set_var(foo_d_var, pears)
         .set_var(person_var, bob)
         .each_iter(|it, index, ()| {
-            assert_eq!(it.entity(index), alice);
-            assert_eq!(it.id(0), world.id_first::<Eats>(pears));
-            assert_eq!(it.id(1), world.id_first::<Likes>(bob));
+            assert_eq!(it.entity(index).unwrap(), alice);
+            assert_eq!(it.id(0), world.id_view_from((id::<Eats>(), pears)));
+            assert_eq!(it.id(1), world.id_view_from((id::<Likes>(), bob)));
             assert_eq!(it.get_var_by_name("Food"), pears);
             assert_eq!(it.get_var(foo_d_var), pears);
             assert_eq!(it.get_var_by_name("Person"), bob);
@@ -516,13 +534,13 @@ fn query_builder_set_var_by_name() {
     let apples = world.entity();
     let pears = world.entity();
 
-    world.entity().add_first::<Likes>(apples);
+    world.entity().add((id::<Likes>(), apples));
 
-    let e2 = world.entity().add_first::<Likes>(pears);
+    let e2 = world.entity().add((id::<Likes>(), pears));
 
     let r = world
         .query::<()>()
-        .with::<&Likes>()
+        .with(id::<&Likes>())
         .second()
         .set_var("Food")
         .set_cache_kind(QueryCacheKind::Auto)
@@ -532,8 +550,8 @@ fn query_builder_set_var_by_name() {
     r.iterable()
         .set_var_expr("Food", pears)
         .each_iter(|it, index, ()| {
-            assert_eq!(it.entity(index), e2);
-            assert_eq!(it.id(0), world.id_first::<Likes>(pears));
+            assert_eq!(it.entity(index).unwrap(), e2);
+            assert_eq!(it.id(0), world.id_view_from((id::<Likes>(), pears)));
             count += 1;
         });
     assert_eq!(count, 1);
@@ -546,21 +564,21 @@ fn query_builder_set_2_vars_by_name() {
     let apples = world.entity();
     let pears = world.entity();
 
-    let bob = world.entity().add_first::<Eats>(apples);
+    let bob = world.entity().add((id::<Eats>(), apples));
 
     let alice = world
         .entity()
-        .add_first::<Eats>(pears)
-        .add_first::<Likes>(bob);
+        .add((id::<Eats>(), pears))
+        .add((id::<Likes>(), bob));
 
-    bob.add_first::<Likes>(alice);
+    bob.add((id::<Likes>(), alice));
 
     let r = world
         .query::<()>()
-        .with::<&Eats>()
+        .with(id::<&Eats>())
         .second()
         .set_var("Food")
-        .with::<&Likes>()
+        .with(id::<&Likes>())
         .second()
         .set_var("Person")
         .set_cache_kind(QueryCacheKind::Auto)
@@ -574,9 +592,9 @@ fn query_builder_set_2_vars_by_name() {
         .set_var_expr("Food", pears)
         .set_var_expr("Person", bob)
         .each_iter(|it, index, ()| {
-            assert_eq!(it.entity(index), alice);
-            assert_eq!(it.id(0), world.id_first::<Eats>(pears));
-            assert_eq!(it.id(1), world.id_first::<Likes>(bob));
+            assert_eq!(it.entity(index).unwrap(), alice);
+            assert_eq!(it.id(0), world.id_view_from((id::<Eats>(), pears)));
+            assert_eq!(it.id(1), world.id_view_from((id::<Likes>(), bob)));
             assert_eq!(it.get_var_by_name("Food"), pears);
             assert_eq!(it.get_var(foo_d_var), pears);
             assert_eq!(it.get_var_by_name("Person"), bob);
@@ -592,7 +610,7 @@ fn query_builder_expr_w_var() {
 
     let rel = world.entity_named("Rel");
     let obj = world.entity();
-    let e = world.entity().add_id((rel, obj));
+    let e = world.entity().add((rel, obj));
 
     let r = world
         .query::<()>()
@@ -605,7 +623,7 @@ fn query_builder_expr_w_var() {
 
     let mut count = 0;
     r.each_iter(|it, index, ()| {
-        assert_eq!(it.entity(index), e);
+        assert_eq!(it.entity(index).unwrap(), e);
         assert_eq!(it.pair(0).unwrap().second_id(), obj);
         count += 1;
     });
@@ -619,7 +637,7 @@ fn query_builder_add_1_type() {
 
     let q = world
         .query::<()>()
-        .with::<&Position>()
+        .with(id::<&Position>())
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
@@ -641,8 +659,8 @@ fn query_builder_add_2_types() {
 
     let q = world
         .query::<()>()
-        .with::<&Position>()
-        .with::<&Velocity>()
+        .with(id::<&Position>())
+        .with(id::<&Velocity>())
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
@@ -667,7 +685,7 @@ fn query_builder_add_1_type_w_1_type() {
 
     let q = world
         .query::<&Position>()
-        .with::<&Velocity>()
+        .with(id::<&Velocity>())
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
@@ -692,8 +710,8 @@ fn query_builder_add_2_types_w_1_type() {
 
     let q = world
         .query::<&Position>()
-        .with::<&Velocity>()
-        .with::<&Mass>()
+        .with(id::<&Velocity>())
+        .with(id::<&Mass>())
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
@@ -723,12 +741,12 @@ fn query_builder_add_pair() {
 
     let q = world
         .query::<()>()
-        .with_id((likes, bob))
+        .with((likes, bob))
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
-    let e1 = world.entity().add_id((likes, bob));
-    world.entity().add_id((likes, alice));
+    let e1 = world.entity().add((likes, bob));
+    world.entity().add((likes, alice));
 
     let mut count = 0;
     q.each_entity(|e, _| {
@@ -745,7 +763,7 @@ fn query_builder_add_not() {
 
     let q = world
         .query::<&Position>()
-        .with::<&Velocity>()
+        .with(id::<&Velocity>())
         .set_oper(OperKind::Not)
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
@@ -771,9 +789,9 @@ fn query_builder_add_or() {
 
     let q = world
         .query::<()>()
-        .with::<&Position>()
+        .with(id::<&Position>())
         .set_oper(OperKind::Or)
-        .with::<&Velocity>()
+        .with(id::<&Velocity>())
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
@@ -796,8 +814,8 @@ fn query_builder_add_optional() {
 
     let q = world
         .query::<()>()
-        .with::<&Position>()
-        .with::<&Velocity>()
+        .with(id::<&Position>())
+        .with(id::<&Velocity>())
         .set_oper(OperKind::Optional)
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
@@ -902,7 +920,7 @@ fn query_builder_singleton_term() {
 
     let q = world
         .query::<&SelfRef>()
-        .with::<&Other>()
+        .with(id::<&Other>())
         .singleton()
         .set_inout()
         .set_cache_kind(QueryCacheKind::Auto)
@@ -924,7 +942,7 @@ fn query_builder_singleton_term() {
             assert_eq!(o.value, 10);
 
             for i in it.iter() {
-                assert_eq!(it.entity(i), it.entity(i).id());
+                assert_eq!(it.entity(i).unwrap(), it.entity(i).unwrap().id());
                 count += 1;
             }
         }
@@ -939,11 +957,11 @@ fn query_builder_isa_superset_term() {
 
     world
         .component::<Other>()
-        .add_id((flecs::OnInstantiate::ID, flecs::Inherit::ID));
+        .add((flecs::OnInstantiate::ID, flecs::Inherit::ID));
 
     let q = world
         .query::<&SelfRef>()
-        .with::<&Other>()
+        .with(id::<&Other>())
         .src()
         .up_id(*flecs::IsA)
         .set_in()
@@ -952,11 +970,11 @@ fn query_builder_isa_superset_term() {
 
     let base = world.entity().set(Other { value: 10 });
 
-    let e = world.entity().add_id((*flecs::IsA, base));
+    let e = world.entity().add((*flecs::IsA, base));
     e.set(SelfRef { value: e.id() });
-    let e = world.entity().add_id((*flecs::IsA, base));
+    let e = world.entity().add((*flecs::IsA, base));
     e.set(SelfRef { value: e.id() });
-    let e = world.entity().add_id((*flecs::IsA, base));
+    let e = world.entity().add((*flecs::IsA, base));
     e.set(SelfRef { value: e.id() });
 
     let mut count = 0;
@@ -968,7 +986,7 @@ fn query_builder_isa_superset_term() {
             assert_eq!(o.value, 10);
 
             for i in it.iter() {
-                assert_eq!(it.entity(i), it.entity(i).id());
+                assert_eq!(it.entity(i).unwrap(), it.entity(i).unwrap().id());
                 count += 1;
             }
         }
@@ -983,11 +1001,11 @@ fn query_builder_isa_self_superset_term() {
 
     world
         .component::<Other>()
-        .add_id((flecs::OnInstantiate::ID, flecs::Inherit::ID));
+        .add((flecs::OnInstantiate::ID, flecs::Inherit::ID));
 
     let q = world
         .query::<&SelfRef>()
-        .with::<&Other>()
+        .with(id::<&Other>())
         .src()
         .self_()
         .up_id(*flecs::IsA)
@@ -997,11 +1015,11 @@ fn query_builder_isa_self_superset_term() {
 
     let base = world.entity().set(Other { value: 10 });
 
-    let e = world.entity().add_id((*flecs::IsA, base));
+    let e = world.entity().add((*flecs::IsA, base));
     e.set(SelfRef { value: e.id() });
-    let e = world.entity().add_id((*flecs::IsA, base));
+    let e = world.entity().add((*flecs::IsA, base));
     e.set(SelfRef { value: e.id() });
-    let e = world.entity().add_id((*flecs::IsA, base));
+    let e = world.entity().add((*flecs::IsA, base));
     e.set(SelfRef { value: e.id() });
     let e = world.entity().set(Other { value: 20 });
     e.set(SelfRef { value: e.id() });
@@ -1025,7 +1043,7 @@ fn query_builder_isa_self_superset_term() {
             }
 
             for i in it.iter() {
-                assert_eq!(it.entity(i), it.entity(i).id());
+                assert_eq!(it.entity(i).unwrap(), it.entity(i).unwrap().id());
                 count += 1;
             }
         }
@@ -1041,7 +1059,7 @@ fn query_builder_childof_superset_term() {
 
     let q = world
         .query::<&SelfRef>()
-        .with::<&Other>()
+        .with(id::<&Other>())
         .src()
         .up()
         .set_in()
@@ -1050,11 +1068,11 @@ fn query_builder_childof_superset_term() {
 
     let base = world.entity().set(Other { value: 10 });
 
-    let e = world.entity().child_of_id(base);
+    let e = world.entity().child_of(base);
     e.set(SelfRef { value: e.id() });
-    let e = world.entity().child_of_id(base);
+    let e = world.entity().child_of(base);
     e.set(SelfRef { value: e.id() });
-    let e = world.entity().child_of_id(base);
+    let e = world.entity().child_of(base);
     e.set(SelfRef { value: e.id() });
 
     let mut count = 0;
@@ -1066,7 +1084,7 @@ fn query_builder_childof_superset_term() {
             assert_eq!(o.value, 10);
 
             for i in it.iter() {
-                assert_eq!(it.entity(i), it.entity(i).id());
+                assert_eq!(it.entity(i).unwrap(), it.entity(i).unwrap().id());
                 count += 1;
             }
         }
@@ -1081,7 +1099,7 @@ fn query_builder_childof_self_superset_term() {
 
     let q = world
         .query::<&SelfRef>()
-        .with::<&Other>()
+        .with(id::<&Other>())
         .src()
         .self_()
         .up()
@@ -1091,11 +1109,11 @@ fn query_builder_childof_self_superset_term() {
 
     let base = world.entity().set(Other { value: 10 });
 
-    let e = world.entity().child_of_id(base);
+    let e = world.entity().child_of(base);
     e.set(SelfRef { value: e.id() });
-    let e = world.entity().child_of_id(base);
+    let e = world.entity().child_of(base);
     e.set(SelfRef { value: e.id() });
-    let e = world.entity().child_of_id(base);
+    let e = world.entity().child_of(base);
     e.set(SelfRef { value: e.id() });
     let e = world.entity().set(Other { value: 20 });
     e.set(SelfRef { value: e.id() });
@@ -1119,7 +1137,7 @@ fn query_builder_childof_self_superset_term() {
             }
 
             for i in it.iter() {
-                assert_eq!(it.entity(i), it.entity(i).id());
+                assert_eq!(it.entity(i).unwrap(), it.entity(i).unwrap().id());
                 count += 1;
             }
         }
@@ -1135,7 +1153,7 @@ fn query_builder_isa_superset_term_w_each() {
 
     world
         .component::<Other>()
-        .add_id((flecs::OnInstantiate::ID, flecs::Inherit::ID));
+        .add((flecs::OnInstantiate::ID, flecs::Inherit::ID));
 
     let q = world
         .query::<(&SelfRef, &Other)>()
@@ -1147,11 +1165,11 @@ fn query_builder_isa_superset_term_w_each() {
 
     let base = world.entity().set(Other { value: 10 });
 
-    let e = world.entity().add_id((*flecs::IsA, base));
+    let e = world.entity().add((*flecs::IsA, base));
     e.set(SelfRef { value: e.id() });
-    let e = world.entity().add_id((*flecs::IsA, base));
+    let e = world.entity().add((*flecs::IsA, base));
     e.set(SelfRef { value: e.id() });
-    let e = world.entity().add_id((*flecs::IsA, base));
+    let e = world.entity().add((*flecs::IsA, base));
     e.set(SelfRef { value: e.id() });
 
     let mut count = 0;
@@ -1171,7 +1189,7 @@ fn query_builder_isa_self_superset_term_w_each() {
 
     world
         .component::<Other>()
-        .add_id((flecs::OnInstantiate::ID, flecs::Inherit::ID));
+        .add((flecs::OnInstantiate::ID, flecs::Inherit::ID));
 
     let q = world
         .query::<(&SelfRef, &Other)>()
@@ -1184,11 +1202,11 @@ fn query_builder_isa_self_superset_term_w_each() {
 
     let base = world.entity().set(Other { value: 10 });
 
-    let e = world.entity().add_id((*flecs::IsA, base));
+    let e = world.entity().add((*flecs::IsA, base));
     e.set(SelfRef { value: e.id() });
-    let e = world.entity().add_id((*flecs::IsA, base));
+    let e = world.entity().add((*flecs::IsA, base));
     e.set(SelfRef { value: e.id() });
-    let e = world.entity().add_id((*flecs::IsA, base));
+    let e = world.entity().add((*flecs::IsA, base));
     e.set(SelfRef { value: e.id() });
     let e = world.entity().set(Other { value: 10 });
     e.set(SelfRef { value: e.id() });
@@ -1220,11 +1238,11 @@ fn query_builder_childof_superset_term_w_each() {
 
     let base = world.entity().set(Other { value: 10 });
 
-    let e = world.entity().child_of_id(base);
+    let e = world.entity().child_of(base);
     e.set(SelfRef { value: e.id() });
-    let e = world.entity().child_of_id(base);
+    let e = world.entity().child_of(base);
     e.set(SelfRef { value: e.id() });
-    let e = world.entity().child_of_id(base);
+    let e = world.entity().child_of(base);
     e.set(SelfRef { value: e.id() });
 
     let mut count = 0;
@@ -1253,11 +1271,11 @@ fn query_builder_childof_self_superset_term_w_each() {
 
     let base = world.entity().set(Other { value: 10 });
 
-    let e = world.entity().child_of_id(base);
+    let e = world.entity().child_of(base);
     e.set(SelfRef { value: e.id() });
-    let e = world.entity().child_of_id(base);
+    let e = world.entity().child_of(base);
     e.set(SelfRef { value: e.id() });
-    let e = world.entity().child_of_id(base);
+    let e = world.entity().child_of(base);
     e.set(SelfRef { value: e.id() });
     let e = world.entity().set(Other { value: 10 });
     e.set(SelfRef { value: e.id() });
@@ -1281,7 +1299,7 @@ fn query_builder_isa_superset_shortcut() {
 
     world
         .component::<Other>()
-        .add_id((flecs::OnInstantiate::ID, flecs::Inherit::ID));
+        .add((flecs::OnInstantiate::ID, flecs::Inherit::ID));
 
     let q = world
         .query::<(&SelfRef, &Other)>()
@@ -1292,11 +1310,11 @@ fn query_builder_isa_superset_shortcut() {
 
     let base = world.entity().set(Other { value: 10 });
 
-    let e = world.entity().is_a_id(base);
+    let e = world.entity().is_a(base);
     e.set(SelfRef { value: e.id() });
-    let e = world.entity().is_a_id(base);
+    let e = world.entity().is_a(base);
     e.set(SelfRef { value: e.id() });
-    let e = world.entity().is_a_id(base);
+    let e = world.entity().is_a(base);
     e.set(SelfRef { value: e.id() });
 
     let mut count = 0;
@@ -1316,7 +1334,7 @@ fn query_builder_isa_superset_shortcut_w_self() {
 
     world
         .component::<Other>()
-        .add_id((flecs::OnInstantiate::ID, flecs::Inherit::ID));
+        .add((flecs::OnInstantiate::ID, flecs::Inherit::ID));
 
     let q = world
         .query::<(&SelfRef, &Other)>()
@@ -1328,11 +1346,11 @@ fn query_builder_isa_superset_shortcut_w_self() {
 
     let base = world.entity().set(Other { value: 10 });
 
-    let e = world.entity().is_a_id(base);
+    let e = world.entity().is_a(base);
     e.set(SelfRef { value: e.id() });
-    let e = world.entity().is_a_id(base);
+    let e = world.entity().is_a(base);
     e.set(SelfRef { value: e.id() });
-    let e = world.entity().is_a_id(base);
+    let e = world.entity().is_a(base);
     e.set(SelfRef { value: e.id() });
     let e = world.entity().set(Other { value: 10 });
     e.set(SelfRef { value: e.id() });
@@ -1363,11 +1381,11 @@ fn query_builder_childof_superset_shortcut() {
 
     let base = world.entity().set(Other { value: 10 });
 
-    let e = world.entity().child_of_id(base);
+    let e = world.entity().child_of(base);
     e.set(SelfRef { value: e.id() });
-    let e = world.entity().child_of_id(base);
+    let e = world.entity().child_of(base);
     e.set(SelfRef { value: e.id() });
-    let e = world.entity().child_of_id(base);
+    let e = world.entity().child_of(base);
     e.set(SelfRef { value: e.id() });
 
     let mut count = 0;
@@ -1395,11 +1413,11 @@ fn query_builder_childof_superset_shortcut_w_self() {
 
     let base = world.entity().set(Other { value: 10 });
 
-    let e = world.entity().child_of_id(base);
+    let e = world.entity().child_of(base);
     e.set(SelfRef { value: e.id() });
-    let e = world.entity().child_of_id(base);
+    let e = world.entity().child_of(base);
     e.set(SelfRef { value: e.id() });
-    let e = world.entity().child_of_id(base);
+    let e = world.entity().child_of(base);
     e.set(SelfRef { value: e.id() });
     let e = world.entity().set(Other { value: 10 });
     e.set(SelfRef { value: e.id() });
@@ -1427,18 +1445,18 @@ fn query_builder_relation() {
 
     let q = world
         .query::<&SelfRef>()
-        .with_id((likes, bob))
+        .with((likes, bob))
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
-    let e = world.entity().add_id((likes, bob));
+    let e = world.entity().add((likes, bob));
     e.set(SelfRef { value: e.id() });
-    let e = world.entity().add_id((likes, bob));
+    let e = world.entity().add((likes, bob));
     e.set(SelfRef { value: e.id() });
 
-    let e = world.entity().add_id((likes, alice));
+    let e = world.entity().add((likes, alice));
     e.set(SelfRef { value: Entity(0) });
-    let e = world.entity().add_id((likes, alice));
+    let e = world.entity().add((likes, alice));
     e.set(SelfRef { value: Entity(0) });
 
     let mut count = 0;
@@ -1461,18 +1479,18 @@ fn query_builder_relation_w_object_wildcard() {
 
     let q = world
         .query::<&SelfRef>()
-        .with_id((likes, *flecs::Wildcard))
+        .with((likes, *flecs::Wildcard))
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
-    let e = world.entity().add_id((likes, bob));
+    let e = world.entity().add((likes, bob));
     e.set(SelfRef { value: e.id() });
-    let e = world.entity().add_id((likes, bob));
+    let e = world.entity().add((likes, bob));
     e.set(SelfRef { value: e.id() });
 
-    let e = world.entity().add_id((likes, alice));
+    let e = world.entity().add((likes, alice));
     e.set(SelfRef { value: e.id() });
-    let e = world.entity().add_id((likes, alice));
+    let e = world.entity().add((likes, alice));
     e.set(SelfRef { value: e.id() });
 
     let e = world.entity();
@@ -1501,18 +1519,18 @@ fn query_builder_relation_w_predicate_wildcard() {
 
     let q = world
         .query::<&SelfRef>()
-        .with_id((*flecs::Wildcard, alice))
+        .with((*flecs::Wildcard, alice))
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
-    let e = world.entity().add_id((likes, alice));
+    let e = world.entity().add((likes, alice));
     e.set(SelfRef { value: e.id() });
-    let e = world.entity().add_id((dislikes, alice));
+    let e = world.entity().add((dislikes, alice));
     e.set(SelfRef { value: e.id() });
 
-    let e = world.entity().add_id((likes, bob));
+    let e = world.entity().add((likes, bob));
     e.set(SelfRef { value: Entity(0) });
-    let e = world.entity().add_id((dislikes, bob));
+    let e = world.entity().add((dislikes, bob));
     e.set(SelfRef { value: Entity(0) });
 
     let mut count = 0;
@@ -1535,18 +1553,18 @@ fn query_builder_add_pair_w_rel_type() {
 
     let q = world
         .query::<&SelfRef>()
-        .with_first::<&Likes>(*flecs::Wildcard)
+        .with((id::<&Likes>(), *flecs::Wildcard))
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
-    let e = world.entity().add_first::<Likes>(alice);
+    let e = world.entity().add((id::<Likes>(), alice));
     e.set(SelfRef { value: e.id() });
-    let e = world.entity().add_id((dislikes, alice));
+    let e = world.entity().add((dislikes, alice));
     e.set(SelfRef { value: Entity(0) });
 
-    let e = world.entity().add_first::<Likes>(bob);
+    let e = world.entity().add((id::<Likes>(), bob));
     e.set(SelfRef { value: e.id() });
-    let e = world.entity().add_id((dislikes, bob));
+    let e = world.entity().add((dislikes, bob));
     e.set(SelfRef { value: Entity(0) });
 
     let mut count = 0;
@@ -1565,7 +1583,7 @@ fn query_builder_template_term() {
 
     let q = world
         .query::<&Position>()
-        .with::<&Template<u32>>()
+        .with(id::<&Template<u32>>())
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
@@ -1590,7 +1608,7 @@ fn query_builder_explicit_subject_w_id() {
 
     let q = world
         .query::<&Position>()
-        .with::<&Position>()
+        .with(id::<&Position>())
         .set_id(*flecs::This_)
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
@@ -1618,8 +1636,8 @@ fn query_builder_explicit_subject_w_type() {
 
     let q = world
         .query::<&Position>()
-        .with::<&Position>()
-        .set_src::<Position>()
+        .with(id::<&Position>())
+        .set_src(id::<Position>())
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
@@ -1644,13 +1662,13 @@ fn query_builder_explicit_object_w_id() {
 
     let q = world
         .query::<()>()
-        .with_id(likes)
-        .set_second_id(alice)
+        .with(likes)
+        .set_second(alice)
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
-    let e1 = world.entity().add_id((likes, alice));
-    world.entity().add_id((likes, bob));
+    let e1 = world.entity().add((likes, alice));
+    world.entity().add((likes, bob));
 
     let mut count = 0;
     q.each_entity(|e, _| {
@@ -1670,15 +1688,15 @@ fn query_builder_explicit_object_w_type() {
 
     let q = world
         .query::<()>()
-        .with_id(likes)
-        .set_second::<Alice>()
+        .with(likes)
+        .set_second(id::<Alice>())
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
     let e1 = world
         .entity()
-        .add_id((likes, *world.id_from::<Alice>().id()));
-    world.entity().add_id((likes, bob));
+        .add((likes, *world.id_view_from(id::<Alice>()).id()));
+    world.entity().add((likes, bob));
 
     let mut count = 0;
     q.each_entity(|e, _| {
@@ -1696,7 +1714,7 @@ fn query_builder_explicit_term() {
 
     // let q = world
     //     .query::<()>()
-    //     .with(world.term(world.id_from::<Position>()))
+    //     .with(world.term(world.id_view_from(id::<Position>())))
     //     .set_cache_kind(QueryCacheKind::Auto)
     //     .build();
 
@@ -1740,12 +1758,12 @@ fn query_builder_explicit_term_w_pair_type() {
     //     let world = create_world();
 
     //     let q = world.query::<()>()
-    //         .with_id((world.term<Likes, alice>()))
+    //         .with((world.term<Likes, alice>()))
     //         .set_cache_kind(QueryCacheKind::Auto)
     //         .build();
 
-    //     let e1 = world.entity().add::<(Likes, alice)>();
-    //     world.entity().add::<(Likes, bob)>();
+    //     let e1 = world.entity().add((id::<Likes>(), id::<alice>()));
+    //     world.entity().add((id::<Likes>(), id::<bob>()));
 
     //    let mut count = 0;
     //     q.each_entity(|e, _| {
@@ -1769,8 +1787,8 @@ fn query_builder_explicit_term_w_id() {
     //         .set_cache_kind(QueryCacheKind::Auto)
     //         .build();
 
-    //     let e1 = world.entity().add_id(apples);
-    //     world.entity().add_id(pears);
+    //     let e1 = world.entity().add(apples);
+    //     world.entity().add(pears);
 
     //    let mut count = 0;
     //     q.each_entity(|e, _| {
@@ -1794,8 +1812,8 @@ fn query_builder_explicit_term_w_pair_id() {
     //         .set_cache_kind(QueryCacheKind::Auto)
     //         .build();
 
-    //     let e1 = world.entity().add_id((likes,apples));
-    //     world.entity().add_id((likes,pears));
+    //     let e1 = world.entity().add((likes,apples));
+    //     world.entity().add((likes,pears));
 
     //    let mut count = 0;
     //     q.each_entity(|e, _| {
@@ -1814,14 +1832,15 @@ fn query_builder_1_term_to_empty() {
     let apples = world.entity();
 
     let mut q = world.query::<()>();
-    q.with::<&Position>().set_cache_kind(QueryCacheKind::Auto);
-    q.with_id((likes, apples));
+    q.with(id::<&Position>())
+        .set_cache_kind(QueryCacheKind::Auto);
+    q.with((likes, apples));
 
     let q = q.build();
 
     assert_eq!(q.field_count(), 2);
-    assert_eq!(q.term(0).id(), world.id_from::<Position>());
-    assert_eq!(q.term(1).id(), world.id_from_id((likes, apples)));
+    assert_eq!(q.term(0).id(), world.id_view_from(id::<Position>()));
+    assert_eq!(q.term(1).id(), world.id_view_from((likes, apples)));
 }
 
 #[test]
@@ -1857,14 +1876,14 @@ fn query_builder_optional_tag_is_set() {
 
     let q = world
         .query::<()>()
-        .with::<&TagA>()
-        .with::<&TagB>()
+        .with(id::<&TagA>())
+        .with(id::<&TagB>())
         .set_oper(OperKind::Optional)
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
-    let e_1 = world.entity().add::<TagA>().add::<TagB>();
-    let e_2 = world.entity().add::<TagA>();
+    let e_1 = world.entity().add(id::<TagA>()).add(id::<TagB>());
+    let e_2 = world.entity().add(id::<TagA>());
 
     let mut count = 0;
 
@@ -1874,11 +1893,11 @@ fn query_builder_optional_tag_is_set() {
 
             count += it.count();
 
-            if it.entity(0) == e_1 {
+            if it.entity(0).unwrap() == e_1 {
                 assert!(it.is_set(0));
                 assert!(it.is_set(1));
             } else {
-                assert_eq!(it.entity(0), e_2);
+                assert_eq!(it.entity(0).unwrap(), e_2);
                 assert!(it.is_set(0));
                 assert!(!it.is_set(1));
             }
@@ -1894,16 +1913,16 @@ fn query_builder_10_terms() {
 
     let f = world
         .query::<()>()
-        .with::<&TagA>()
-        .with::<&TagB>()
-        .with::<&TagC>()
-        .with::<&TagD>()
-        .with::<&TagE>()
-        .with::<&TagF>()
-        .with::<&TagG>()
-        .with::<&TagH>()
-        .with::<&TagI>()
-        .with::<&TagJ>()
+        .with(id::<&TagA>())
+        .with(id::<&TagB>())
+        .with(id::<&TagC>())
+        .with(id::<&TagD>())
+        .with(id::<&TagE>())
+        .with(id::<&TagF>())
+        .with(id::<&TagG>())
+        .with(id::<&TagH>())
+        .with(id::<&TagI>())
+        .with(id::<&TagJ>())
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
@@ -1911,23 +1930,23 @@ fn query_builder_10_terms() {
 
     let e = world
         .entity()
-        .add::<TagA>()
-        .add::<TagB>()
-        .add::<TagC>()
-        .add::<TagD>()
-        .add::<TagE>()
-        .add::<TagF>()
-        .add::<TagG>()
-        .add::<TagH>()
-        .add::<TagI>()
-        .add::<TagJ>();
+        .add(id::<TagA>())
+        .add(id::<TagB>())
+        .add(id::<TagC>())
+        .add(id::<TagD>())
+        .add(id::<TagE>())
+        .add(id::<TagF>())
+        .add(id::<TagG>())
+        .add(id::<TagH>())
+        .add(id::<TagI>())
+        .add(id::<TagJ>());
 
     let mut count = 0;
     f.run(|mut it| {
         while it.next() {
-            assert_eq!(it.count(), 1);
-            assert_eq!(it.entity(0), e);
             assert_eq!(it.field_count(), 10);
+            assert_eq!(it.entity(0).unwrap(), e);
+            assert_eq!(it.count(), 1);
             count += 1;
         }
     });
@@ -1941,22 +1960,22 @@ fn query_builder_16_terms() {
 
     let f = world
         .query::<()>()
-        .with::<&TagA>()
-        .with::<&TagB>()
-        .with::<&TagC>()
-        .with::<&TagD>()
-        .with::<&TagE>()
-        .with::<&TagF>()
-        .with::<&TagG>()
-        .with::<&TagH>()
-        .with::<&TagI>()
-        .with::<&TagJ>()
-        .with::<&TagK>()
-        .with::<&TagL>()
-        .with::<&TagM>()
-        .with::<&TagN>()
-        .with::<&TagO>()
-        .with::<&TagP>()
+        .with(id::<&TagA>())
+        .with(id::<&TagB>())
+        .with(id::<&TagC>())
+        .with(id::<&TagD>())
+        .with(id::<&TagE>())
+        .with(id::<&TagF>())
+        .with(id::<&TagG>())
+        .with(id::<&TagH>())
+        .with(id::<&TagI>())
+        .with(id::<&TagJ>())
+        .with(id::<&TagK>())
+        .with(id::<&TagL>())
+        .with(id::<&TagM>())
+        .with(id::<&TagN>())
+        .with(id::<&TagO>())
+        .with(id::<&TagP>())
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
@@ -1964,32 +1983,32 @@ fn query_builder_16_terms() {
 
     let e = world
         .entity()
-        .add::<TagA>()
-        .add::<TagB>()
-        .add::<TagC>()
-        .add::<TagD>()
-        .add::<TagE>()
-        .add::<TagF>()
-        .add::<TagG>()
-        .add::<TagH>()
-        .add::<TagI>()
-        .add::<TagJ>()
-        .add::<TagK>()
-        .add::<TagL>()
-        .add::<TagM>()
-        .add::<TagN>()
-        .add::<TagO>()
-        .add::<TagP>()
-        .add::<TagQ>()
-        .add::<TagR>()
-        .add::<TagS>()
-        .add::<TagT>();
+        .add(id::<TagA>())
+        .add(id::<TagB>())
+        .add(id::<TagC>())
+        .add(id::<TagD>())
+        .add(id::<TagE>())
+        .add(id::<TagF>())
+        .add(id::<TagG>())
+        .add(id::<TagH>())
+        .add(id::<TagI>())
+        .add(id::<TagJ>())
+        .add(id::<TagK>())
+        .add(id::<TagL>())
+        .add(id::<TagM>())
+        .add(id::<TagN>())
+        .add(id::<TagO>())
+        .add(id::<TagP>())
+        .add(id::<TagQ>())
+        .add(id::<TagR>())
+        .add(id::<TagS>())
+        .add(id::<TagT>());
 
     let mut count = 0;
     f.run(|mut it| {
         while it.next() {
             assert_eq!(it.count(), 1);
-            assert_eq!(it.entity(0), e);
+            assert_eq!(it.entity(0).unwrap(), e);
             assert_eq!(it.field_count(), 16);
             count += 1;
         }
@@ -2030,19 +2049,19 @@ fn query_builder_group_by_raw() {
 
     let q = world
         .query::<()>()
-        .with::<&TagX>()
-        .group_by_id_fn(world.entity_from::<TagX>(), Some(group_by_first_id))
+        .with(id::<&TagX>())
+        .group_by_fn(world.entity_from::<TagX>(), Some(group_by_first_id))
         .build();
 
     let q_reverse = world
         .query::<()>()
-        .with::<&TagX>()
-        .group_by_id_fn(world.entity_from::<TagX>(), Some(group_by_first_id_negated))
+        .with(id::<&TagX>())
+        .group_by_fn(world.entity_from::<TagX>(), Some(group_by_first_id_negated))
         .build();
 
-    let e3 = world.entity().add::<TagX>().add::<TagC>();
-    let e2 = world.entity().add::<TagX>().add::<TagB>();
-    let e1 = world.entity().add::<TagX>().add::<TagA>();
+    let e3 = world.entity().add(id::<TagX>()).add(id::<TagC>());
+    let e2 = world.entity().add(id::<TagX>()).add(id::<TagB>());
+    let e1 = world.entity().add(id::<TagX>()).add(id::<TagA>());
 
     let mut count = 0;
 
@@ -2050,11 +2069,11 @@ fn query_builder_group_by_raw() {
         while it.next() {
             assert_eq!(it.count(), 1);
             if count == 0 {
-                assert!(it.entity(0) == e1);
+                assert!(it.entity(0).unwrap() == e1);
             } else if count == 1 {
-                assert!(it.entity(0) == e2);
+                assert!(it.entity(0).unwrap() == e2);
             } else if count == 2 {
-                assert!(it.entity(0) == e3);
+                assert!(it.entity(0).unwrap() == e3);
             } else {
                 panic!();
             }
@@ -2068,11 +2087,11 @@ fn query_builder_group_by_raw() {
         while it.next() {
             assert_eq!(it.count(), 1);
             if count == 0 {
-                assert!(it.entity(0) == e3);
+                assert!(it.entity(0).unwrap() == e3);
             } else if count == 1 {
-                assert!(it.entity(0) == e2);
+                assert!(it.entity(0).unwrap() == e2);
             } else if count == 2 {
-                assert!(it.entity(0) == e1);
+                assert!(it.entity(0).unwrap() == e1);
             } else {
                 panic!();
             }
@@ -2093,19 +2112,19 @@ fn query_builder_group_by_template() {
 
     let q = world
         .query::<()>()
-        .with::<&TagX>()
-        .group_by_fn::<TagX>(Some(group_by_first_id))
+        .with(id::<&TagX>())
+        .group_by_fn(id::<TagX>(), Some(group_by_first_id))
         .build();
 
     let q_reverse = world
         .query::<()>()
-        .with::<&TagX>()
-        .group_by_fn::<TagX>(Some(group_by_first_id_negated))
+        .with(id::<&TagX>())
+        .group_by_fn(id::<TagX>(), Some(group_by_first_id_negated))
         .build();
 
-    let e3 = world.entity().add::<TagX>().add::<TagC>();
-    let e2 = world.entity().add::<TagX>().add::<TagB>();
-    let e1 = world.entity().add::<TagX>().add::<TagA>();
+    let e3 = world.entity().add(id::<TagX>()).add(id::<TagC>());
+    let e2 = world.entity().add(id::<TagX>()).add(id::<TagB>());
+    let e1 = world.entity().add(id::<TagX>()).add(id::<TagA>());
 
     let mut count = 0;
 
@@ -2113,11 +2132,11 @@ fn query_builder_group_by_template() {
         while it.next() {
             assert_eq!(it.count(), 1);
             if count == 0 {
-                assert!(it.entity(0) == e1);
+                assert!(it.entity(0).unwrap() == e1);
             } else if count == 1 {
-                assert!(it.entity(0) == e2);
+                assert!(it.entity(0).unwrap() == e2);
             } else if count == 2 {
-                assert!(it.entity(0) == e3);
+                assert!(it.entity(0).unwrap() == e3);
             } else {
                 panic!();
             }
@@ -2131,11 +2150,11 @@ fn query_builder_group_by_template() {
         while it.next() {
             assert_eq!(it.count(), 1);
             if count == 0 {
-                assert!(it.entity(0) == e3);
+                assert!(it.entity(0).unwrap() == e3);
             } else if count == 1 {
-                assert!(it.entity(0) == e2);
+                assert!(it.entity(0).unwrap() == e2);
             } else if count == 2 {
-                assert!(it.entity(0) == e1);
+                assert!(it.entity(0).unwrap() == e1);
             } else {
                 panic!();
             }
@@ -2171,26 +2190,26 @@ fn query_builder_group_by_iter_one() {
     let tgt_c = world.entity();
     let tag = world.entity();
 
-    world.entity().add_id((rel, tgt_a));
-    let e2 = world.entity().add_id((rel, tgt_b));
-    world.entity().add_id((rel, tgt_c));
+    world.entity().add((rel, tgt_a));
+    let e2 = world.entity().add((rel, tgt_b));
+    world.entity().add((rel, tgt_c));
 
-    world.entity().add_id((rel, tgt_a)).add_id(tag);
-    let e5 = world.entity().add_id((rel, tgt_b)).add_id(tag);
-    world.entity().add_id((rel, tgt_c)).add_id(tag);
+    world.entity().add((rel, tgt_a)).add(tag);
+    let e5 = world.entity().add((rel, tgt_b)).add(tag);
+    world.entity().add((rel, tgt_c)).add(tag);
 
     let q = world
         .query::<()>()
-        .with_id((rel, *flecs::Wildcard))
-        .group_by_id_fn(rel, Some(group_by_rel))
+        .with((rel, *flecs::Wildcard))
+        .group_by_fn(rel, Some(group_by_rel))
         .build();
 
     let mut e2_found = false;
     let mut e5_found = false;
     let mut count = 0;
 
-    q.iterable().set_group_id(tgt_b).each_iter(|it, size, ()| {
-        let e = it.entity(size);
+    q.iterable().set_group(tgt_b).each_iter(|it, size, ()| {
+        let e = it.entity(size).unwrap();
         assert_eq!(it.group_id(), tgt_b);
 
         if e == e2 {
@@ -2211,36 +2230,47 @@ fn query_builder_group_by_iter_one() {
 fn query_builder_group_by_iter_one_template() {
     let world = World::new();
 
-    world.entity().add::<(Rel, TagA)>();
-    let e2 = world.entity().add::<(Rel, TagB)>();
-    world.entity().add::<(Rel, TagC)>();
+    world.entity().add((id::<Rel>(), id::<TagA>()));
+    let e2 = world.entity().add((id::<Rel>(), id::<TagB>()));
+    world.entity().add((id::<Rel>(), id::<TagC>()));
 
-    world.entity().add::<(Rel, TagA)>().add::<Tag>();
-    let e5 = world.entity().add::<(Rel, TagB)>().add::<Tag>();
-    world.entity().add::<(Rel, TagC)>().add::<Tag>();
+    world
+        .entity()
+        .add((id::<Rel>(), id::<TagA>()))
+        .add(id::<Tag>());
+    let e5 = world
+        .entity()
+        .add((id::<Rel>(), id::<TagB>()))
+        .add(id::<Tag>());
+    world
+        .entity()
+        .add((id::<Rel>(), id::<TagC>()))
+        .add(id::<Tag>());
 
     let q = world
         .query::<()>()
-        .with_first::<&Rel>(*flecs::Wildcard)
-        .group_by_fn::<Rel>(Some(group_by_rel))
+        .with((id::<&Rel>(), *flecs::Wildcard))
+        .group_by_fn(id::<Rel>(), Some(group_by_rel))
         .build();
 
     let mut e2_found = false;
     let mut e5_found = false;
     let mut count = 0;
 
-    q.iterable().set_group::<TagB>().each_iter(|it, size, ()| {
-        let e = it.entity(size);
-        assert_eq!(it.group_id(), world.id_from::<TagB>());
+    q.iterable()
+        .set_group(id::<TagB>())
+        .each_iter(|it, size, ()| {
+            let e = it.entity(size).unwrap();
+            assert_eq!(it.group_id(), world.id_view_from(id::<TagB>()));
 
-        if e == e2 {
-            e2_found = true;
-        }
-        if e == e5 {
-            e5_found = true;
-        }
-        count += 1;
-    });
+            if e == e2 {
+                e2_found = true;
+            }
+            if e == e5 {
+                e5_found = true;
+            }
+            count += 1;
+        });
 
     assert_eq!(2, count);
     assert!(e2_found);
@@ -2257,18 +2287,18 @@ fn query_builder_group_by_iter_one_all_groups() {
     let tgt_c = world.entity();
     let tag = world.entity();
 
-    let e1 = world.entity().add_id((rel, tgt_a));
-    let e2 = world.entity().add_id((rel, tgt_b));
-    let e3 = world.entity().add_id((rel, tgt_c));
+    let e1 = world.entity().add((rel, tgt_a));
+    let e2 = world.entity().add((rel, tgt_b));
+    let e3 = world.entity().add((rel, tgt_c));
 
-    let e4 = world.entity().add_id((rel, tgt_a)).add_id(tag);
-    let e5 = world.entity().add_id((rel, tgt_b)).add_id(tag);
-    let e6 = world.entity().add_id((rel, tgt_c)).add_id(tag);
+    let e4 = world.entity().add((rel, tgt_a)).add(tag);
+    let e5 = world.entity().add((rel, tgt_b)).add(tag);
+    let e6 = world.entity().add((rel, tgt_c)).add(tag);
 
     let q = world
         .query::<()>()
-        .with_id((rel, *flecs::Wildcard))
-        .group_by_id_fn(rel, Some(group_by_rel))
+        .with((rel, *flecs::Wildcard))
+        .group_by_fn(rel, Some(group_by_rel))
         .build();
 
     let group_id = Cell::new(0u64);
@@ -2281,7 +2311,7 @@ fn query_builder_group_by_iter_one_all_groups() {
     let e6_found = Cell::new(false);
 
     let func = |it: TableIter<false>, size: usize, ()| {
-        let e = it.entity(size);
+        let e = it.entity(size).unwrap();
         if it.group_id() == group_id.get() {
             if e == e1 {
                 e1_found.set(true);
@@ -2306,19 +2336,19 @@ fn query_builder_group_by_iter_one_all_groups() {
     };
 
     group_id.set(*tgt_b.id());
-    q.iterable().set_group_id(tgt_b).each_iter(func);
+    q.iterable().set_group(tgt_b).each_iter(func);
     assert_eq!(2, count.get());
     assert!(e2_found.get());
     assert!(e5_found.get());
 
     group_id.set(*tgt_a.id());
-    q.iterable().set_group_id(tgt_a).each_iter(func);
+    q.iterable().set_group(tgt_a).each_iter(func);
     assert_eq!(4, count.get());
     assert!(e1_found.get());
     assert!(e4_found.get());
 
     group_id.set(*tgt_c.id());
-    q.iterable().set_group_id(tgt_c).each_iter(func);
+    q.iterable().set_group(tgt_c).each_iter(func);
     assert_eq!(6, count.get());
     assert!(e3_found.get());
     assert!(e6_found.get());
@@ -2333,14 +2363,14 @@ fn query_builder_group_by_default_func_w_id() {
     let tgt_b = world.entity();
     let tgt_c = world.entity();
 
-    let e1 = world.entity().add_id((rel, tgt_c));
-    let e2 = world.entity().add_id((rel, tgt_b));
-    let e3 = world.entity().add_id((rel, tgt_a));
+    let e1 = world.entity().add((rel, tgt_c));
+    let e2 = world.entity().add((rel, tgt_b));
+    let e3 = world.entity().add((rel, tgt_a));
 
     let q = world
         .query::<()>()
-        .with_id((rel, *flecs::Wildcard))
-        .group_by_id(rel)
+        .with((rel, *flecs::Wildcard))
+        .group_by(rel)
         .build();
 
     let mut e1_found = false;
@@ -2349,7 +2379,7 @@ fn query_builder_group_by_default_func_w_id() {
     let mut count = 0;
 
     q.each_iter(|it: TableIter<false>, size: usize, ()| {
-        let e = it.entity(size);
+        let e = it.entity(size).unwrap();
         if e == e1 {
             assert_eq!(it.group_id(), tgt_c);
             assert!(!e1_found);
@@ -2388,14 +2418,14 @@ fn query_builder_group_by_default_func_w_type() {
     let tgt_b = world.entity();
     let tgt_c = world.entity();
 
-    let e1 = world.entity().add_first::<Rel>(tgt_c);
-    let e2 = world.entity().add_first::<Rel>(tgt_b);
-    let e3 = world.entity().add_first::<Rel>(tgt_a);
+    let e1 = world.entity().add((id::<Rel>(), tgt_c));
+    let e2 = world.entity().add((id::<Rel>(), tgt_b));
+    let e3 = world.entity().add((id::<Rel>(), tgt_a));
 
     let q = world
         .query::<()>()
-        .with_first::<&Rel>(*flecs::Wildcard)
-        .group_by::<Rel>()
+        .with((id::<Rel>(), id::<flecs::Wildcard>()))
+        .group_by(id::<Rel>())
         .build();
 
     let mut e1_found = false;
@@ -2404,7 +2434,7 @@ fn query_builder_group_by_default_func_w_type() {
     let mut count = 0;
 
     q.each_iter(|it: TableIter<false>, size: usize, ()| {
-        let e = it.entity(size);
+        let e = it.entity(size).unwrap();
         if e == e1 {
             assert_eq!(it.group_id(), tgt_c);
             assert!(!e1_found);
@@ -2474,14 +2504,14 @@ fn query_builder_group_by_callbacks() {
     let tgt_b = world.entity();
     let tgt_c = world.entity();
 
-    let e1 = world.entity().add_first::<Rel>(tgt_c);
-    let e2 = world.entity().add_first::<Rel>(tgt_b);
-    let e3 = world.entity().add_first::<Rel>(tgt_a);
+    let e1 = world.entity().add((id::<Rel>(), tgt_c));
+    let e2 = world.entity().add((id::<Rel>(), tgt_b));
+    let e3 = world.entity().add((id::<Rel>(), tgt_a));
 
     let q = world
         .query::<()>()
-        .with_first::<&Rel>(*flecs::Wildcard)
-        .group_by::<Rel>()
+        .with((id::<&Rel>(), *flecs::Wildcard))
+        .group_by(id::<Rel>())
         .group_by_ctx(cell_count_group_ctx.as_ptr() as *mut c_void, None)
         .on_group_create(Some(callback_group_create))
         .on_group_delete(Some(callback_group_delete))
@@ -2493,7 +2523,7 @@ fn query_builder_group_by_callbacks() {
     let mut count = 0;
 
     q.each_iter(|it: TableIter<false>, size: usize, ()| {
-        let e = it.entity(size);
+        let e = it.entity(size).unwrap();
         if e == e1 {
             assert_eq!(it.group_id(), tgt_c);
             assert!(!e1_found);
@@ -2536,7 +2566,7 @@ fn query_builder_create_w_no_template_args() {
 
     let q = world
         .query::<()>()
-        .with::<&Position>()
+        .with(id::<&Position>())
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
@@ -2559,11 +2589,11 @@ fn query_builder_any_wildcard() {
     let apple = world.entity();
     let mango = world.entity();
 
-    let e1 = world.entity().add_id((likes, apple)).add_id((likes, mango));
+    let e1 = world.entity().add((likes, apple)).add((likes, mango));
 
     let q = world
         .query::<()>()
-        .with_id((likes, *flecs::Any))
+        .with((likes, *flecs::Any))
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
@@ -2582,25 +2612,25 @@ fn query_builder_cascade() {
 
     let tag = world
         .entity()
-        .add_id((flecs::OnInstantiate::ID, flecs::Inherit::ID));
+        .add((flecs::OnInstantiate::ID, flecs::Inherit::ID));
 
     let foo_ = world.entity();
     let bar = world.entity();
 
-    let e0 = world.entity().add_id(tag);
-    let e1 = world.entity().is_a_id(e0);
-    let e2 = world.entity().is_a_id(e1);
-    let e3 = world.entity().is_a_id(e2);
+    let e0 = world.entity().add(tag);
+    let e1 = world.entity().is_a(e0);
+    let e2 = world.entity().is_a(e1);
+    let e3 = world.entity().is_a(e2);
 
     let q = world
         .query::<()>()
-        .with_id(tag)
+        .with(tag)
         .cascade_id(*flecs::IsA)
         .set_cached()
         .build();
 
-    e1.add_id(bar);
-    e2.add_id(foo_);
+    e1.add(bar);
+    e2.add(foo_);
 
     let mut e1_found = false;
     let mut e2_found = false;
@@ -2642,26 +2672,26 @@ fn query_builder_cascade_desc() {
 
     let tag = world
         .entity()
-        .add_id((flecs::OnInstantiate::ID, flecs::Inherit::ID));
+        .add((flecs::OnInstantiate::ID, flecs::Inherit::ID));
 
     let foo_ = world.entity();
     let bar = world.entity();
 
-    let e0 = world.entity().add_id(tag);
-    let e1 = world.entity().is_a_id(e0);
-    let e2 = world.entity().is_a_id(e1);
-    let e3 = world.entity().is_a_id(e2);
+    let e0 = world.entity().add(tag);
+    let e1 = world.entity().is_a(e0);
+    let e2 = world.entity().is_a(e1);
+    let e3 = world.entity().is_a(e2);
 
     let q = world
         .query::<()>()
-        .with_id(tag)
+        .with(tag)
         .cascade_id(*flecs::IsA)
         .desc()
         .set_cached()
         .build();
 
-    e1.add_id(bar);
-    e2.add_id(foo_);
+    e1.add(bar);
+    e2.add(foo_);
 
     let mut e1_found = false;
     let mut e2_found = false;
@@ -2705,20 +2735,20 @@ fn query_builder_cascade_w_relationship() {
     let foo_ = world.entity();
     let bar = world.entity();
 
-    let e0 = world.entity().add_id(tag);
-    let e1 = world.entity().child_of_id(e0);
-    let e2 = world.entity().child_of_id(e1);
-    let e3 = world.entity().child_of_id(e2);
+    let e0 = world.entity().add(tag);
+    let e1 = world.entity().child_of(e0);
+    let e2 = world.entity().child_of(e1);
+    let e3 = world.entity().child_of(e2);
 
     let q = world
         .query::<()>()
-        .with_id(tag)
+        .with(tag)
         .cascade_id(*flecs::ChildOf)
         .set_cached()
         .build();
 
-    e1.add_id(bar);
-    e2.add_id(foo_);
+    e1.add(bar);
+    e2.add(foo_);
 
     let mut e1_found = false;
     let mut e2_found = false;
@@ -2758,24 +2788,24 @@ fn query_builder_cascade_w_relationship() {
 fn query_builder_up_w_type() {
     let world = World::new();
 
-    world.component::<Rel>().add_id(*flecs::Traversable);
+    world.component::<Rel>().add(*flecs::Traversable);
 
     let q = world
         .query::<&SelfRef2>()
-        .with::<&Other>()
+        .with(id::<&Other>())
         .src()
-        .up_type::<Rel>()
+        .up_id(id::<Rel>())
         .set_in()
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
     let base = world.entity().set(Other { value: 10 });
 
-    let e = world.entity().add_first::<Rel>(base);
+    let e = world.entity().add((id::<Rel>(), base));
     e.set(SelfRef2 { value: e.id() });
-    let e = world.entity().add_first::<Rel>(base);
+    let e = world.entity().add((id::<Rel>(), base));
     e.set(SelfRef2 { value: e.id() });
-    let e = world.entity().add_first::<Rel>(base);
+    let e = world.entity().add((id::<Rel>(), base));
     e.set(SelfRef2 { value: e.id() });
 
     let mut count = 0;
@@ -2788,7 +2818,7 @@ fn query_builder_up_w_type() {
             assert_eq!(o.value, 10);
 
             for i in it.iter() {
-                assert_eq!(it.entity(i), s[i].value);
+                assert_eq!(it.entity(i).unwrap(), s[i].value);
                 count += 1;
             }
         }
@@ -2801,26 +2831,26 @@ fn query_builder_up_w_type() {
 fn query_builder_cascade_w_type() {
     let world = World::new();
 
-    world.component::<Rel>().add_id(*flecs::Traversable);
+    world.component::<Rel>().add(*flecs::Traversable);
 
     let tag = world.entity();
     let foo_ = world.entity();
     let bar = world.entity();
 
-    let e0 = world.entity().add_id(tag);
-    let e1 = world.entity().add_first::<Rel>(e0);
-    let e2 = world.entity().add_first::<Rel>(e1);
-    let e3 = world.entity().add_first::<Rel>(e2);
+    let e0 = world.entity().add(tag);
+    let e1 = world.entity().add((id::<Rel>(), e0));
+    let e2 = world.entity().add((id::<Rel>(), e1));
+    let e3 = world.entity().add((id::<Rel>(), e2));
 
     let q = world
         .query::<()>()
-        .with_id(tag)
-        .cascade_type::<Rel>()
+        .with(tag)
+        .cascade_id(id::<Rel>())
         .set_cached()
         .build();
 
-    e1.add_id(bar);
-    e2.add_id(foo_);
+    e1.add(bar);
+    e2.add(foo_);
 
     let mut e1_found = false;
     let mut e2_found = false;
@@ -2865,7 +2895,7 @@ fn query_builder_named_query() {
 
     let q = world
         .query_named::<()>("my_query")
-        .with::<&Position>()
+        .with(id::<&Position>())
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
@@ -2887,10 +2917,10 @@ fn query_builder_term_w_write() {
 
     let q = world
         .query::<()>()
-        .with::<&Position>()
-        .with::<&Position>()
+        .with(id::<&Position>())
+        .with(id::<&Position>())
         .write_curr()
-        .with::<&mut Position>()
+        .with(id::<&mut Position>())
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
@@ -2908,8 +2938,8 @@ fn query_builder_term_w_read() {
 
     let q = world
         .query::<()>()
-        .with::<&Position>()
-        .with::<&Position>()
+        .with(id::<&Position>())
+        .with(id::<&Position>())
         .read_curr()
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
@@ -2935,7 +2965,7 @@ fn query_builder_iter_w_stage() {
     //    let mut count = 0;
     //     q.each(stage, [&](flecs::iter& it, size_t i, Position&) {
     //         assert_eq!(it.world(), stage);
-    //         assert_eq!(it.entity(i), e1);
+    //         assert_eq!(it.entity(i).unwrap(), e1);
     //         count += 1;
     //     });
 
@@ -2958,7 +2988,7 @@ fn query_builder_builder_force_assign_operator() {
 
     // let q = world
     //     .query::<()>()
-    //     .with::<&Position>()
+    //     .with(id::<&Position>())
     //     .set_cache_kind(QueryCacheKind::Auto)
     //     .build();
     // let entity_query = q.entity().id();
@@ -3209,15 +3239,19 @@ fn query_builder_world_each_query_2_components_no_entity() {
 fn query_builder_term_after_arg() {
     let world = World::new();
 
-    let e_1 = world.entity().add::<TagA>().add::<TagB>().add::<TagC>();
+    let e_1 = world
+        .entity()
+        .add(id::<TagA>())
+        .add(id::<TagB>())
+        .add(id::<TagC>());
 
-    world.entity().add::<TagA>().add::<TagB>();
+    world.entity().add(id::<TagA>()).add(id::<TagB>());
 
     let f = world
         .query::<(&TagA, &TagB)>()
         .term_at(0)
-        .set_src_id(*flecs::This_) // dummy
-        .with::<&TagC>()
+        .set_src(*flecs::This_) // dummy
+        .with(id::<&TagC>())
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
@@ -3227,7 +3261,7 @@ fn query_builder_term_after_arg() {
     f.run(|mut it| {
         while it.next() {
             for i in it.iter() {
-                assert_eq!(it.entity(i), e_1);
+                assert_eq!(it.entity(i).unwrap(), e_1);
                 count += 1;
             }
         }
@@ -3273,7 +3307,7 @@ fn query_builder_const_in_term() {
 
     let f = world
         .query::<()>()
-        .with::<&Position>()
+        .with(id::<&Position>())
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
@@ -3297,8 +3331,11 @@ fn query_builder_const_in_term() {
 fn query_builder_const_optional() {
     let world = World::new();
 
-    world.entity().set(Position { x: 10, y: 20 }).add::<TagD>();
-    world.entity().add::<TagD>();
+    world
+        .entity()
+        .set(Position { x: 10, y: 20 })
+        .add(id::<TagD>());
+    world.entity().add(id::<TagD>());
 
     let f = world
         .query::<(&TagD, Option<&Position>)>()
@@ -3332,7 +3369,7 @@ fn query_builder_2_terms_w_expr() {
     let a = world.entity_named("A");
     let b = world.entity_named("B");
 
-    let e1 = world.entity().add_id(a).add_id(b);
+    let e1 = world.entity().add(a).add(b);
 
     let f = world
         .query::<()>()
@@ -3344,7 +3381,7 @@ fn query_builder_2_terms_w_expr() {
 
     let mut count = 0;
     f.each_iter(|it, index, ()| {
-        if it.entity(index) == e1 {
+        if it.entity(index).unwrap() == e1 {
             assert_eq!(it.id(0), a);
             assert_eq!(it.id(1), b);
             count += 1;
@@ -3386,20 +3423,20 @@ fn query_builder_operator_shortcuts() {
 
     let query = world
         .query::<()>()
-        .with_id(a)
+        .with(a)
         .and()
-        .with_id(b)
+        .with(b)
         .or()
-        .with_id(c)
-        .with_id(d)
+        .with(c)
+        .with(d)
         .not()
-        .with_id(e)
+        .with(e)
         .optional()
-        .with_id(f)
+        .with(f)
         .and_from()
-        .with_id(g)
+        .with(g)
         .or_from()
-        .with_id(h)
+        .with(h)
         .not_from()
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
@@ -3448,13 +3485,13 @@ fn query_builder_inout_shortcuts() {
 
     let query = world
         .query::<()>()
-        .with_id(a)
+        .with(a)
         .set_in()
-        .with_id(b)
+        .with(b)
         .set_out()
-        .with_id(c)
+        .with(c)
         .set_inout()
-        .with_id(d)
+        .with(d)
         .set_inout_none()
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
@@ -3524,8 +3561,8 @@ fn query_builder_iter_column_w_const_as_ptr() {
         .build();
 
     let base = world.prefab().set(Position { x: 10, y: 20 });
-    world.entity().is_a_id(base);
-    world.entity().is_a_id(base);
+    world.entity().is_a(base);
+    world.entity().is_a(base);
 
     let mut count = 0;
     f.run(|mut it| {
@@ -3543,13 +3580,13 @@ fn query_builder_iter_column_w_const_as_ptr() {
 }
 
 #[test]
-fn query_builder_with_id() {
+fn query_builder_with() {
     let world = World::new();
 
     let q = world
         .query::<()>()
-        .with_id(world.id_from::<Position>())
-        .with_id(world.id_from::<Velocity>())
+        .with(world.id_view_from(id::<Position>()))
+        .with(world.id_view_from(id::<Velocity>()))
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
@@ -3576,7 +3613,7 @@ fn query_builder_with_name() {
 
     let q = world
         .query::<()>()
-        .with::<&Position>()
+        .with(id::<&Position>())
         .with_name("flecs.common_test.Velocity")
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
@@ -3602,8 +3639,8 @@ fn query_builder_with_component() {
 
     let q = world
         .query::<()>()
-        .with::<&Position>()
-        .with::<&Velocity>()
+        .with(id::<&Position>())
+        .with(id::<&Velocity>())
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
@@ -3632,19 +3669,19 @@ fn query_builder_with_pair_id() {
 
     let q = world
         .query::<()>()
-        .with::<&Position>()
-        .with_id((likes, apples))
+        .with(id::<&Position>())
+        .with((likes, apples))
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
     let e1 = world
         .entity()
         .set(Position { x: 0, y: 0 })
-        .add_id((likes, apples));
+        .add((likes, apples));
     world
         .entity()
         .set(Position { x: 0, y: 0 })
-        .add_id((likes, pears));
+        .add((likes, pears));
 
     let mut count = 0;
     q.each_entity(|e, _| {
@@ -3665,7 +3702,7 @@ fn query_builder_with_pair_name() {
 
     let q = world
         .query::<()>()
-        .with::<&Position>()
+        .with(id::<&Position>())
         .with_names("likes", "Apples")
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
@@ -3673,11 +3710,11 @@ fn query_builder_with_pair_name() {
     let e1 = world
         .entity()
         .set(Position { x: 0, y: 0 })
-        .add_id((likes, apples));
+        .add((likes, apples));
     world
         .entity()
         .set(Position { x: 0, y: 0 })
-        .add_id((likes, pears));
+        .add((likes, pears));
 
     let mut count = 0;
     q.each_entity(|e, _| {
@@ -3694,19 +3731,19 @@ fn query_builder_with_pair_components() {
 
     let q = world
         .query::<()>()
-        .with::<&Position>()
-        .with::<(Likes, Apples)>()
+        .with(id::<&Position>())
+        .with((id::<Likes>(), id::<Apples>()))
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
     let e1 = world
         .entity()
         .set(Position { x: 0, y: 0 })
-        .add::<(Likes, Apples)>();
+        .add((id::<Likes>(), id::<Apples>()));
     world
         .entity()
         .set(Position { x: 0, y: 0 })
-        .add::<(Likes, Pears)>();
+        .add((id::<Likes>(), id::<Pears>()));
 
     let mut count = 0;
     q.each_entity(|e, _| {
@@ -3726,19 +3763,19 @@ fn query_builder_with_pair_component_id() {
 
     let q = world
         .query::<()>()
-        .with::<&Position>()
-        .with_first::<&Likes>(apples)
+        .with(id::<&Position>())
+        .with((id::<&Likes>(), apples))
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
     let e1 = world
         .entity()
         .set(Position { x: 0, y: 0 })
-        .add_first::<Likes>(apples);
+        .add((id::<Likes>(), apples));
     world
         .entity()
         .set(Position { x: 0, y: 0 })
-        .add_first::<Likes>(pears);
+        .add((id::<Likes>(), pears));
 
     let mut count = 0;
     q.each_entity(|e, _| {
@@ -3759,19 +3796,19 @@ fn query_builder_with_pair_name_component_id() {
 
     let q = world
         .query::<()>()
-        .with::<Position>()
-        .with_second_id("Likes", apples)
+        .with(id::<Position>())
+        .with_name_first("Likes", apples)
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
     let e1 = world
         .entity()
         .set(Position { x: 0, y: 0 })
-        .add_id((likes, apples));
+        .add((likes, apples));
     world
         .entity()
         .set(Position { x: 0, y: 0 })
-        .add_id((likes, pears));
+        .add((likes, pears));
 
     let mut count = 0;
     q.each_entity(|e, _| {
@@ -3791,19 +3828,19 @@ fn query_builder_with_pair_component_name() {
 
     let q = world
         .query::<()>()
-        .with::<&Position>()
-        .with_first_name::<&Likes>("Apples")
+        .with(id::<&Position>())
+        .with_name_second(id::<Likes>(), "Apples")
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
     let e1 = world
         .entity()
         .set(Position { x: 0, y: 0 })
-        .add_first::<Likes>(apples);
+        .add((id::<Likes>(), apples));
     world
         .entity()
         .set(Position { x: 0, y: 0 })
-        .add_first::<Likes>(pears);
+        .add((id::<Likes>(), pears));
 
     let mut count = 0;
     q.each_entity(|e, _| {
@@ -3828,7 +3865,7 @@ fn query_builder_with_enum() {
 
     let q = world
         .query::<()>()
-        .with::<&Position>()
+        .with(id::<&Position>())
         .with_enum(Color::Green)
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
@@ -3852,13 +3889,13 @@ fn query_builder_with_enum() {
 }
 
 #[test]
-fn query_builder_without_id() {
+fn query_builder_without() {
     let world = World::new();
 
     let q = world
         .query::<()>()
-        .with_id(world.id_from::<Position>())
-        .without_id(world.id_from::<Velocity>())
+        .with(world.id_view_from(id::<Position>()))
+        .without(world.id_view_from(id::<Velocity>()))
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
@@ -3885,7 +3922,7 @@ fn query_builder_without_name() {
 
     let q = world
         .query::<()>()
-        .with_id(world.id_from::<Position>())
+        .with(world.id_view_from(id::<Position>()))
         .without_name("flecs.common_test.Velocity")
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
@@ -3911,8 +3948,8 @@ fn query_builder_without_component() {
 
     let q = world
         .query::<()>()
-        .with::<&Position>()
-        .without::<&Velocity>()
+        .with(id::<&Position>())
+        .without(id::<Velocity>())
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
@@ -3941,19 +3978,19 @@ fn query_builder_without_pair_id() {
 
     let q = world
         .query::<()>()
-        .with::<&Position>()
-        .without_id((likes, apples))
+        .with(id::<&Position>())
+        .without((likes, apples))
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
     world
         .entity()
         .set(Position { x: 0, y: 0 })
-        .add_id((likes, apples));
+        .add((likes, apples));
     let e2 = world
         .entity()
         .set(Position { x: 0, y: 0 })
-        .add_id((likes, pears));
+        .add((likes, pears));
 
     let mut count = 0;
     q.each_entity(|e, _| {
@@ -3974,7 +4011,7 @@ fn query_builder_without_pair_name() {
 
     let q = world
         .query::<()>()
-        .with::<&Position>()
+        .with(id::<&Position>())
         .without_names("likes", "Apples")
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
@@ -3982,11 +4019,11 @@ fn query_builder_without_pair_name() {
     world
         .entity()
         .set(Position { x: 0, y: 0 })
-        .add_id((likes, apples));
+        .add((likes, apples));
     let e2 = world
         .entity()
         .set(Position { x: 0, y: 0 })
-        .add_id((likes, pears));
+        .add((likes, pears));
 
     let mut count = 0;
     q.each_entity(|e, _| {
@@ -4003,19 +4040,19 @@ fn query_builder_without_pair_components() {
 
     let q = world
         .query::<()>()
-        .with::<&Position>()
-        .without::<(Likes, Apples)>()
+        .with(id::<&Position>())
+        .without((id::<Likes>(), id::<Apples>()))
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
     world
         .entity()
         .set(Position { x: 0, y: 0 })
-        .add::<(Likes, Apples)>();
+        .add((id::<Likes>(), id::<Apples>()));
     let e2 = world
         .entity()
         .set(Position { x: 0, y: 0 })
-        .add::<(Likes, Pears)>();
+        .add((id::<Likes>(), id::<Pears>()));
 
     let mut count = 0;
     q.each_entity(|e, _| {
@@ -4035,19 +4072,19 @@ fn query_builder_without_pair_component_id() {
 
     let q = world
         .query::<()>()
-        .with::<&Position>()
-        .without_first::<&Likes>(apples)
+        .with(id::<&Position>())
+        .without((id::<&Likes>(), apples))
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
     world
         .entity()
         .set(Position { x: 0, y: 0 })
-        .add_first::<Likes>(apples);
+        .add((id::<Likes>(), apples));
     let e2 = world
         .entity()
         .set(Position { x: 0, y: 0 })
-        .add_first::<Likes>(pears);
+        .add((id::<Likes>(), pears));
 
     let mut count = 0;
     q.each_entity(|e, _| {
@@ -4067,19 +4104,19 @@ fn query_builder_without_pair_component_name() {
 
     let q = world
         .query::<()>()
-        .with::<&Position>()
-        .without_first_name::<&Likes>("Apples")
+        .with(id::<&Position>())
+        .without_name_second(id::<Likes>(), "Apples")
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
     world
         .entity()
         .set(Position { x: 0, y: 0 })
-        .add_first::<Likes>(apples);
+        .add((id::<Likes>(), apples));
     let e2 = world
         .entity()
         .set(Position { x: 0, y: 0 })
-        .add_first::<Likes>(pears);
+        .add((id::<Likes>(), pears));
 
     let mut count = 0;
     q.each_entity(|e, _| {
@@ -4100,19 +4137,19 @@ fn query_builder_without_pair_name_component_id() {
 
     let q = world
         .query::<()>()
-        .with::<&Position>()
-        .without_second_id("Likes", apples)
+        .with(id::<&Position>())
+        .without_name_first("Likes", apples)
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
     world
         .entity()
         .set(Position { x: 0, y: 0 })
-        .add_id((likes, apples));
+        .add((likes, apples));
     let e2 = world
         .entity()
         .set(Position { x: 0, y: 0 })
-        .add_id((likes, pears));
+        .add((likes, pears));
 
     let mut count = 0;
     q.each_entity(|e, _| {
@@ -4137,7 +4174,7 @@ fn query_builder_without_enum() {
 
     let q = world
         .query::<()>()
-        .with::<&Position>()
+        .with(id::<&Position>())
         .without_enum(Color::Green)
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
@@ -4161,18 +4198,18 @@ fn query_builder_without_enum() {
 }
 
 #[test]
-fn query_builder_write_id() {
+fn query_builder_write() {
     let world = World::new();
 
     let q = world
         .query::<()>()
-        .with::<&Position>()
-        .write_id(world.id_from::<Position>())
+        .with(id::<&Position>())
+        .write(world.id_view_from(id::<Position>()))
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
     assert_eq!(q.term(1).inout(), InOutKind::Out);
-    assert_eq!(q.term(1).first_id(), world.id_from::<Position>());
+    assert_eq!(q.term(1).first_id(), world.id_view_from(id::<Position>()));
     assert_eq!(q.term(1).src_id(), 0);
 }
 
@@ -4184,13 +4221,13 @@ fn query_builder_write_name() {
 
     let q = world
         .query::<()>()
-        .with::<&Position>()
+        .with(id::<&Position>())
         .write_name("flecs.common_test.Position")
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
     assert_eq!(q.term(1).inout(), InOutKind::Out);
-    assert_eq!(q.term(1).first_id(), world.id_from::<Position>());
+    assert_eq!(q.term(1).first_id(), world.id_view_from(id::<Position>()));
     assert_eq!(q.term(1).src_id(), 0);
 }
 
@@ -4202,13 +4239,13 @@ fn query_builder_write_component() {
 
     let q = world
         .query::<()>()
-        .with::<&Position>()
-        .write::<Position>()
+        .with(id::<&Position>())
+        .write(id::<Position>())
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
     assert_eq!(q.term(1).inout(), InOutKind::Out);
-    assert_eq!(q.term(1).first_id(), world.id_from::<Position>());
+    assert_eq!(q.term(1).first_id(), world.id_view_from(id::<Position>()));
     assert_eq!(q.term(1).src_id(), 0);
 }
 
@@ -4221,8 +4258,8 @@ fn query_builder_write_pair_id() {
 
     let q = world
         .query::<()>()
-        .with::<&Position>()
-        .write_id((likes, apples))
+        .with(id::<&Position>())
+        .write((likes, apples))
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
@@ -4241,7 +4278,7 @@ fn query_builder_write_pair_name() {
 
     let q = world
         .query::<()>()
-        .with::<&Position>()
+        .with(id::<&Position>())
         .write_names("likes", "Apples")
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
@@ -4258,14 +4295,14 @@ fn query_builder_write_pair_components() {
 
     let q = world
         .query::<()>()
-        .with::<&Position>()
-        .write::<(Likes, Apples)>()
+        .with(id::<&Position>())
+        .write((id::<Likes>(), id::<Apples>()))
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
     assert_eq!(q.term(1).inout(), InOutKind::Out);
-    assert_eq!(q.term(1).first_id(), world.id_from::<Likes>());
-    assert_eq!(q.term(1).second_id(), world.id_from::<Apples>());
+    assert_eq!(q.term(1).first_id(), world.id_view_from(id::<Likes>()));
+    assert_eq!(q.term(1).second_id(), world.id_view_from(id::<Apples>()));
     assert_eq!(q.term(1).src_id(), 0);
 }
 
@@ -4277,13 +4314,13 @@ fn query_builder_write_pair_component_id() {
 
     let q = world
         .query::<()>()
-        .with::<&Position>()
-        .write_first::<&Likes>(apples)
+        .with(id::<&Position>())
+        .write((id::<&Likes>(), apples))
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
     assert_eq!(q.term(1).inout(), InOutKind::Out);
-    assert_eq!(q.term(1).first_id(), world.id_from::<Likes>());
+    assert_eq!(q.term(1).first_id(), world.id_view_from(id::<Likes>()));
     assert_eq!(q.term(1).second_id(), apples);
     assert_eq!(q.term(1).src_id(), 0);
 }
@@ -4296,13 +4333,13 @@ fn query_builder_write_pair_component_name() {
 
     let q = world
         .query::<()>()
-        .with::<&Position>()
-        .write_first_name::<&Likes>("Apples")
+        .with(id::<&Position>())
+        .write_name_second(id::<Likes>(), "Apples")
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
     assert_eq!(q.term(1).inout(), InOutKind::Out);
-    assert_eq!(q.term(1).first_id(), world.id_from::<Likes>());
+    assert_eq!(q.term(1).first_id(), world.id_view_from(id::<Likes>()));
     assert_eq!(q.term(1).second_id(), apples);
     assert_eq!(q.term(1).src_id(), 0);
 }
@@ -4321,30 +4358,30 @@ fn query_builder_write_enum() {
 
     let q = world
         .query::<()>()
-        .with::<&Position>()
+        .with(id::<&Position>())
         .write_enum(Color::Green)
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
     assert_eq!(q.term(1).inout(), InOutKind::Out);
-    assert_eq!(q.term(1).first_id(), world.id_from::<Color>());
+    assert_eq!(q.term(1).first_id(), world.id_view_from(id::<Color>()));
     assert_eq!(q.term(1).second_id(), world.entity_from_enum(Color::Green));
     assert_eq!(q.term(1).src_id(), 0);
 }
 
 #[test]
-fn query_builder_read_id() {
+fn query_builder_read() {
     let world = World::new();
 
     let q = world
         .query::<()>()
-        .with::<&Position>()
-        .read_id(world.id_from::<Position>())
+        .with(id::<&Position>())
+        .read(world.id_view_from(id::<Position>()))
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
     assert_eq!(q.term(1).inout(), InOutKind::In);
-    assert_eq!(q.term(1).first_id(), world.id_from::<Position>());
+    assert_eq!(q.term(1).first_id(), world.id_view_from(id::<Position>()));
     assert_eq!(q.term(1).src_id(), 0);
 }
 
@@ -4356,13 +4393,13 @@ fn query_builder_read_name() {
 
     let q = world
         .query::<()>()
-        .with::<&Position>()
+        .with(id::<&Position>())
         .read_name("flecs.common_test.Position")
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
     assert_eq!(q.term(1).inout(), InOutKind::In);
-    assert_eq!(q.term(1).first_id(), world.id_from::<Position>());
+    assert_eq!(q.term(1).first_id(), world.id_view_from(id::<Position>()));
     assert_eq!(q.term(1).src_id(), 0);
 }
 
@@ -4374,13 +4411,13 @@ fn query_builder_read_component() {
 
     let q = world
         .query::<()>()
-        .with::<&Position>()
-        .read::<&Position>()
+        .with(id::<&Position>())
+        .read(id::<Position>())
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
     assert_eq!(q.term(1).inout(), InOutKind::In);
-    assert_eq!(q.term(1).first_id(), world.id_from::<Position>());
+    assert_eq!(q.term(1).first_id(), world.id_view_from(id::<Position>()));
     assert_eq!(q.term(1).src_id(), 0);
 }
 
@@ -4393,8 +4430,8 @@ fn query_builder_read_pair_id() {
 
     let q = world
         .query::<()>()
-        .with::<&Position>()
-        .read_id((likes, apples))
+        .with(id::<&Position>())
+        .read((likes, apples))
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
@@ -4413,7 +4450,7 @@ fn query_builder_read_pair_name() {
 
     let q = world
         .query::<()>()
-        .with::<&Position>()
+        .with(id::<&Position>())
         .read_names("likes", "Apples")
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
@@ -4430,14 +4467,14 @@ fn query_builder_read_pair_components() {
 
     let q = world
         .query::<()>()
-        .with::<&Position>()
-        .read::<(Likes, Apples)>()
+        .with(id::<&Position>())
+        .read((id::<Likes>(), id::<Apples>()))
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
     assert_eq!(q.term(1).inout(), InOutKind::In);
-    assert_eq!(q.term(1).first_id(), world.id_from::<Likes>());
-    assert_eq!(q.term(1).second_id(), world.id_from::<Apples>());
+    assert_eq!(q.term(1).first_id(), world.id_view_from(id::<Likes>()));
+    assert_eq!(q.term(1).second_id(), world.id_view_from(id::<Apples>()));
     assert_eq!(q.term(1).src_id(), 0);
 }
 
@@ -4449,13 +4486,13 @@ fn query_builder_read_pair_component_id() {
 
     let q = world
         .query::<()>()
-        .with::<&Position>()
-        .read_first::<&Likes>(apples)
+        .with(id::<&Position>())
+        .read((id::<Likes>(), apples))
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
     assert_eq!(q.term(1).inout(), InOutKind::In);
-    assert_eq!(q.term(1).first_id(), world.id_from::<Likes>());
+    assert_eq!(q.term(1).first_id(), world.id_view_from(id::<Likes>()));
     assert_eq!(q.term(1).second_id(), apples);
     assert_eq!(q.term(1).src_id(), 0);
 }
@@ -4468,13 +4505,13 @@ fn query_builder_read_pair_component_name() {
 
     let q = world
         .query::<()>()
-        .with::<&Position>()
-        .read_first_name::<&Likes>("Apples")
+        .with(id::<&Position>())
+        .read_name_second(id::<Likes>(), "Apples")
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
     assert_eq!(q.term(1).inout(), InOutKind::In);
-    assert_eq!(q.term(1).first_id(), world.id_from::<Likes>());
+    assert_eq!(q.term(1).first_id(), world.id_view_from(id::<Likes>()));
     assert_eq!(q.term(1).second_id(), apples);
 
     assert_eq!(q.term(1).src_id(), 0);
@@ -4494,13 +4531,13 @@ fn query_builder_read_enum() {
 
     let q = world
         .query::<()>()
-        .with::<&Position>()
+        .with(id::<&Position>())
         .read_enum(Color::Green)
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
     assert_eq!(q.term(1).inout(), InOutKind::In);
-    assert_eq!(q.term(1).first_id(), world.id_from::<Color>());
+    assert_eq!(q.term(1).first_id(), world.id_view_from(id::<Color>()));
     assert_eq!(q.term(1).second_id(), world.entity_from_enum(Color::Green));
     assert_eq!(q.term(1).src_id(), 0);
 }
@@ -4512,7 +4549,7 @@ fn query_builder_assign_after_init() {
     #[allow(unused_assignments)]
     let mut f: Query<()> = world.new_query::<()>();
     let mut fb = world.query::<()>();
-    fb.with::<&Position>();
+    fb.with(id::<&Position>());
     fb.set_cache_kind(QueryCacheKind::Auto);
     f = fb.build();
 
@@ -4533,7 +4570,7 @@ fn query_builder_with_t_inout() {
 
     let f = world
         .query::<()>()
-        .with_id(world.id_from::<Position>())
+        .with(world.id_view_from(id::<Position>()))
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
@@ -4546,7 +4583,7 @@ fn query_builder_with_t_inout_1() {
 
     let f = world
         .query::<()>()
-        .with::<&Position>()
+        .with(id::<&Position>())
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
@@ -4559,7 +4596,7 @@ fn query_builder_with_r_t_inout_2() {
 
     let f = world
         .query::<()>()
-        .with::<(Position, Velocity)>()
+        .with((id::<Position>(), id::<Velocity>()))
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
@@ -4572,7 +4609,7 @@ fn query_builder_with_r_t_inout_3() {
 
     let f = world
         .query::<()>()
-        .with_first::<&Position>(world.entity_from::<Velocity>())
+        .with((id::<Position>(), world.entity_from::<Velocity>()))
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
@@ -4585,7 +4622,7 @@ fn query_builder_with_r_t_inout() {
 
     let f = world
         .query::<()>()
-        .with_id((
+        .with((
             world.entity_from::<Position>(),
             world.entity_from::<Velocity>(),
         ))
@@ -4805,12 +4842,12 @@ fn query_builder_var_src_w_prefixed_name() {
 
     let r = world
         .query::<()>()
-        .with::<&Foo>()
+        .with(id::<&Foo>())
         .set_src_name("$Var")
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
-    let e = world.entity().add::<Foo>();
+    let e = world.entity().add(id::<Foo>());
 
     let mut count = 0;
     r.run(|mut it| {
@@ -4829,20 +4866,20 @@ fn query_builder_var_first_w_prefixed_name() {
 
     let r = world
         .query::<()>()
-        .with::<&Foo>()
+        .with(id::<&Foo>())
         .term()
         .set_first_name("$Var")
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
-    let e = world.entity().add::<Foo>();
+    let e = world.entity().add(id::<Foo>());
 
     let mut count = 0;
     r.run(|mut it| {
         while it.next() {
             assert_eq!(it.count(), 1);
-            assert_eq!(it.entity(0), e);
-            assert_eq!(it.get_var_by_name("Var"), world.id_from::<Foo>());
+            assert_eq!(it.entity(0).unwrap(), e);
+            assert_eq!(it.get_var_by_name("Var"), world.id_view_from(id::<Foo>()));
             count += 1;
         }
     });
@@ -4856,19 +4893,19 @@ fn query_builder_var_second_w_prefixed_name() {
 
     let r = world
         .query::<()>()
-        .with::<&Foo>()
+        .with(id::<&Foo>())
         .set_second_name("$Var")
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
     let t = world.entity();
-    let e = world.entity().add_first::<Foo>(t);
+    let e = world.entity().add((id::<Foo>(), t));
 
     let mut count = 0;
     r.run(|mut it| {
         while it.next() {
             assert_eq!(it.count(), 1);
-            assert_eq!(it.entity(0), e);
+            assert_eq!(it.entity(0).unwrap(), e);
             assert_eq!(it.get_var_by_name("Var"), t);
             count += 1;
         }
@@ -4885,18 +4922,18 @@ fn query_builder_term_w_second_var_string() {
 
     let r = world
         .query::<()>()
-        .with_first_id(foo_, "$Var")
+        .with_name_second(foo_, "$Var")
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
     let t = world.entity();
-    let e = world.entity().add_id((foo_, t));
+    let e = world.entity().add((foo_, t));
 
     let mut count = 0;
     r.run(|mut it| {
         while it.next() {
             assert_eq!(it.count(), 1);
-            assert_eq!(it.entity(0), e);
+            assert_eq!(it.entity(0).unwrap(), e);
             assert_eq!(it.get_var_by_name("Var"), t);
             count += 1;
         }
@@ -4911,18 +4948,18 @@ fn query_builder_term_type_w_second_var_string() {
 
     let r = world
         .query::<()>()
-        .with_first_name::<&Foo>("$Var")
+        .with_name_second(id::<Foo>(), "$Var")
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
     let t = world.entity();
-    let e = world.entity().add_first::<Foo>(t);
+    let e = world.entity().add((id::<Foo>(), t));
 
     let mut count = 0;
     r.run(|mut it| {
         while it.next() {
             assert_eq!(it.count(), 1);
-            assert_eq!(it.entity(0), e);
+            assert_eq!(it.entity(0).unwrap(), e);
             assert_eq!(it.get_var_by_name("Var"), t);
             count += 1;
         }
@@ -5022,21 +5059,21 @@ fn query_builder_scope() {
     let tag_a = world.entity();
     let tag_b = world.entity();
 
-    world.entity().add_id(root).add_id(tag_a).add_id(tag_b);
+    world.entity().add(root).add(tag_a).add(tag_b);
 
-    let e2 = world.entity().add_id(root).add_id(tag_a);
+    let e2 = world.entity().add(root).add(tag_a);
 
-    world.entity().add_id(root).add_id(tag_b);
+    world.entity().add(root).add(tag_b);
 
-    world.entity().add_id(root);
+    world.entity().add(root);
 
     let r = world
         .query::<()>()
-        .with_id(root)
+        .with(root)
         .scope_open()
         .not()
-        .with_id(tag_a)
-        .without_id(tag_b)
+        .with(tag_a)
+        .without(tag_b)
         .scope_close()
         .set_cache_kind(QueryCacheKind::Auto)
         .build();

--- a/flecs_ecs/tests/flecs/query_rust_test.rs
+++ b/flecs_ecs/tests/flecs/query_rust_test.rs
@@ -105,7 +105,7 @@ fn test_trait_query() {
     query.run(|mut it| {
         while it.next() {
             for i in it.iter() {
-                let e = it.entity(i);
+                let e = it.entity(i).unwrap();
                 let id = it.id(0);
                 // cast the component to the Shapes trait
                 let shape: &dyn Shapes = ShapesTrait::cast(e, id);

--- a/flecs_ecs/tests/flecs/query_test.rs
+++ b/flecs_ecs/tests/flecs/query_test.rs
@@ -169,15 +169,18 @@ fn query_iter_targets() {
     let likes = world.entity();
     let pizza = world.entity();
     let salad = world.entity();
-    let alice = world.entity().add_id((likes, pizza)).add_id((likes, salad));
+    let alice = world.entity().add((likes, pizza)).add((likes, salad));
 
-    let q = world.query::<()>().with_second::<flecs::Any>(likes).build();
+    let q = world
+        .query::<()>()
+        .with((likes, id::<flecs::Any>()))
+        .build();
 
     let mut count = 0;
     let mut tgt_count = 0;
 
     q.each_iter(|mut it, row, _| {
-        let e = it.entity(row);
+        let e = it.entity(row).unwrap();
         assert_eq!(e, alice);
 
         it.targets(0, |tgt| {
@@ -206,20 +209,20 @@ fn query_iter_targets_second_field() {
     let salad = world.entity();
     let alice = world
         .entity()
-        .add::<Position>()
-        .add_id((likes, pizza))
-        .add_id((likes, salad));
+        .add(id::<Position>())
+        .add((likes, pizza))
+        .add((likes, salad));
 
     let q = world
         .query::<&Position>()
-        .with_second::<flecs::Any>(likes)
+        .with((likes, id::<flecs::Any>()))
         .build();
 
     let mut count = 0;
     let mut tgt_count = 0;
 
     q.each_iter(|mut it, row, _| {
-        let e = it.entity(row);
+        let e = it.entity(row).unwrap();
         assert_eq!(e, alice);
 
         it.targets(1, |tgt| {
@@ -248,12 +251,15 @@ fn query_iter_targets_field_out_of_range() {
     let likes = world.entity();
     let pizza = world.entity();
     let salad = world.entity();
-    let alice = world.entity().add_id((likes, pizza)).add_id((likes, salad));
+    let alice = world.entity().add((likes, pizza)).add((likes, salad));
 
-    let q = world.query::<()>().with_second::<flecs::Any>(likes).build();
+    let q = world
+        .query::<()>()
+        .with((likes, id::<flecs::Any>()))
+        .build();
 
     q.each_iter(|mut it, row, _| {
-        let e = it.entity(row);
+        let e = it.entity(row).unwrap();
         assert_eq!(e, alice);
 
         it.targets(1, |_| {});
@@ -271,14 +277,14 @@ fn query_iter_targets_field_not_a_pair() {
     let salad = world.entity();
     let alice = world
         .entity()
-        .add::<Position>()
-        .add_id((likes, pizza))
-        .add_id((likes, salad));
+        .add(id::<Position>())
+        .add((likes, pizza))
+        .add((likes, salad));
 
     let q = world.query::<&Position>().build();
 
     q.each_iter(|mut it, row, _| {
-        let e = it.entity(row);
+        let e = it.entity(row).unwrap();
         assert_eq!(e, alice);
 
         it.targets(1, |_| {});
@@ -292,16 +298,16 @@ fn query_iter_targets_field_not_set() {
     let world = World::new();
 
     let likes = world.entity();
-    let alice = world.entity().add::<Position>();
+    let alice = world.entity().add(id::<Position>());
 
     let q = world
         .query::<&Position>()
-        .with_second::<flecs::Any>(likes)
+        .with((likes, id::<flecs::Any>()))
         .optional()
         .build();
 
     q.each_iter(|mut it, row, _| {
-        let e = it.entity(row);
+        let e = it.entity(row).unwrap();
         assert_eq!(e, alice);
         assert!(!it.is_set(1));
 

--- a/flecs_ecs/tests/flecs/system_test.rs
+++ b/flecs_ecs/tests/flecs/system_test.rs
@@ -120,7 +120,7 @@ fn system_iter_shared() {
     let e1 = world
         .entity()
         .set(Position { x: 10, y: 20 })
-        .add_id((flecs::IsA::ID, base));
+        .add((flecs::IsA::ID, base));
 
     let e2 = world
         .entity()
@@ -285,7 +285,7 @@ fn system_each_shared() {
     let e1 = world
         .entity()
         .set(Position { x: 10, y: 20 })
-        .add_id((flecs::IsA::ID, base));
+        .add((flecs::IsA::ID, base));
 
     let e2 = world
         .entity()
@@ -464,7 +464,7 @@ fn system_signature_shared() {
     let e1 = world
         .entity()
         .set(Position { x: 10, y: 20 })
-        .add_id((flecs::IsA::ID, base));
+        .add((flecs::IsA::ID, base));
 
     let e2 = world
         .entity()
@@ -647,7 +647,7 @@ fn system_iter_tag() {
         }
     });
 
-    world.entity().add::<TagA>();
+    world.entity().add(id::<TagA>());
 
     world.progress();
 
@@ -673,7 +673,7 @@ fn system_each_tag() {
         }
     });
 
-    world.entity().add::<TagA>();
+    world.entity().add(id::<TagA>());
 
     world.progress();
 
@@ -687,11 +687,7 @@ fn system_each_tag() {
 fn system_set_interval() {
     let world = World::new();
 
-    let _sys = world
-        .system::<()>()
-        .kind_id(0)
-        .set_interval(1.0)
-        .run(|_it| {});
+    let _sys = world.system::<()>().kind(0).set_interval(1.0).run(|_it| {});
 
     // float i = sys.set_interval();
     // assert_eq!(i, 1.0f);
@@ -903,16 +899,16 @@ fn system_add_from_each() {
     let e3 = world.entity().set(Position { x: 2, y: 0 });
 
     world.system::<&Position>().each_entity(|e, _p| {
-        e.add::<Velocity>();
+        e.add(id::<Velocity>());
         // Add is deferred
-        assert!(!e.has::<Velocity>());
+        assert!(!e.has(id::<Velocity>()));
     });
 
     world.progress();
 
-    assert!(e1.has::<Velocity>());
-    assert!(e2.has::<Velocity>());
-    assert!(e3.has::<Velocity>());
+    assert!(e1.has(id::<Velocity>()));
+    assert!(e2.has(id::<Velocity>()));
+    assert!(e3.has(id::<Velocity>()));
 }
 
 #[test]
@@ -953,24 +949,24 @@ fn system_add_from_each_world_handle() {
     world.system::<&EntityRef>().each_entity(|e, c| {
         let world = e.world();
         let e = world.entity_from_id(c.value);
-        e.mut_stage_of(e).add::<Position>();
+        e.mut_stage_of(e).add(id::<Position>());
     });
 
     world.progress();
 
     e1.get::<&EntityRef>(|c| {
         let e = world.entity_from_id(c.value);
-        assert!(e.has::<Position>());
+        assert!(e.has(id::<Position>()));
     });
 
     e2.get::<&EntityRef>(|c| {
         let e = world.entity_from_id(c.value);
-        assert!(e.has::<Position>());
+        assert!(e.has(id::<Position>()));
     });
 
     e3.get::<&EntityRef>(|c| {
         let e = world.entity_from_id(c.value);
-        assert!(e.has::<Position>());
+        assert!(e.has(id::<Position>()));
     });
 }
 
@@ -984,26 +980,26 @@ fn system_new_from_each() {
 
     world.system::<&Position>().each_entity(|e, _p| {
         e.set(EntityRef {
-            value: e.world().entity().add::<Velocity>().id(),
+            value: e.world().entity().add(id::<Velocity>()).id(),
         });
     });
 
     world.progress();
 
-    assert!(e1.has::<EntityRef>());
-    assert!(e2.has::<EntityRef>());
-    assert!(e3.has::<EntityRef>());
+    assert!(e1.has(id::<EntityRef>()));
+    assert!(e2.has(id::<EntityRef>()));
+    assert!(e3.has(id::<EntityRef>()));
 
     e1.get::<&EntityRef>(|c| {
-        assert!(world.entity_from_id(c.value).has::<Velocity>());
+        assert!(world.entity_from_id(c.value).has(id::<Velocity>()));
     });
 
     e2.get::<&EntityRef>(|c| {
-        assert!(world.entity_from_id(c.value).has::<Velocity>());
+        assert!(world.entity_from_id(c.value).has(id::<Velocity>()));
     });
 
     e3.get::<&EntityRef>(|c| {
-        assert!(world.entity_from_id(c.value).has::<Velocity>());
+        assert!(world.entity_from_id(c.value).has(id::<Velocity>()));
     });
 }
 
@@ -1018,17 +1014,17 @@ fn system_add_from_iter() {
     world.system::<&Position>().run(|mut it| {
         while it.next() {
             for i in it.iter() {
-                it.entity(i).add::<Velocity>();
-                assert!(!it.entity(i).has::<Velocity>());
+                it.entity(i).unwrap().add(id::<Velocity>());
+                assert!(!it.entity(i).unwrap().has(id::<Velocity>()));
             }
         }
     });
 
     world.progress();
 
-    assert!(e1.has::<Velocity>());
-    assert!(e2.has::<Velocity>());
-    assert!(e3.has::<Velocity>());
+    assert!(e1.has(id::<Velocity>()));
+    assert!(e2.has(id::<Velocity>()));
+    assert!(e3.has(id::<Velocity>()));
 }
 
 #[test]
@@ -1042,9 +1038,9 @@ fn system_delete_from_iter() {
     world.system::<&Position>().run(|mut it| {
         while it.next() {
             for i in it.iter() {
-                it.entity(i).destruct();
+                it.entity(i).unwrap().destruct();
                 // Delete is deferred
-                assert!(it.entity(i).is_alive());
+                assert!(it.entity(i).unwrap().is_alive());
             }
         }
     });
@@ -1078,7 +1074,7 @@ fn system_add_from_iter_world_handle() {
                 world
                     .entity_from_id(c[i].value)
                     .mut_current_stage(it.world())
-                    .add::<Position>();
+                    .add(id::<Position>());
             }
         }
     });
@@ -1087,17 +1083,17 @@ fn system_add_from_iter_world_handle() {
 
     e1.get::<&EntityRef>(|c| {
         let e = world.entity_from_id(c.value);
-        assert!(e.has::<Position>());
+        assert!(e.has(id::<Position>()));
     });
 
     e2.get::<&EntityRef>(|c| {
         let e = world.entity_from_id(c.value);
-        assert!(e.has::<Position>());
+        assert!(e.has(id::<Position>()));
     });
 
     e3.get::<&EntityRef>(|c| {
         let e = world.entity_from_id(c.value);
-        assert!(e.has::<Position>());
+        assert!(e.has(id::<Position>()));
     });
 }
 
@@ -1112,8 +1108,8 @@ fn system_new_from_iter() {
     world.system::<&Position>().run(|mut it| {
         while it.next() {
             for i in it.iter() {
-                it.entity(i).set(EntityRef {
-                    value: it.world().entity().add::<Velocity>().id(),
+                it.entity(i).unwrap().set(EntityRef {
+                    value: it.world().entity().add(id::<Velocity>()).id(),
                 });
             }
         }
@@ -1121,20 +1117,20 @@ fn system_new_from_iter() {
 
     world.progress();
 
-    assert!(e1.has::<EntityRef>());
-    assert!(e2.has::<EntityRef>());
-    assert!(e3.has::<EntityRef>());
+    assert!(e1.has(id::<EntityRef>()));
+    assert!(e2.has(id::<EntityRef>()));
+    assert!(e3.has(id::<EntityRef>()));
 
     e1.get::<&EntityRef>(|c| {
-        assert!(world.entity_from_id(c.value).has::<Velocity>());
+        assert!(world.entity_from_id(c.value).has(id::<Velocity>()));
     });
 
     e2.get::<&EntityRef>(|c| {
-        assert!(world.entity_from_id(c.value).has::<Velocity>());
+        assert!(world.entity_from_id(c.value).has(id::<Velocity>()));
     });
 
     e3.get::<&EntityRef>(|c| {
-        assert!(world.entity_from_id(c.value).has::<Velocity>());
+        assert!(world.entity_from_id(c.value).has(id::<Velocity>()));
     });
 }
 
@@ -1143,18 +1139,9 @@ fn system_each_w_mut_children_it() {
     let world = World::new();
 
     let parent = world.entity().set(Position { x: 0, y: 0 });
-    let e1 = world
-        .entity()
-        .set(Position { x: 0, y: 0 })
-        .child_of_id(parent);
-    let e2 = world
-        .entity()
-        .set(Position { x: 0, y: 0 })
-        .child_of_id(parent);
-    let e3 = world
-        .entity()
-        .set(Position { x: 0, y: 0 })
-        .child_of_id(parent);
+    let e1 = world.entity().set(Position { x: 0, y: 0 }).child_of(parent);
+    let e2 = world.entity().set(Position { x: 0, y: 0 }).child_of(parent);
+    let e3 = world.entity().set(Position { x: 0, y: 0 }).child_of(parent);
 
     world.set(Count(0));
 
@@ -1162,8 +1149,8 @@ fn system_each_w_mut_children_it() {
         let world = it.world();
         while it.next() {
             for i in it.iter() {
-                it.entity(i).each_child(|child| {
-                    child.add::<Velocity>();
+                it.entity(i).unwrap().each_child(|child| {
+                    child.add(id::<Velocity>());
                     world.get::<&mut Count>(|c| {
                         c.0 += 1;
                     });
@@ -1178,9 +1165,9 @@ fn system_each_w_mut_children_it() {
         assert_eq!(c.0, 3);
     });
 
-    assert!(e1.has::<Velocity>());
-    assert!(e2.has::<Velocity>());
-    assert!(e3.has::<Velocity>());
+    assert!(e1.has(id::<Velocity>()));
+    assert!(e2.has(id::<Velocity>()));
+    assert!(e3.has(id::<Velocity>()));
 }
 
 #[test]
@@ -1189,18 +1176,9 @@ fn system_readonly_children_iter() {
 
     let parent = world.entity();
     world.entity().set(EntityRef { value: parent.id() });
-    world
-        .entity()
-        .set(Position { x: 1, y: 0 })
-        .child_of_id(parent);
-    world
-        .entity()
-        .set(Position { x: 1, y: 0 })
-        .child_of_id(parent);
-    world
-        .entity()
-        .set(Position { x: 1, y: 0 })
-        .child_of_id(parent);
+    world.entity().set(Position { x: 1, y: 0 }).child_of(parent);
+    world.entity().set(Position { x: 1, y: 0 }).child_of(parent);
+    world.entity().set(Position { x: 1, y: 0 }).child_of(parent);
 
     world.set(Count(0));
 
@@ -1450,27 +1428,27 @@ fn system_update_rate_filter() {
 fn system_test_let_defer_each() {
     let world = World::new();
 
-    let e1 = world.entity().add::<Tag>().set(Value { value: 10 });
-    let e2 = world.entity().add::<Tag>().set(Value { value: 20 });
-    let e3 = world.entity().add::<Tag>().set(Value { value: 30 });
+    let e1 = world.entity().add(id::<Tag>()).set(Value { value: 10 });
+    let e2 = world.entity().add(id::<Tag>()).set(Value { value: 20 });
+    let e3 = world.entity().add(id::<Tag>()).set(Value { value: 30 });
 
     let s = world
         .system::<&mut Value>()
-        .with::<Tag>()
+        .with(id::<Tag>())
         .each_entity(|e, v| {
             v.value += 1;
-            e.remove::<Tag>();
+            e.remove(id::<Tag>());
         });
 
     s.run();
 
-    assert!(!e1.has::<Tag>());
-    assert!(!e2.has::<Tag>());
-    assert!(!e3.has::<Tag>());
+    assert!(!e1.has(id::<Tag>()));
+    assert!(!e2.has(id::<Tag>()));
+    assert!(!e3.has(id::<Tag>()));
 
-    assert!(e1.has::<Value>());
-    assert!(e2.has::<Value>());
-    assert!(e3.has::<Value>());
+    assert!(e1.has(id::<Value>()));
+    assert!(e2.has(id::<Value>()));
+    assert!(e3.has(id::<Value>()));
 
     e1.get::<&Value>(|v| {
         assert_eq!(v.value, 11);
@@ -1489,29 +1467,32 @@ fn system_test_let_defer_each() {
 fn system_test_let_defer_iter() {
     let world = World::new();
 
-    let e1 = world.entity().add::<Tag>().set(Value { value: 10 });
-    let e2 = world.entity().add::<Tag>().set(Value { value: 20 });
-    let e3 = world.entity().add::<Tag>().set(Value { value: 30 });
+    let e1 = world.entity().add(id::<Tag>()).set(Value { value: 10 });
+    let e2 = world.entity().add(id::<Tag>()).set(Value { value: 20 });
+    let e3 = world.entity().add(id::<Tag>()).set(Value { value: 30 });
 
-    let s = world.system::<&mut Value>().with::<Tag>().run(|mut it| {
-        while it.next() {
-            let mut v = it.field::<Value>(0).unwrap();
-            for i in it.iter() {
-                v[i].value += 1;
-                it.entity(i).remove::<Tag>();
+    let s = world
+        .system::<&mut Value>()
+        .with(id::<Tag>())
+        .run(|mut it| {
+            while it.next() {
+                let mut v = it.field::<Value>(0).unwrap();
+                for i in it.iter() {
+                    v[i].value += 1;
+                    it.entity(i).unwrap().remove(id::<Tag>());
+                }
             }
-        }
-    });
+        });
 
     s.run();
 
-    assert!(!e1.has::<Tag>());
-    assert!(!e2.has::<Tag>());
-    assert!(!e3.has::<Tag>());
+    assert!(!e1.has(id::<Tag>()));
+    assert!(!e2.has(id::<Tag>()));
+    assert!(!e3.has(id::<Tag>()));
 
-    assert!(e1.has::<Value>());
-    assert!(e2.has::<Value>());
-    assert!(e3.has::<Value>());
+    assert!(e1.has(id::<Value>()));
+    assert!(e2.has(id::<Value>()));
+    assert!(e3.has(id::<Value>()));
 
     e1.get::<&Value>(|v| {
         assert_eq!(v.value, 11);
@@ -1531,13 +1512,13 @@ fn system_test_let_defer_iter() {
 fn system_custom_pipeline() {
     // let world = World::new();
 
-    // let mut preFrame = world.entity().add::<flecs::pipeline::Phase>();
-    // let OnFrame = world.entity().add::<flecs::pipeline::Phase>().depends_on(PreFrame);
-    // let mut postFrame = world.entity().add::<flecs::pipeline::Phase>().depends_on(OnFrame);
+    // let mut preFrame = world.entity().add(id::<flecs::pipeline::Phase>());
+    // let OnFrame = world.entity().add(id::<flecs::pipeline::Phase>()).depends_on(PreFrame);
+    // let mut postFrame = world.entity().add(id::<flecs::pipeline::Phase>()).depends_on(OnFrame);
     // let tag = world.entity();
 
     // let pip = world.pipeline()
-    //     .with::<flecs::system::System>()
+    //     .with(id::<flecs::system::System>())
     //     .with(flecs::pipeline::Phase).cascade(flecs::DependsOn)
     //     .with(Tag)
     //     .build();
@@ -1586,7 +1567,7 @@ fn system_custom_pipeline() {
 
     // assert_eq!(count, 0);
 
-    // world.set_pipeline_id(pip);
+    // world.set_pipeline(pip);
 
     // world.progress();
 
@@ -1603,13 +1584,13 @@ fn system_custom_pipeline_w_kind() {
 
     let pip = world
         .pipeline()
-        .with::<flecs::system::System>()
-        .with_id(tag)
+        .with(id::<flecs::system::System>())
+        .with(tag)
         .build();
 
     world.set(Count(0));
 
-    world.system::<()>().kind_id(tag).run(|mut it| {
+    world.system::<()>().kind(tag).run(|mut it| {
         while it.next() {
             let world = it.world();
             world.get::<&mut Count>(|c| {
@@ -1619,7 +1600,7 @@ fn system_custom_pipeline_w_kind() {
         }
     });
 
-    world.system::<()>().kind_id(tag).run(|mut it| {
+    world.system::<()>().kind(tag).run(|mut it| {
         let world = it.world();
         while it.next() {
             world.get::<&mut Count>(|c| {
@@ -1629,7 +1610,7 @@ fn system_custom_pipeline_w_kind() {
         }
     });
 
-    world.system::<()>().kind_id(tag).run(|mut it| {
+    world.system::<()>().kind(tag).run(|mut it| {
         let world = it.world();
         while it.next() {
             world.get::<&mut Count>(|c| {
@@ -1643,7 +1624,7 @@ fn system_custom_pipeline_w_kind() {
         assert_eq!(c.0, 0);
     });
 
-    world.set_pipeline_id(pip.id());
+    world.set_pipeline(pip.id());
 
     world.progress();
 
@@ -1663,7 +1644,7 @@ fn system_create_w_no_template_args() {
 
     let s = world
         .system::<()>()
-        .with::<Position>()
+        .with(id::<Position>())
         .each_entity(move |e, _| {
             let world = e.world();
             assert!(e == entity_id);
@@ -1692,51 +1673,61 @@ fn system_system_w_type_kind_type_pipeline() {
 
     world
         .component::<Second>()
-        .add::<flecs::pipeline::Phase>()
-        .depends_on_id(world.component::<First>().add::<flecs::pipeline::Phase>());
+        .add(id::<flecs::pipeline::Phase>())
+        .depends_on(
+            world
+                .component::<First>()
+                .add(id::<flecs::pipeline::Phase>()),
+        );
 
     world
         .pipeline_type::<PipelineType>()
-        .with::<flecs::system::System>()
-        .with::<flecs::pipeline::Phase>()
-        .cascade_type::<flecs::DependsOn>()
+        .with(id::<flecs::system::System>())
+        .with(id::<flecs::pipeline::Phase>())
+        .cascade_id(id::<flecs::DependsOn>())
         .build();
 
-    world.set_pipeline::<PipelineType>();
+    world.set_pipeline(id::<PipelineType>());
 
-    let entity = world.entity().add::<Tag>();
+    let entity = world.entity().add(id::<Tag>());
     let entity_id = entity.id();
 
     world.set(Count2 { a: 0, b: 0 });
 
-    world.system::<&Tag>().kind::<Second>().run(move |mut it| {
-        while it.next() {
-            for i in it.iter() {
-                let e = it.entity(i);
-                let world = e.world();
-                assert!(e == entity_id);
-                world.get::<&mut Count2>(|c| {
-                    assert_eq!(c.a, 0);
-                    assert_eq!(c.b, 1);
-                    c.a += 1;
-                });
+    world
+        .system::<&Tag>()
+        .kind(id::<Second>())
+        .run(move |mut it| {
+            while it.next() {
+                for i in it.iter() {
+                    let e = it.entity(i).unwrap();
+                    let world = e.world();
+                    assert!(e == entity_id);
+                    world.get::<&mut Count2>(|c| {
+                        assert_eq!(c.a, 0);
+                        assert_eq!(c.b, 1);
+                        c.a += 1;
+                    });
+                }
             }
-        }
-    });
+        });
 
-    world.system::<&Tag>().kind::<First>().run(move |mut it| {
-        while it.next() {
-            for i in it.iter() {
-                let world = it.world();
-                let e = it.entity(i);
-                assert!(e == entity_id);
-                world.get::<&mut Count2>(|c| {
-                    assert_eq!(c.b, 0);
-                    c.b += 1;
-                });
+    world
+        .system::<&Tag>()
+        .kind(id::<First>())
+        .run(move |mut it| {
+            while it.next() {
+                for i in it.iter() {
+                    let world = it.world();
+                    let e = it.entity(i).unwrap();
+                    assert!(e == entity_id);
+                    world.get::<&mut Count2>(|c| {
+                        assert_eq!(c.b, 0);
+                        c.b += 1;
+                    });
+                }
             }
-        }
-    });
+        });
 
     world.progress();
 
@@ -2014,7 +2005,7 @@ fn system_startup_system() {
 
     world
         .system::<()>()
-        .kind_id(flecs::pipeline::OnStart::ID)
+        .kind(flecs::pipeline::OnStart::ID)
         .run(|mut it| {
             let world = it.world();
             while it.next() {
@@ -2027,7 +2018,7 @@ fn system_startup_system() {
 
     world
         .system::<()>()
-        .kind_id(flecs::pipeline::OnUpdate::ID)
+        .kind(flecs::pipeline::OnUpdate::ID)
         .run(|mut it| {
             let world = it.world();
             while it.next() {
@@ -2062,7 +2053,7 @@ fn system_interval_tick_source() {
 
     world.set(Count2 { a: 0, b: 0 });
 
-    world.system::<()>().set_tick_source_id(t).run(|mut it| {
+    world.system::<()>().set_tick_source(t).run(|mut it| {
         let world = it.world();
         while it.next() {
             world.get::<&mut Count2>(|c| {
@@ -2071,7 +2062,7 @@ fn system_interval_tick_source() {
         }
     });
 
-    world.system::<()>().set_tick_source_id(t).run(|mut it| {
+    world.system::<()>().set_tick_source(t).run(|mut it| {
         let world = it.world();
         while it.next() {
             world.get::<&mut Count2>(|c| {
@@ -2104,7 +2095,7 @@ fn system_rate_tick_source() {
 
     world.set(Count2 { a: 0, b: 0 });
 
-    world.system::<()>().set_tick_source_id(t).run(|mut it| {
+    world.system::<()>().set_tick_source(t).run(|mut it| {
         let world = it.world();
         while it.next() {
             world.get::<&mut Count2>(|c| {
@@ -2113,7 +2104,7 @@ fn system_rate_tick_source() {
         }
     });
 
-    world.system::<()>().set_tick_source_id(t).run(|mut it| {
+    world.system::<()>().set_tick_source(t).run(|mut it| {
         let world = it.world();
         while it.next() {
             world.get::<&mut Count2>(|c| {
@@ -2200,9 +2191,9 @@ fn system_nested_rate_tick_source() {
 //     flecs::entity e2 = world.entity().set(Position{x: 20, y: 30});
 
 //     let s = world.system::<()>()
-//         .with::<Position>()
+//         .with(id::<Position>())
 //         .each([&](flecs::iter& iter, size_t index) {
-//             let e = iter.entity(index);
+//             let e = iter.entity(index).unwrap();
 //             &Position *p = &iter.table().get<Position>()[index];
 //             assert_ne!(p, nullptr);
 //             assert!(e == e1 || e == e2);
@@ -2225,9 +2216,9 @@ fn system_nested_rate_tick_source() {
 //     flecs::entity e2 = world.entity().set(Position{x: 20, y: 30});
 
 //     let s = world.system::<()>()
-//         .with::<Position>()
+//         .with(id::<Position>())
 //         .each([&](flecs::iter& iter, size_t index) {
-//             let e = iter.entity(index);
+//             let e = iter.entity(index).unwrap();
 //             &Position *p = &iter.range().get<Position>()[index];
 //             assert_ne!(p, nullptr);
 //             assert!(e == e1 || e == e2);
@@ -2291,7 +2282,7 @@ fn system_run_w_0_src_query() {
 
     world.set(Count(0));
 
-    world.system::<()>().write::<Position>().run(|it| {
+    world.system::<()>().write(id::<Position>()).run(|it| {
         let world = it.world();
         world.get::<&mut Count>(|c| {
             c.0 += 1;

--- a/flecs_ecs/tests/flecs/world_test.rs
+++ b/flecs_ecs/tests/flecs/world_test.rs
@@ -61,7 +61,7 @@ fn world_finis_reentrancy() {
         // therefore, world destroy will be called again wreaking havoc.
     });
 
-    world.entity().add::<A>();
+    world.entity().add(id::<A>());
 
     // world will be destroyed here, and hook above will be called.
 }

--- a/flecs_ecs_derive/Cargo.toml
+++ b/flecs_ecs_derive/Cargo.toml
@@ -15,9 +15,9 @@ name = "flecs_ecs_derive"
 workspace = true
 
 [dependencies]
-syn = "2.0.33"
-quote = "1.0.33"
-proc-macro2 = "1.0.67"
+syn = "2.0.101"
+quote = "1.0.40"
+proc-macro2 = "1.0.95"
 
 [dev-dependencies]
 flecs_ecs = { version = "*", path = "../flecs_ecs" }


### PR DESCRIPTION
merge typed, first, second and id functions into one function

Introduce:

```
fn id<T: ComponentId>()
IntoEntity trait
improved IntoId trait
```

```rs
before:
    world
        .query::<()>()
        .with::<Position>()
        .with_id(some_entity)
        .with_first::<Position>(some_entity)

after:
    world
        .query::<()>()
        .with(id::<Position>())
        .with(some_entity)
        .with((id::<Position>(),some_entity))
```

```rs
before
    world
        .entity()
        .add::<Position>()
        .add_id(some_id)
        .add_first::<Likes>(some_entity)
        .add_second::<Bob>(likes);

after
    world
        .entity()
        .add(id::<Position>())
        .add(some_id)
        .add((id::<Likes>(), some_entity))
        .add((likes, id::<Bob>));
```

previously: 261 functions
now: 100
reduction: 62%

```
=== World ================================================
* add_id
* add
* add_first
* add_second
--> add

* remove
* remove_id
* remove_first
* remove_second
--> remove

* modified
* modified_id
--> modified

* doc_name
* doc_name_id
--> doc_name

* doc_brief
* doc_brief_id
--> doc_brief

* doc_detail
* doc_detail_id
--> doc_detail

* doc_link
* doc_link_id
--> doc_link

* doc_color
* doc_color_id
--> doc_color

* doc_uuid
* doc_uuid_id
--> doc_uuid

* doc_name
* doc_name_id
--> doc_name

* set_doc_brief
* set_doc_brief_id
--> set_doc_brief

* set_doc_detail
* set_doc_detail_id
--> set_doc_detail

* set_doc_link
* set_doc_link_id
--> set_doc_link

* set_doc_color
* set_doc_color_id
--> set_doc_color

* set_doc_uuid
* set_doc_uuid_id
--> set_doc_uuid

* cursor
* cursor_id
--> cursor

* array
* array_id
--> array

* to_expr_id --> to_expr
* to_expr --> to_expr_typed

* script_entity_from_id
* script_entity_from
--> script_entity_from

* set_scope
* set_scope_id
--> set_scope

* scope
* scope_id
--> scope

* with
* with_id
* with_first
* with_second
* with_name
* with_names
* with_name_first
* with_name_second
--> with

* delete_entities_with
* delete_entities_with_id
* delete_entities_with_first
* delete_entities_with_second
--> delete_entities_with

* remove_all
* remove_all_id
* remove_all_first
* remove_all_second
--> remove_all

* count
* count_id
* count_first
* count_second
--> count

* run_in_scope_with
* run_in_scope_with_id
--> run_in_scope_with

* component_untyped_from
* component_untyped_from_id
--> component_untyped_from

* set_pipeline
* set_pipeline_id
--> set_pipeline

* run_pipeline
* run_pipeline_id
--> run_pipeline

* run_pipeline_time
* run_pipeline_id_time
--> run_pipeline_time

* id_from
* id_from_id
* id_first
* id_second
--> id_view_from

=== EntityView ================================================
* add_id
* add
* add_first
* add_second
--> add

* add_if
* add_id_if
* add_if_first
* add_if_second
--> add_if

* remove
* remove_id
* remove_first
* remove_second
--> remove

* is_a_id
* is_a
--> is_a

*.child_of
* child_of
--> child_of

* depends_on_id
* depends_on
--> depends_on

* slot_of_id
* slot_of
--> slot

* auto_override_id
* auto_override
* auto_override_first
* auto_override_second
* set_pair_override
--> auto_override

* enable
* enable_id
* enable_first
* enable_second
--> enable

* is_enabled
* is_enabled_id
* is_enabled_first
* is_enabled_second
--> is_enabled

* disable
* disable_id
* disable_first
* disable_second
--> disable

* modified
* modified_id
* modified_first
* modified_second
--> modified

* has
* has_id
* has_first
* has_second
--> has

* has_enum
* has_enum_id
--> has_enum

* owns
* owns_id
* owns_first
* owns_second
--> owns

* with_first
* with_second
* with_first_id
* with_second_id
--> with_first / with_second

* set_json
* set_json_id
* set_json_first
* set_json_second
--> set_json

* path_from
* path_from_id
path_from_id_default_sep
--> path_from

* path_from_w_sep
* path_from_id_w_sep
--> path_from_w_sep

* hierarchy_path_from_parent_type
--> hierarchy_path_from_parent

* each_target
* each_target_id
--> each_target

* each_child_of
* each_child_of_id
--> each_child_of

* count_relationship
* count_relationship_id
--> count_relationship

* target
* target_id
--> target

* target_for
* target_for_id
--> target_for

* depth
* depth_id
--> depth

=== EventBuilder ================================================
* add
* add_id
* add_first
* add_second
--> Add

=== System ===
* set_tick_source
* set_tick_source_id
--> set_tick_source

=== SystemBuilder ===
* set_tick_source
* set_tick_source_id
--> set_tick_source

* kind_id
* kind
--> kind

=== AlertBuilder ================================================

* severity
* severity_id
--> severity

* severity_filter
* severity_filter_id
--> severity_filter

* member_id
--> member

=== UntypedComponent ================================================

* member_id
* member
--> member

* member_id_unit
* member_unit
--> member_unit

=== MetricBuilder ===

* member_id
--> member

* kind_id
* kind
--> kind

* id
* id_pair
* id_type
* id_first
* id_second
--> id

=== UnManagedScript================================================

* to_expr
* to_expr_id
--> to_expr

=== ObserverBuilder ================================================

* add_event
* add_event_id
--> add_event

=== TermBuilder ===

* set_second
* set_second_id
--> set_second

* set_first
* set_first_id
--> set_first

* up_id
* up_type
--> up_id

* cascade_id
* cascade_type
--> cascade_id

* set_src
* set_src_id
* set_src_name
--> set_src

=== QueryBuilder ================================================

* with
* with_id
* with_first
* with_second
--> with

* without
* without_id
* without_first
* without_second
--> without

* with_second_id
* with_first_name
--> with_name_first

* with_first_id
* with_second_name
--> with_name_second

* without_first_id
* without_second_name
--> without_name_second

* without_second_id
* without_first_name
--> without_name_first

* write
* write_id
* write_first
* write_second
* write_name
* write_names
* write_name_first
* write_name_second
--> write

* read
* read_id
* read_first
* read_second
* write_name
* write_names
* write_name_first
* write_name_second
--> read

* with_first_id --> with_name_second
* with_second_id --> with_name_first

* write_first_name --> write_name_second
* write_second_name --> write_name_first

* read_first_name --> read_name_second
* read_second_name --> read_name_first

* set_second, set_second_name --> set_second
* set_first, set_first_name --> set_first

* group_by
* group_by_id
--> group_by

=== QueryIter ================================================

* set_group
* set_group_id
--> set_group

=== Table ================================================

* find_type_index
* find_type_index_id
* find_type_index_pair_ids
* find_type_index_pair
* find_type_index_first
* find_type_index_second
--> find_type_index

* find_column_index
* find_column_index_id
* find_column_index_pair
* find_column_index_pair_ids
* find_column_index_first
* find_column_index_second
--> find_column_index

* has_type
* has_type_id
* has_pair
* has_pair_ids
--> has

* depth
* depth_id
--> depth

=== Query ================================================

* set_group
* set_group_id
--> set_group
```