### PR TITLE
More precise docs regarding system rate

### DIFF
--- a/flecs_ecs/src/addons/timer.rs
+++ b/flecs_ecs/src/addons/timer.rs
@@ -275,20 +275,17 @@ impl<T: QueryTuple> SystemBuilder<'_, T> {
         self
     }
 
-    /// Set system rate.
-    /// This operation will cause the system to be ran at a multiple of the
-    /// provided tick source. The tick source may be any entity, including
-    /// another system.
+    /// Sets a rate filter on the system, causing it to run once every `rate` 
+    /// ticks. The tick source may be any entity, including another system.
     pub fn set_tick_source_rate(&mut self, tick_source: impl Into<Entity>, rate: i32) -> &mut Self {
         self.desc.rate = rate;
         self.desc.tick_source = *tick_source.into();
         self
     }
 
-    /// Set system rate.
-    /// This operation will cause the system to be ran at a multiple of the
-    /// frame tick frequency. If a tick source was provided, this just updates
-    /// the rate of the system.
+    /// Sets a rate filter on the system, causing it to run once every `rate` 
+    /// ticks. If a tick source was provided, this just updates the rate of the
+    /// system.
     pub fn set_rate(&mut self, rate: i32) -> &mut Self {
         self.desc.rate = rate;
         self


### PR DESCRIPTION
I noticed the docs for the `set_rate`, et al functions didn't match what the [official docs](https://www.flecs.dev/flecs/md_docs_2Systems.html#rate) say. This PR updates the docs accordingly. I also noticed the official docs mention that setting a tick source for a system isn't supported using the rust bindings, but it appears they actually are now.