### PR TITLE
Remove trailing comma from .vscode/launch.json breaking nvim plugins

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "args": [],
             "cwd": "${fileDirname}",
             "console": "externalTerminal"
-        },
+        }
         // {
         //     "type": "lldb",
         //     "request": "launch",


### PR DESCRIPTION
The `.vscode/launch.json` file contains invalid JSON syntax due to a trailing comma after the last configuration object. This causes issues for development tools that parse this file, particularly:

* `nvim-dap` fails to parse the file with error: `Expected value but found T_ARR_END at character 349`
* `rustaceanvim` (which depends on `nvim-dap` on some configs) fails to initialize properly

The comments in the json seem to be ignored however and not cause issues, so I left them intact.