### PR TITLE
flecs_sys_sys: `flecs_alerts` requires `flecs_script`

### DIFF
--- a/flecs_ecs_sys/Cargo.toml
+++ b/flecs_ecs_sys/Cargo.toml
@@ -74,7 +74,7 @@ flecs_stats = ["flecs_pipeline", "flecs_timer", "flecs_module"]
 flecs_metrics = ["flecs_meta", "flecs_units", "flecs_pipeline"]
 
 # Monitor conditions for errors
-flecs_alerts = ["flecs_pipeline", "flecs_metrics"]
+flecs_alerts = ["flecs_pipeline", "flecs_metrics", "flecs_script"]
 
 # System support
 flecs_system = ["flecs_module"]


### PR DESCRIPTION
If you build with the `flecs_alerts` feature, you also have to enable the `flecs_script` feature.