### PR TITLE
feat: impl ExactSizeIterator for TableRowIter

### DIFF
--- a/flecs_ecs/src/core/table/iter.rs
+++ b/flecs_ecs/src/core/table/iter.rs
@@ -1002,4 +1002,11 @@ where
             None
         }
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let c = self.iter.count();
+        (c, Some(c))
+    }
 }
+
+impl<const IS_RUN: bool, P> ExactSizeIterator for TableRowIter<'_, IS_RUN, P> where P: ComponentId {}


### PR DESCRIPTION
Iteration over table rows is a trivial loop from `0..len` so let's implement [ExactSizeIterator](https://doc.rust-lang.org/std/iter/trait.ExactSizeIterator.html) and an accurate size_hint for it