### PR TITLE
Fix meta vector register

### DIFF
--- a/flecs_ecs/src/addons/meta/builtin.rs
+++ b/flecs_ecs/src/addons/meta/builtin.rs
@@ -153,13 +153,13 @@ pub fn meta_register_vector_default<T: Default>(world: WorldRef) -> Opaque<Vec<T
 
     fn ensure_generic_element<T: Default>(data: &mut Vec<T>, elem: usize) -> &mut T {
         if data.len() <= elem {
-            data.resize_with(elem, || T::default());
+            data.resize_with(elem + 1, || T::default());
         }
         &mut data[elem]
     }
 
-    fn resize_generic_vec<T: Default>(data: &mut Vec<T>, elem: usize) {
-        data.resize_with(elem, || T::default());
+    fn resize_generic_vec<T: Default>(data: &mut Vec<T>, new_size: usize) {
+        data.resize_with(new_size, || T::default());
     }
 
     // Ensure element exists, return

--- a/flecs_ecs/src/addons/meta/builtin.rs
+++ b/flecs_ecs/src/addons/meta/builtin.rs
@@ -153,13 +153,13 @@ pub fn meta_register_vector_default<T: Default>(world: WorldRef) -> Opaque<Vec<T
 
     fn ensure_generic_element<T: Default>(data: &mut Vec<T>, elem: usize) -> &mut T {
         if data.len() <= elem {
-            data.resize_with(elem + 1, || T::default());
+            data.resize_with(elem, || T::default());
         }
         &mut data[elem]
     }
 
     fn resize_generic_vec<T: Default>(data: &mut Vec<T>, elem: usize) {
-        data.resize_with(elem + 1, || T::default());
+        data.resize_with(elem, || T::default());
     }
 
     // Ensure element exists, return


### PR DESCRIPTION
Deserialized vector types registered using the `meta_register_vector_default` function have an extra default element in their array because `resize_generic_vec` resizes the data array to be `len() + 1` instead of to `len()`

This fixes that so that the data array is only sized to be the length of the needed space.