### PR TITLE
fix arm64 char issue

### DIFF
--- a/flecs_ecs/src/addons/module/world.rs
+++ b/flecs_ecs/src/addons/module/world.rs
@@ -39,7 +39,7 @@ impl World {
         let symbol_name = core::any::type_name::<T>();
         let symbol = compact_str::format_compact!("{}\0", symbol_name);
         let m =
-            unsafe { sys::ecs_lookup_symbol(raw_world, symbol.as_ptr() as *const i8, true, false) };
+            unsafe { sys::ecs_lookup_symbol(raw_world, symbol.as_ptr() as *const std::ffi::c_char, true, false) };
         let module = if T::is_registered_with_world(self) && m != 0 {
             self.component::<T>().entity
         } else {


### PR DESCRIPTION
This PR fix [Build fails on aarch64 (Linux)](#283)#283 by using `std::ffi::c_char` instead `i8`

Tested on x64 Windows 11 and aarch64 Ubuntu 22.04