### PR TITLE
Add Crates.io badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # ![Flecs](flecs_ecs/assets/flecs_rust_logo.png)
 
 [![Generic badge](https://img.shields.io/badge/Flecs_Version-4.0.1-E56717.svg)](https://github.com/SanderMertens/flecs/releases)
+[![Crates.io](https://img.shields.io/crates/v/flecs_ecs.svg)](https://crates.io/crates/flecs_ecs)
 [![License](https://badgen.net/pypi/license/pip/)](https://github.com/Indra-db/Flecs-Rust/blob/master/LICENSE)
 [![CI](https://github.com/indra-db/Flecs-Rust/actions/workflows/ci.yml/badge.svg)](https://github.com/indra-db/Flecs-Rust/actions/workflows/ci.yml)
 [![Flecs Official Docs](https://img.shields.io/badge/Flecs%20C%2FC%2B%2B%20Docs-View-161b22)](https://www.flecs.dev/flecs/md_docs_2Docs.html)


### PR DESCRIPTION
Finding the correct flecs rust bindings on crates.io can be a bit tricky given the existence of other, similar projects. Link directly to the associated crates.io page to reduce mistakes, confusion, and manual searching.