### PR TITLE
Use implicit lifetime for query builder expr() arg

### DIFF
--- a/flecs_ecs/src/core/query_builder.rs
+++ b/flecs_ecs/src/core/query_builder.rs
@@ -761,7 +761,7 @@ pub trait QueryBuilderImpl<'a>: TermBuilderImpl<'a> {
     /// # Arguments
     ///
     /// * `expr` - the expression to set
-    fn expr(&mut self, expr: &'a str) -> &mut Self {
+    fn expr(&mut self, expr: &str) -> &mut Self {
         let expr = ManuallyDrop::new(format!("{expr}\0"));
         ecs_assert!(
             *self.expr_count_mut() == 0,


### PR DESCRIPTION
`QueryBuilderImpl<'a>::expr` improperly ties the lifetime of the `expr` argument to the lifetime of the `QueryBuilderImpl` instance, despite not accessing the argument outside the scope of the function. This makes using the API with non-static query expressions difficult/impossible.

Use an implicit lifetime for the `expr` argument, such that its lifetime is only tied to the duration of the function call.

fixes: https://github.com/Indra-db/Flecs-Rust/issues/292