### PR TITLE
Don't capture self in `TableIter<'a, ...>::iter()`

### DIFF
--- a/flecs_ecs/src/core/table/iter.rs
+++ b/flecs_ecs/src/core/table/iter.rs
@@ -92,7 +92,7 @@ where
     /// });
     /// ```
     #[inline(always)]
-    pub fn iter(&self) -> impl ExactSizeIterator<Item = FieldIndex> {
+    pub fn iter(&self) -> impl ExactSizeIterator<Item = FieldIndex> + use<IS_RUN, P> {
         // Range has no bounds checks, .map(FieldIndex) is inlined out to a single `add+load`
         (0..self.count).map(FieldIndex)
     }


### PR DESCRIPTION
Due to the changes to capture logic in rust 2024 when returning `impl TYPE`, the result of `TableIter::iter()` currently captures an immutable reference to `&self`. Thus, one cannot mutably use a `TableIter` while the results of `TableIter::iter()` are being held.

Use precise capturing on `TableIter::iter()` to allow the mutable use of `TableIter` while the result of `TableIter::iter()` is being held.

See: https://blog.rust-lang.org/2024/09/05/impl-trait-capture-rules