### PR TITLE
Make MetaMember::name 'a instead of 'static

### DIFF
--- a/flecs_ecs/src/addons/meta/meta_traits.rs
+++ b/flecs_ecs/src/addons/meta/meta_traits.rs
@@ -2,23 +2,23 @@ use super::Count;
 
 /// Meant to be used with `.member` method of (untyped) components.
 /// This is to allow an unified function API to allow arbitrary number of arguments.
-/// valid options are (name : &'static str,), (name: &'static str, count: i32), (name: &'static str, count: i32, offset: i32)
-pub trait MetaMember: 'static {
+/// valid options are (name: &'a str,), (name: &'a str, count: i32), (name: &'a str, count: i32, offset: i32)
+pub trait MetaMember<'a> {
     /// Whether to use explicit offset or not
     /// when false, flecs calculates the offset for us, this is useful for simple structs.
     /// but might fail for more complex structs.
     const USE_OFFSET: bool;
 
-    fn name(&self) -> &str;
+    fn name(&self) -> &'a str;
     fn count(&self) -> i32;
     fn offset(&self) -> i32;
 }
 
-impl MetaMember for &'static str {
+impl<'a> MetaMember<'a> for &'a str {
     const USE_OFFSET: bool = false;
 
     #[inline(always)]
-    fn name(&self) -> &str {
+    fn name(&self) -> &'a str {
         self
     }
 
@@ -33,11 +33,11 @@ impl MetaMember for &'static str {
     }
 }
 
-impl MetaMember for (&'static str,) {
+impl<'a> MetaMember<'a> for (&'a str,) {
     const USE_OFFSET: bool = false;
 
     #[inline(always)]
-    fn name(&self) -> &str {
+    fn name(&self) -> &'a str {
         self.0
     }
 
@@ -52,11 +52,11 @@ impl MetaMember for (&'static str,) {
     }
 }
 
-impl MetaMember for (&'static str, Count) {
+impl<'a> MetaMember<'a> for (&'a str, Count) {
     const USE_OFFSET: bool = false;
 
     #[inline(always)]
-    fn name(&self) -> &str {
+    fn name(&self) -> &'a str {
         self.0
     }
 
@@ -71,11 +71,11 @@ impl MetaMember for (&'static str, Count) {
     }
 }
 
-impl MetaMember for (&'static str, Count, usize) {
+impl<'a> MetaMember<'a> for (&'a str, Count, usize) {
     const USE_OFFSET: bool = true;
 
     #[inline(always)]
-    fn name(&self) -> &str {
+    fn name(&self) -> &'a str {
         self.0
     }
 

--- a/flecs_ecs/src/addons/meta/untyped_component.rs
+++ b/flecs_ecs/src/addons/meta/untyped_component.rs
@@ -38,10 +38,10 @@ impl UntypedComponent<'_> {
     /// Add member with unit.
     ///
     /// [`MetaMember`] is a trait that accepts the following options:
-    /// (name : &'static str,),
-    /// (name: &'static str, count: i32),
-    /// (name: &'static str, count: i32, offset: i32)
-    pub fn member_unit<Meta: MetaMember>(
+    /// (name: &'a str,),
+    /// (name: &'a str, count: i32),
+    /// (name: &'a str, count: i32, offset: i32)
+    pub fn member_unit<'a , Meta: MetaMember<'a>>(
         self,
         type_id: impl IntoEntity,
         unit: impl IntoEntity,
@@ -82,20 +82,20 @@ impl UntypedComponent<'_> {
     /// Add member.
     ///
     /// [`MetaMember`] is a trait that accepts the following options:
-    /// (name : &'static str,),
-    /// (name: &'static str, count: i32),
-    /// (name: &'static str, count: i32, offset: i32)
-    pub fn member(self, type_id: impl IntoEntity, data: impl MetaMember) -> Self {
+    /// (name: &'a str,),
+    /// (name: &'a str, count: i32),
+    /// (name: &'a str, count: i32, offset: i32)
+    pub fn member<'a>(self, type_id: impl IntoEntity, data: impl MetaMember<'a>) -> Self {
         self.member_unit(type_id, 0, data)
     }
 
     /// Add member with unit typed.
     ///
     /// [`MetaMember`] is a trait that accepts the following options:
-    /// (name : &'static str,),
-    /// (name: &'static str, count: i32),
-    /// (name: &'static str, count: i32, offset: i32)
-    pub fn member_unit_type<T: ComponentId, U: ComponentId>(self, data: impl MetaMember) -> Self {
+    /// (name: &'satatic str,),
+    /// (name: &'a str, count: i32),
+    /// (name: &'a str, count: i32, offset: i32)
+    pub fn member_unit_type<'a, T: ComponentId, U: ComponentId>(self, data: impl MetaMember<'a>) -> Self {
         self.member_unit(T::get_id(self.world()), U::get_id(self.world()), data)
     }
 


### PR DESCRIPTION
UntypedComponent::member() and friends take a MetaMember with a 'static name string. This string is then immediately copied into a c-string before use, so the 'static lifetime is not necessary. The name only needs to live for the duration of the function call.

Using 'static is fine for many cases, but makes generating arbitrary component members at runtime problematic. Given the nature of the API, this usecase is highly likely.

Instead of using 'static name, use 'a instead, such that generating dynamic component members at runtime using dynamic string names is easily possible.