### PR TITLE
Make GetTuple public

### DIFF
--- a/flecs_ecs/src/core/mod.rs
+++ b/flecs_ecs/src/core/mod.rs
@@ -41,6 +41,7 @@ pub use entity_view::EntityView;
 pub use entity_view::EntityViewGet;
 pub use event::EventBuilder;
 pub(crate) use get_tuple::*;
+pub use get_tuple::GetTuple;
 pub use id::Id;
 pub use id_view::IdView;
 pub use observer::Observer;


### PR DESCRIPTION
GetTuple is part of the API for world::get(), but is not publically exposed. This means consumers cannot make wrappers around world::get() without losing significant flexibility. Since world::get() is part of the public API, also publicly expose GetTuple.