### PR TITLE
Sparse-term safety locks pass a stage where a world is required

### DIFF
--- a/flecs_ecs/src/core/safety_map.rs
+++ b/flecs_ecs/src/core/safety_map.rs
@@ -406,6 +406,14 @@ fn __internal_do_read_write_locks<
     stage: i32,
     table_records: &[super::TableColumnSafety],
 ) {
+    // Inside a multithreaded system this `WorldRef` is a stage, and
+    // `flecs_components_get` asserts on `ecs_world_t_magic`, so every sparse
+    // term in a threaded system aborted the process.
+    let real_world = unsafe {
+        sys::ecs_get_world(world.raw_world.as_ptr().cast_const().cast()).cast_mut()
+    }
+    .cast::<sys::ecs_world_t>();
+
     let count_immutable: usize = const { T::COUNT_IMMUTABLE };
     let start_index_mutable: usize = const { T::COUNT_IMMUTABLE };
     let start_index_optional_immutable: usize = const { T::COUNT_IMMUTABLE + T::COUNT_MUTABLE };
@@ -427,7 +435,7 @@ fn __internal_do_read_write_locks<
 
             //if component_id is set, that means this term is a row term
             if ANY_SPARSE_TERMS && info.component_id != 0 {
-                let idr = sys::flecs_components_get(world.raw_world.as_ptr(), info.component_id);
+                let idr = sys::flecs_components_get(real_world, info.component_id);
                 lock_sparse::<INCREMENT, true, MULTITHREADED>(world, idr);
                 continue;
             }
@@ -442,7 +450,7 @@ fn __internal_do_read_write_locks<
 
             //if component_id is set, that means this term is a row term
             if ANY_SPARSE_TERMS && info.component_id != 0 {
-                let idr = sys::flecs_components_get(world.raw_world.as_ptr(), info.component_id);
+                let idr = sys::flecs_components_get(real_world, info.component_id);
                 lock_sparse::<INCREMENT, false, MULTITHREADED>(world, idr);
                 continue;
             }
@@ -460,7 +468,7 @@ fn __internal_do_read_write_locks<
             let info = table_records.get_unchecked(i);
 
             if ANY_SPARSE_TERMS && info.component_id != 0 {
-                let idr = sys::flecs_components_get(world.raw_world.as_ptr(), info.component_id);
+                let idr = sys::flecs_components_get(real_world, info.component_id);
                 lock_sparse::<INCREMENT, true, MULTITHREADED>(world, idr);
                 continue;
             }
@@ -478,7 +486,7 @@ fn __internal_do_read_write_locks<
             let info = table_records.get_unchecked(i);
 
             if ANY_SPARSE_TERMS && info.component_id != 0 {
-                let idr = sys::flecs_components_get(world.raw_world.as_ptr(), info.component_id);
+                let idr = sys::flecs_components_get(real_world, info.component_id);
                 lock_sparse::<INCREMENT, false, MULTITHREADED>(world, idr);
                 continue;
             }


### PR DESCRIPTION
Inside a multithreaded system the `WorldRef` handed to the callback is a stage. `__internal_do_read_write_locks` forwards its raw pointer straight to `flecs_components_get`, which asserts on `ecs_world_t_magic`, so any system with a sparse term and `set_threads > 1` aborts the process:

```
error: flecs.c: 61000: type 'EntitySize' reregistered as 'Opaque' (was 'Struct')
fatal: flecs.c: 40950: assert(hdr->type == ecs_world_t_magic): ecs_stage_t (INVALID_PARAMETER)
  5  flecs_components_get + 244
  6  flecs_ecs::core::safety_map::do_read_write_locks
  7  flecs_ecs::addons::system::system_builder::...::execute_run_each_iter
  8  flecs_run_system + 3540
 10  flecs_run_pipeline + 1480
 11  flecs_workers_progress + 540
 12  ecs_progress + 2376
```

Resolve the stage to its world once with `ecs_get_world`, as `get_tuple.rs` and `query.rs` already do, and use it for all four `flecs_components_get` lookups.

Found moving [hyperion](https://github.com/hyperion-mc/hyperion) — a Minecraft engine that runs every system multithreaded — from 0.2.2 to main. Three of its integration tests abort on `main` at `bf956db` and all 92 pass with this change.